### PR TITLE
perf(profile,search): cut request volume to fix rate-limit slowdowns

### DIFF
--- a/app/src/main/graphql/Fragments.graphql
+++ b/app/src/main/graphql/Fragments.graphql
@@ -1,0 +1,33 @@
+"""
+Shared media-card selection. Used by every list/grid that renders a media cover
++ title + basic counts (favourites, search results) so the field set stays
+consistent and Apollo's normalized cache entries are complete across queries.
+Superset of what those mappers read; manga simply returns null for the
+anime-only fields (episodes, nextAiringEpisode).
+"""
+fragment MediaCardFields on Media {
+  id
+  type
+  status
+  format
+  episodes
+  chapters
+  volumes
+  averageScore
+  nextAiringEpisode {
+    episode
+    timeUntilAiring
+    airingAt
+  }
+  title {
+    userPreferred
+    romaji
+    english
+    native
+  }
+  coverImage {
+    medium
+    large
+    extraLarge
+  }
+}

--- a/app/src/main/graphql/Profile.graphql
+++ b/app/src/main/graphql/Profile.graphql
@@ -49,52 +49,12 @@ query GetUserProfile($name: String, $includeViewer: Boolean = false) {
           lastPage
         }
         nodes {
-          id
-          type
-          status
-          format
-          episodes
-          chapters
-          volumes
-          averageScore
-          nextAiringEpisode {
-            episode
-            timeUntilAiring
-            airingAt
-          }
-          title {
-            userPreferred
-            romaji
-            english
-            native
-          }
-          coverImage {
-            medium
-            large
-            extraLarge
-          }
+          ...MediaCardFields
         }
       }
       manga(page: 1, perPage: 25) {
         nodes {
-          id
-          type
-          status
-          format
-          chapters
-          volumes
-          averageScore
-          title {
-            userPreferred
-            romaji
-            english
-            native
-          }
-          coverImage {
-            medium
-            large
-            extraLarge
-          }
+          ...MediaCardFields
         }
       }
       characters(page: 1, perPage: 25) {
@@ -193,52 +153,12 @@ query GetFullUserProfile(
           lastPage
         }
         nodes {
-          id
-          type
-          status
-          format
-          episodes
-          chapters
-          volumes
-          averageScore
-          nextAiringEpisode {
-            episode
-            timeUntilAiring
-            airingAt
-          }
-          title {
-            userPreferred
-            romaji
-            english
-            native
-          }
-          coverImage {
-            medium
-            large
-            extraLarge
-          }
+          ...MediaCardFields
         }
       }
       manga(page: 1, perPage: 25) {
         nodes {
-          id
-          type
-          status
-          format
-          chapters
-          volumes
-          averageScore
-          title {
-            userPreferred
-            romaji
-            english
-            native
-          }
-          coverImage {
-            medium
-            large
-            extraLarge
-          }
+          ...MediaCardFields
         }
       }
       characters(page: 1, perPage: 25) {
@@ -303,30 +223,7 @@ query GetUserFavorites($userId: Int, $page: Int) {
           lastPage
         }
         nodes {
-          id
-          type
-          status
-          format
-          episodes
-          chapters
-          volumes
-          averageScore
-          nextAiringEpisode {
-            episode
-            timeUntilAiring
-            airingAt
-          }
-          title {
-            userPreferred
-            romaji
-            english
-            native
-          }
-          coverImage {
-            medium
-            large
-            extraLarge
-          }
+          ...MediaCardFields
         }
       }
     }

--- a/app/src/main/graphql/Profile.graphql
+++ b/app/src/main/graphql/Profile.graphql
@@ -129,6 +129,170 @@ query GetUserProfile($name: String, $includeViewer: Boolean = false) {
   }
 }
 
+"""
+Single-request profile fetch. Folds the former GetUserProfile + GetUserActivities
+into one operation. Activity feeds are gated by `$includeActivities` so the
+own-profile path (cached/known userId) gets everything in one round-trip, while
+the target-by-name path (userId unknown until User resolves) sets it false and
+issues GetUserActivities as a follow-up. Favourites are page-1 only here — the
+rest is paginated lazily when the Favorites tab opens (no eager fan-out).
+"""
+query GetFullUserProfile(
+  $userId: Int,
+  $name: String,
+  $includeViewer: Boolean = false,
+  $includeActivities: Boolean = false
+) {
+  Viewer @include(if: $includeViewer) {
+    id
+    unreadNotificationCount
+    mediaListOptions {
+      scoreFormat
+    }
+  }
+  User(id: $userId, name: $name) {
+    name
+    id
+    avatar {
+      large
+    }
+    bannerImage
+    about(asHtml: true)
+    aboutRaw: about(asHtml: false)
+    updatedAt
+    donatorTier
+    donatorBadge
+    moderatorRoles
+    createdAt
+    statistics {
+      anime {
+        count
+        minutesWatched
+        meanScore
+        statuses {
+          count
+          status
+        }
+        genres(sort: [COUNT_DESC], limit: 5) {
+          genre
+          count
+          meanScore
+        }
+      }
+      manga {
+        count
+        chaptersRead
+        meanScore
+      }
+    }
+    favourites {
+      anime(page: 1, perPage: 50) {
+        pageInfo {
+          hasNextPage
+          total
+          lastPage
+        }
+        nodes {
+          id
+          type
+          status
+          format
+          episodes
+          chapters
+          volumes
+          averageScore
+          nextAiringEpisode {
+            episode
+            timeUntilAiring
+            airingAt
+          }
+          title {
+            userPreferred
+            romaji
+            english
+            native
+          }
+          coverImage {
+            medium
+            large
+            extraLarge
+          }
+        }
+      }
+      manga(page: 1, perPage: 25) {
+        nodes {
+          id
+          type
+          status
+          format
+          chapters
+          volumes
+          averageScore
+          title {
+            userPreferred
+            romaji
+            english
+            native
+          }
+          coverImage {
+            medium
+            large
+            extraLarge
+          }
+        }
+      }
+      characters(page: 1, perPage: 25) {
+        nodes {
+          id
+          name {
+            userPreferred
+          }
+          image {
+            large
+          }
+        }
+      }
+      staff(page: 1, perPage: 25) {
+        nodes {
+          id
+          name {
+            userPreferred
+          }
+          image {
+            large
+          }
+        }
+      }
+      studios(page: 1, perPage: 25) {
+        nodes {
+          id
+          name
+        }
+      }
+    }
+  }
+  allActivities: Page(perPage: 50) @include(if: $includeActivities) {
+    activities(userId: $userId, sort: [PINNED, ID_DESC], type_in: [ANIME_LIST, MANGA_LIST, TEXT, MESSAGE]) {
+      ...ActivityFields
+    }
+  }
+  textActivities: Page(perPage: 20) @include(if: $includeActivities) {
+    activities(userId: $userId, sort: [PINNED, ID_DESC], type_in: [TEXT]) {
+      ...ActivityFields
+    }
+  }
+  messageReceived: Page(perPage: 20) @include(if: $includeActivities) {
+    activities(userId: $userId, sort: [ID_DESC], type_in: [MESSAGE]) {
+      ...ActivityFields
+    }
+  }
+  messageSent: Page(perPage: 20) @include(if: $includeActivities) {
+    activities(messengerId: $userId, sort: [ID_DESC], type_in: [MESSAGE]) {
+      ...ActivityFields
+    }
+  }
+}
+
 query GetUserFavorites($userId: Int, $page: Int) {
   User(id: $userId) {
     favourites {

--- a/app/src/main/graphql/SearchEverything.graphql
+++ b/app/src/main/graphql/SearchEverything.graphql
@@ -1,0 +1,194 @@
+"""
+Single-request universal search. Collapses the former 3-request fan-out
+(SearchMedia[ANIME] + SearchMedia[MANGA] + SearchAll) into one operation using
+aliased Page selections. The `$wantAnime` / `$wantManga` / `$wantEntities`
+booleans gate each bucket via @include so a type-pinned search fetches only what
+it needs while Auto mode fetches all buckets — still one HTTP round-trip.
+
+Media field set mirrors SearchMedia; entity field set mirrors SearchAll, so the
+existing mappers port over unchanged. Fragments are intentionally NOT used yet
+(see P3) to keep generated field access identical to the current queries.
+"""
+query SearchEverything(
+  $search: String,
+  $perPage: Int = 20,
+  $wantAnime: Boolean!,
+  $wantManga: Boolean!,
+  $wantEntities: Boolean!,
+  $sort: [MediaSort],
+  $genre_in: [String],
+  $genre_not_in: [String],
+  $tag_in: [String],
+  $tag_not_in: [String],
+  $format_in: [MediaFormat],
+  $status_in: [MediaStatus],
+  $source_in: [MediaSource],
+  $startDate_greater: FuzzyDateInt,
+  $startDate_lesser: FuzzyDateInt,
+  $season: MediaSeason,
+  $averageScore: Int,
+  $averageScore_greater: Int,
+  $averageScore_lesser: Int,
+  $episodes: Int,
+  $episodes_greater: Int,
+  $episodes_lesser: Int,
+  $chapters: Int,
+  $chapters_greater: Int,
+  $chapters_lesser: Int,
+  $countryOfOrigin: CountryCode,
+  $isAdult: Boolean
+) {
+  anime: Page(page: 1, perPage: $perPage) @include(if: $wantAnime) {
+    pageInfo {
+      total
+      currentPage
+      hasNextPage
+    }
+    media(
+      search: $search,
+      type: ANIME,
+      sort: $sort,
+      genre_in: $genre_in,
+      genre_not_in: $genre_not_in,
+      tag_in: $tag_in,
+      tag_not_in: $tag_not_in,
+      format_in: $format_in,
+      status_in: $status_in,
+      source_in: $source_in,
+      startDate_greater: $startDate_greater,
+      startDate_lesser: $startDate_lesser,
+      season: $season,
+      averageScore: $averageScore,
+      averageScore_greater: $averageScore_greater,
+      averageScore_lesser: $averageScore_lesser,
+      episodes: $episodes,
+      episodes_greater: $episodes_greater,
+      episodes_lesser: $episodes_lesser,
+      chapters: $chapters,
+      chapters_greater: $chapters_greater,
+      chapters_lesser: $chapters_lesser,
+      countryOfOrigin: $countryOfOrigin,
+      isAdult: $isAdult
+    ) {
+      id
+      title {
+        userPreferred
+        romaji
+        english
+        native
+      }
+      coverImage {
+        medium
+        large
+        extraLarge
+      }
+      status
+      averageScore
+      episodes
+      chapters
+      volumes
+      type
+      format
+      genres
+    }
+  }
+  manga: Page(page: 1, perPage: $perPage) @include(if: $wantManga) {
+    pageInfo {
+      total
+      currentPage
+      hasNextPage
+    }
+    media(
+      search: $search,
+      type: MANGA,
+      sort: $sort,
+      genre_in: $genre_in,
+      genre_not_in: $genre_not_in,
+      tag_in: $tag_in,
+      tag_not_in: $tag_not_in,
+      format_in: $format_in,
+      status_in: $status_in,
+      source_in: $source_in,
+      startDate_greater: $startDate_greater,
+      startDate_lesser: $startDate_lesser,
+      season: $season,
+      averageScore: $averageScore,
+      averageScore_greater: $averageScore_greater,
+      averageScore_lesser: $averageScore_lesser,
+      episodes: $episodes,
+      episodes_greater: $episodes_greater,
+      episodes_lesser: $episodes_lesser,
+      chapters: $chapters,
+      chapters_greater: $chapters_greater,
+      chapters_lesser: $chapters_lesser,
+      countryOfOrigin: $countryOfOrigin,
+      isAdult: $isAdult
+    ) {
+      id
+      title {
+        userPreferred
+        romaji
+        english
+        native
+      }
+      coverImage {
+        medium
+        large
+        extraLarge
+      }
+      status
+      averageScore
+      episodes
+      chapters
+      volumes
+      type
+      format
+      genres
+    }
+  }
+  characters: Page(page: 1, perPage: 5) @include(if: $wantEntities) {
+    characters(search: $search, sort: [FAVOURITES_DESC]) {
+      id
+      name {
+        full
+        native
+        userPreferred
+      }
+      image {
+        medium
+      }
+      favourites
+    }
+  }
+  staff: Page(page: 1, perPage: 5) @include(if: $wantEntities) {
+    staff(search: $search, sort: [FAVOURITES_DESC]) {
+      id
+      name {
+        full
+        native
+        userPreferred
+      }
+      image {
+        medium
+      }
+      primaryOccupations
+      favourites
+    }
+  }
+  users: Page(page: 1, perPage: 5) @include(if: $wantEntities) {
+    users(search: $search, sort: [SEARCH_MATCH]) {
+      id
+      name
+      avatar {
+        medium
+      }
+    }
+  }
+  studios: Page(page: 1, perPage: 5) @include(if: $wantEntities) {
+    studios(search: $search, sort: [SEARCH_MATCH]) {
+      id
+      name
+      favourites
+    }
+  }
+}

--- a/app/src/main/graphql/SearchEverything.graphql
+++ b/app/src/main/graphql/SearchEverything.graphql
@@ -70,26 +70,7 @@ query SearchEverything(
       countryOfOrigin: $countryOfOrigin,
       isAdult: $isAdult
     ) {
-      id
-      title {
-        userPreferred
-        romaji
-        english
-        native
-      }
-      coverImage {
-        medium
-        large
-        extraLarge
-      }
-      status
-      averageScore
-      episodes
-      chapters
-      volumes
-      type
-      format
-      genres
+      ...MediaCardFields
     }
   }
   manga: Page(page: 1, perPage: $perPage) @include(if: $wantManga) {
@@ -124,26 +105,7 @@ query SearchEverything(
       countryOfOrigin: $countryOfOrigin,
       isAdult: $isAdult
     ) {
-      id
-      title {
-        userPreferred
-        romaji
-        english
-        native
-      }
-      coverImage {
-        medium
-        large
-        extraLarge
-      }
-      status
-      averageScore
-      episodes
-      chapters
-      volumes
-      type
-      format
-      genres
+      ...MediaCardFields
     }
   }
   characters: Page(page: 1, perPage: 5) @include(if: $wantEntities) {

--- a/app/src/main/java/com/anisync/android/data/ProfileRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/ProfileRepositoryImpl.kt
@@ -1,9 +1,9 @@
 package com.anisync.android.data
 
+import com.anisync.android.GetFullUserProfileQuery
 import com.anisync.android.GetUserActivitiesQuery
 import com.anisync.android.GetUserFavoritesQuery
 import com.anisync.android.GetUserFollowStateQuery
-import com.anisync.android.GetUserProfileQuery
 import com.anisync.android.GetViewerQuery
 import com.anisync.android.ToggleUserFollowMutation
 import com.anisync.android.data.local.dao.UserProfileDao
@@ -85,32 +85,48 @@ class ProfileRepositoryImpl @Inject constructor(
     ): Result<Pair<UserProfile, ProfileRefreshTimings>> = dedupe("profile:${username}:$forceNetwork") {
         safeApiCall {
             val isOwnProfile = username.isBlank()
-            // For the viewer's own profile we previously always issued GetViewerQuery
-            // just to learn the username. Reuse the cached profile name when present
-            // so refresh skips a sequential network round-trip.
-            val actualUsername = username.ifBlank {
-                userProfileDao.get()?.name?.takeIf { it.isNotBlank() }
-                    ?: run {
-                        val viewerResponse = apolloClient.query(GetViewerQuery())
-                            .fetchPolicy(FetchPolicy.NetworkOnly)
-                            .execute()
-                        viewerResponse.data?.Viewer?.name
-                            ?: throw Exception("Unable to get current user")
-                    }
+
+            // Resolve the userId up front when we can. The own profile reuses its
+            // cached id; a cold first launch with no cache pays a one-time
+            // GetViewer to learn id + name. Knowing the id lets us fold the
+            // activity feeds into the single GetFullUserProfile request via
+            // `includeActivities`. Target profiles are addressed by name (their id
+            // is unknown until User resolves), so they fetch activities as a
+            // lightweight follow-up — still fewer round-trips than before and with
+            // no favourites fan-out.
+            var knownUserId: Int? = null
+            var queryName: String? = null
+            if (isOwnProfile) {
+                knownUserId = userProfileDao.get()?.id?.takeIf { it > 0 }
+                if (knownUserId == null) {
+                    val viewerResponse = apolloClient.query(GetViewerQuery())
+                        .fetchPolicy(FetchPolicy.NetworkOnly)
+                        .execute()
+                    val viewer = viewerResponse.data?.Viewer
+                        ?: throw Exception("Unable to get current user")
+                    knownUserId = viewer.id
+                    queryName = viewer.name
+                }
+            } else {
+                queryName = username
             }
 
+            val includeActivities = knownUserId != null
             val policy = if (forceNetwork) FetchPolicy.NetworkOnly else FetchPolicy.CacheFirst
 
             val profileQueryStart = SystemClock.elapsedRealtime()
-            Trace.beginSection("AniSync.Profile.Query.UserProfile")
+            Trace.beginSection("AniSync.Profile.Query.FullProfile")
             val response = try {
                 apolloClient.query(
-                    GetUserProfileQuery(
-                        name = Optional.present(actualUsername),
-                        // Piggyback viewer fields onto the own-profile query so the
-                        // notification badge can be updated without a separate
-                        // `GetViewer` round-trip on every screen resume.
-                        includeViewer = Optional.present(isOwnProfile)
+                    GetFullUserProfileQuery(
+                        userId = knownUserId?.let { Optional.present(it) } ?: Optional.absent(),
+                        name = queryName?.let { Optional.present(it) } ?: Optional.absent(),
+                        // Own-profile path piggybacks viewer fields so the notification
+                        // badge updates without a separate GetViewer round-trip.
+                        includeViewer = Optional.present(isOwnProfile),
+                        // Activity feeds only resolve when the userId is already known;
+                        // otherwise they're fetched once User has resolved the id below.
+                        includeActivities = Optional.present(includeActivities)
                     )
                 )
                     .fetchPolicy(policy)
@@ -126,86 +142,63 @@ class ProfileRepositoryImpl @Inject constructor(
             }
 
             val user = response.data?.User
-                ?: throw Exception("User not found: @$actualUsername")
+                ?: throw Exception("User not found: @${queryName ?: knownUserId}")
 
             // Refresh the notification badge from the piggy-backed Viewer block.
-            // Skipped when `includeViewer` is false or the server omitted it.
             response.data?.Viewer?.unreadNotificationCount?.let {
                 notificationBadgeStore.setFromServer(it)
             }
 
-            // Build a page-1 seed for the favorites paginator from the inline
-            // `favourites.anime` block in the same `GetUserProfile` response.
-            // Avoids a redundant `GetUserFavorites(page=1)` round-trip on every
-            // refresh — the first page is already paid for in the profile fetch.
-            val seedAnimePage = user.favourites?.anime
-            val seedFavorites = FavoritesPage(
-                entries = seedAnimePage?.nodes?.filterNotNull()?.map { node ->
-                    LibraryEntry(
-                        id = 0,
-                        mediaId = node.id ?: 0,
-                        titleRomaji = node.title?.romaji,
-                        titleEnglish = node.title?.english,
-                        titleNative = node.title?.native,
-                        titleUserPreferred = node.title?.userPreferred ?: "Unknown",
-                        coverUrl = node.coverImage?.large,
-                        cover = com.anisync.android.domain.CoverImage.of(
-                            node.coverImage?.medium,
-                            node.coverImage?.large,
-                            node.coverImage?.extraLarge
-                        ),
-                        progress = 0,
-                        totalEpisodes = node.episodes,
-                        totalChapters = node.chapters,
-                        totalVolumes = node.volumes,
-                        type = node.type,
-                        status = LibraryStatus.UNKNOWN
-                    )
-                }.orEmpty(),
-                lastPage = seedAnimePage?.pageInfo?.lastPage
-            )
+            // Page-1 favourites preview only — the eager all-pages fan-out is gone.
+            // The Favorites tab pulls the remaining pages on demand via
+            // getFavoriteAnime(), so a profile load/refresh costs a single request.
+            val favorites = user.favourites?.anime?.nodes?.filterNotNull()?.map { node ->
+                LibraryEntry(
+                    id = 0,
+                    mediaId = node.id ?: 0,
+                    titleRomaji = node.title?.romaji,
+                    titleEnglish = node.title?.english,
+                    titleNative = node.title?.native,
+                    titleUserPreferred = node.title?.userPreferred ?: "Unknown",
+                    coverUrl = node.coverImage?.large,
+                    cover = com.anisync.android.domain.CoverImage.of(
+                        node.coverImage?.medium,
+                        node.coverImage?.large,
+                        node.coverImage?.extraLarge
+                    ),
+                    progress = 0,
+                    totalEpisodes = node.episodes,
+                    totalChapters = node.chapters,
+                    totalVolumes = node.volumes,
+                    type = node.type,
+                    status = LibraryStatus.UNKNOWN
+                )
+            }.orEmpty()
 
-            // Activities and favorites pagination both depend on user.id but not on
-            // each other; run them in parallel to halve the post-profile latency.
-            var activitiesMs = 0L
-            var favoritesResult = FavoritesResult(emptyList(), 0, 0L, 0L)
-            val (activitiesResponse, favorites) = coroutineScope {
-                val activitiesDeferred = async {
-                    val start = SystemClock.elapsedRealtime()
-                    Trace.beginSection("AniSync.Profile.Query.UserActivities")
-                    try {
-                        apolloClient.query(
-                            GetUserActivitiesQuery(userId = Optional.present(user.id))
-                        )
-                            .fetchPolicy(policy)
-                            .execute()
-                    } finally {
-                        Trace.endSection()
-                        activitiesMs = SystemClock.elapsedRealtime() - start
-                    }
-                }
-                val favoritesDeferred = async {
-                    val r = fetchFavoritesTimed(user.id ?: 0, policy, seedFavorites)
-                    favoritesResult = r
-                    r.entries
-                }
-                activitiesDeferred.await() to favoritesDeferred.await()
-            }
-
+            // Activities: folded into the unified response when the userId was known
+            // up front; otherwise fetched now that User has resolved the id.
+            val activitiesStart = SystemClock.elapsedRealtime()
             val rawActivities = mutableListOf<com.anisync.android.fragment.ActivityFields>()
-
-            activitiesResponse.data?.allActivities?.activities?.filterNotNull()?.forEach {
-                rawActivities.add(it.activityFields)
+            if (includeActivities) {
+                response.data?.allActivities?.activities?.filterNotNull()?.forEach { rawActivities.add(it.activityFields) }
+                response.data?.textActivities?.activities?.filterNotNull()?.forEach { rawActivities.add(it.activityFields) }
+                response.data?.messageReceived?.activities?.filterNotNull()?.forEach { rawActivities.add(it.activityFields) }
+                response.data?.messageSent?.activities?.filterNotNull()?.forEach { rawActivities.add(it.activityFields) }
+            } else {
+                Trace.beginSection("AniSync.Profile.Query.UserActivities")
+                val activitiesResponse = try {
+                    apolloClient.query(GetUserActivitiesQuery(userId = Optional.present(user.id)))
+                        .fetchPolicy(policy)
+                        .execute()
+                } finally {
+                    Trace.endSection()
+                }
+                activitiesResponse.data?.allActivities?.activities?.filterNotNull()?.forEach { rawActivities.add(it.activityFields) }
+                activitiesResponse.data?.textActivities?.activities?.filterNotNull()?.forEach { rawActivities.add(it.activityFields) }
+                activitiesResponse.data?.messageReceived?.activities?.filterNotNull()?.forEach { rawActivities.add(it.activityFields) }
+                activitiesResponse.data?.messageSent?.activities?.filterNotNull()?.forEach { rawActivities.add(it.activityFields) }
             }
-            activitiesResponse.data?.textActivities?.activities?.filterNotNull()?.forEach {
-                rawActivities.add(it.activityFields)
-            }
-            activitiesResponse.data?.messageReceived?.activities?.filterNotNull()?.forEach {
-                rawActivities.add(it.activityFields)
-            }
-            activitiesResponse.data?.messageSent?.activities?.filterNotNull()?.forEach {
-                rawActivities.add(it.activityFields)
-            }
+            val activitiesMs = SystemClock.elapsedRealtime() - activitiesStart
 
             val activities = rawActivities
                 .mapNotNull { it.activityFieldsToDomain() }
@@ -333,10 +326,12 @@ class ProfileRepositoryImpl @Inject constructor(
             val timings = ProfileRefreshTimings(
                 profileQueryMs = profileQueryMs,
                 activitiesQueryMs = activitiesMs,
-                favoritesTotalMs = favoritesResult.firstPageMs + favoritesResult.restMs,
-                favoritesFirstPageMs = favoritesResult.firstPageMs,
-                favoritesRestMs = favoritesResult.restMs,
-                favoritesPageCount = favoritesResult.pageCount
+                // Favourites are page-1 only on the hot path now; the rest loads
+                // lazily from the Favorites tab, so there's no fan-out to time here.
+                favoritesTotalMs = 0L,
+                favoritesFirstPageMs = 0L,
+                favoritesRestMs = 0L,
+                favoritesPageCount = 1
             )
             profile to timings
         }
@@ -492,6 +487,15 @@ class ProfileRepositoryImpl @Inject constructor(
 
         return FavoritesPage(entries = entries, lastPage = pageInfo?.lastPage)
     }
+
+    override suspend fun getFavoriteAnime(userId: Int, policy: CachePolicy): Result<List<LibraryEntry>> =
+        dedupe("favAnime:$userId:$policy") {
+            safeApiCall {
+                // Page 1 + bounded fan-out for the remaining pages. Invoked only when
+                // the Favorites tab opens, never on the profile load/refresh hot path.
+                fetchFavoritesTimed(userId, policy.toFetchPolicy(), seedPageOne = null).entries
+            }
+        }
 
     override suspend fun getSocialData(
         userId: Int,

--- a/app/src/main/java/com/anisync/android/data/ProfileRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/ProfileRepositoryImpl.kt
@@ -153,24 +153,25 @@ class ProfileRepositoryImpl @Inject constructor(
             // The Favorites tab pulls the remaining pages on demand via
             // getFavoriteAnime(), so a profile load/refresh costs a single request.
             val favorites = user.favourites?.anime?.nodes?.filterNotNull()?.map { node ->
+                val m = node.mediaCardFields
                 LibraryEntry(
                     id = 0,
-                    mediaId = node.id ?: 0,
-                    titleRomaji = node.title?.romaji,
-                    titleEnglish = node.title?.english,
-                    titleNative = node.title?.native,
-                    titleUserPreferred = node.title?.userPreferred ?: "Unknown",
-                    coverUrl = node.coverImage?.large,
+                    mediaId = m.id,
+                    titleRomaji = m.title?.romaji,
+                    titleEnglish = m.title?.english,
+                    titleNative = m.title?.native,
+                    titleUserPreferred = m.title?.userPreferred ?: "Unknown",
+                    coverUrl = m.coverImage?.large,
                     cover = com.anisync.android.domain.CoverImage.of(
-                        node.coverImage?.medium,
-                        node.coverImage?.large,
-                        node.coverImage?.extraLarge
+                        m.coverImage?.medium,
+                        m.coverImage?.large,
+                        m.coverImage?.extraLarge
                     ),
                     progress = 0,
-                    totalEpisodes = node.episodes,
-                    totalChapters = node.chapters,
-                    totalVolumes = node.volumes,
-                    type = node.type,
+                    totalEpisodes = m.episodes,
+                    totalChapters = m.chapters,
+                    totalVolumes = m.volumes,
+                    type = m.type,
                     status = LibraryStatus.UNKNOWN
                 )
             }.orEmpty()
@@ -237,20 +238,21 @@ class ProfileRepositoryImpl @Inject constructor(
             // Favorites already fetched in parallel with activities above.
 
                     val overviewManga = user.favourites?.manga?.nodes?.filterNotNull()?.map { media ->
+                        val m = media.mediaCardFields
                         com.anisync.android.domain.LibraryEntry(
                             id = 0,
-                            mediaId = media.id,
-                            titleRomaji = media.title?.romaji,
-                            titleEnglish = media.title?.english,
-                            titleNative = media.title?.native,
-                            titleUserPreferred = media.title?.userPreferred ?: "Unknown",
-                            coverUrl = media.coverImage?.large,
-                            cover = com.anisync.android.domain.CoverImage.of(media.coverImage?.medium, media.coverImage?.large, media.coverImage?.extraLarge),
+                            mediaId = m.id,
+                            titleRomaji = m.title?.romaji,
+                            titleEnglish = m.title?.english,
+                            titleNative = m.title?.native,
+                            titleUserPreferred = m.title?.userPreferred ?: "Unknown",
+                            coverUrl = m.coverImage?.large,
+                            cover = com.anisync.android.domain.CoverImage.of(m.coverImage?.medium, m.coverImage?.large, m.coverImage?.extraLarge),
                             progress = 0,
                             totalEpisodes = null,
-                            totalChapters = media.chapters,
-                            totalVolumes = media.volumes,
-                            type = media.type,
+                            totalChapters = m.chapters,
+                            totalVolumes = m.volumes,
+                            type = m.type,
                             format = null,
                             status = com.anisync.android.domain.LibraryStatus.UNKNOWN
                         )
@@ -462,25 +464,26 @@ class ProfileRepositoryImpl @Inject constructor(
         val nodes = data?.nodes?.filterNotNull() ?: emptyList()
         val pageInfo = data?.pageInfo
 
-        val entries = nodes.map { media ->
+        val entries = nodes.map { node ->
+            val m = node.mediaCardFields
             LibraryEntry(
                 id = 0,
-                mediaId = media.id ?: 0,
-                titleRomaji = media.title?.romaji,
-                titleEnglish = media.title?.english,
-                titleNative = media.title?.native,
-                titleUserPreferred = media.title?.userPreferred ?: "Unknown",
-                coverUrl = media.coverImage?.large,
+                mediaId = m.id,
+                titleRomaji = m.title?.romaji,
+                titleEnglish = m.title?.english,
+                titleNative = m.title?.native,
+                titleUserPreferred = m.title?.userPreferred ?: "Unknown",
+                coverUrl = m.coverImage?.large,
                 cover = com.anisync.android.domain.CoverImage.of(
-                    media.coverImage?.medium,
-                    media.coverImage?.large,
-                    media.coverImage?.extraLarge
+                    m.coverImage?.medium,
+                    m.coverImage?.large,
+                    m.coverImage?.extraLarge
                 ),
                 progress = 0,
-                totalEpisodes = media.episodes,
-                totalChapters = media.chapters,
-                totalVolumes = media.volumes,
-                type = media.type,
+                totalEpisodes = m.episodes,
+                totalChapters = m.chapters,
+                totalVolumes = m.volumes,
+                type = m.type,
                 status = LibraryStatus.UNKNOWN
             )
         }

--- a/app/src/main/java/com/anisync/android/data/SearchRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/SearchRepositoryImpl.kt
@@ -231,10 +231,11 @@ class SearchRepositoryImpl @Inject constructor(
 
                 val data = response.data
 
-                val animeEntries = data?.anime?.media?.filterNotNull()?.map { m ->
+                val animeEntries = data?.anime?.media?.filterNotNull()?.map { node ->
+                    val m = node.mediaCardFields
                     LibraryEntry(
                         id = 0,
-                        mediaId = m.id ?: 0,
+                        mediaId = m.id,
                         titleRomaji = m.title?.romaji,
                         titleEnglish = m.title?.english,
                         titleNative = m.title?.native,
@@ -254,10 +255,11 @@ class SearchRepositoryImpl @Inject constructor(
                     )
                 }.orEmpty()
 
-                val mangaEntries = data?.manga?.media?.filterNotNull()?.map { m ->
+                val mangaEntries = data?.manga?.media?.filterNotNull()?.map { node ->
+                    val m = node.mediaCardFields
                     LibraryEntry(
                         id = 0,
-                        mediaId = m.id ?: 0,
+                        mediaId = m.id,
                         titleRomaji = m.title?.romaji,
                         titleEnglish = m.title?.english,
                         titleNative = m.title?.native,

--- a/app/src/main/java/com/anisync/android/data/SearchRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/SearchRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.anisync.android.data
 
 import com.anisync.android.GetSearchTaxonomyQuery
 import com.anisync.android.SearchAllQuery
+import com.anisync.android.SearchEverythingQuery
 import com.anisync.android.SearchMediaQuery
 import com.anisync.android.data.util.safeApiCall
 import com.anisync.android.domain.GroupedSearchResults
@@ -10,6 +11,7 @@ import com.anisync.android.domain.LibraryStatus
 import com.anisync.android.domain.MediaTag
 import com.anisync.android.domain.Result
 import com.anisync.android.domain.map
+import com.anisync.android.domain.SearchEverythingResult
 import com.anisync.android.domain.SearchFilters
 import com.anisync.android.domain.SearchPage
 import com.anisync.android.domain.SearchRepository
@@ -19,6 +21,9 @@ import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.cache.normalized.FetchPolicy
 import com.apollographql.apollo.cache.normalized.fetchPolicy
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -29,6 +34,22 @@ class SearchRepositoryImpl @Inject constructor(
 
     @Volatile private var cachedGenres: List<String>? = null
     @Volatile private var cachedTags: List<MediaTag>? = null
+
+    /**
+     * In-flight dedup keyed by query + filters. A re-trigger of the same search
+     * (rotation, refocus, rapid identical input) suspends on the mutex and then
+     * hits the now-warm normalized cache instead of issuing a second request.
+     */
+    private val inflightMutexes = ConcurrentHashMap<String, Mutex>()
+
+    private suspend fun <T> dedupe(key: String, block: suspend () -> T): T {
+        val mtx = inflightMutexes.computeIfAbsent(key) { Mutex() }
+        return try {
+            mtx.withLock { block() }
+        } finally {
+            if (!mtx.isLocked) inflightMutexes.remove(key, mtx)
+        }
+    }
 
     override suspend fun searchMedia(
         query: String,
@@ -153,6 +174,159 @@ class SearchRepositoryImpl @Inject constructor(
                 users = users,
                 studios = studios
             )
+        }
+    }
+
+    override suspend fun searchEverything(
+        query: String,
+        filters: SearchFilters,
+        perPage: Int,
+        wantAnime: Boolean,
+        wantManga: Boolean,
+        wantEntities: Boolean
+    ): Result<SearchEverythingResult> {
+        val key = "all:$query:${filters.hashCode()}:$perPage:$wantAnime:$wantManga:$wantEntities"
+        return dedupe(key) {
+            safeApiCall {
+                val response = apolloClient.query(
+                    SearchEverythingQuery(
+                        search = if (query.isBlank()) Optional.absent() else Optional.present(query),
+                        perPage = Optional.present(perPage),
+                        wantAnime = wantAnime,
+                        wantManga = wantManga,
+                        wantEntities = wantEntities,
+                        sort = Optional.present(listOf(filters.sort.apiValue)),
+                        genre_in = filters.genresIncluded.toOptionalList(),
+                        genre_not_in = filters.genresExcluded.toOptionalList(),
+                        tag_in = filters.tagsIncluded.toOptionalList(),
+                        tag_not_in = filters.tagsExcluded.toOptionalList(),
+                        format_in = filters.formats.toOptionalList(),
+                        status_in = filters.statuses.toOptionalList(),
+                        source_in = filters.sources.toOptionalList(),
+                        startDate_greater = filters.yearRange.min?.let { Optional.present(it * 10000 + 101) }
+                            ?: Optional.absent(),
+                        startDate_lesser = filters.yearRange.max?.let { Optional.present(it * 10000 + 1231) }
+                            ?: Optional.absent(),
+                        season = filters.season?.let { Optional.present(it) } ?: Optional.absent(),
+                        averageScore = filters.score.exact(),
+                        averageScore_greater = filters.score.greater(),
+                        averageScore_lesser = filters.score.lesser(),
+                        episodes = filters.episodes.exact(),
+                        episodes_greater = filters.episodes.greater(),
+                        episodes_lesser = filters.episodes.lesser(),
+                        chapters = filters.chapters.exact(),
+                        chapters_greater = filters.chapters.greater(),
+                        chapters_lesser = filters.chapters.lesser(),
+                        countryOfOrigin = filters.country?.let { Optional.present(it.code) }
+                            ?: Optional.absent(),
+                        isAdult = when (filters.adultMode) {
+                            com.anisync.android.domain.AdultMode.ANY -> Optional.absent()
+                            com.anisync.android.domain.AdultMode.HIDE -> Optional.present(false)
+                            com.anisync.android.domain.AdultMode.ONLY -> Optional.present(true)
+                        }
+                    )
+                )
+                    .fetchPolicy(FetchPolicy.NetworkFirst)
+                    .execute()
+
+                val data = response.data
+
+                val animeEntries = data?.anime?.media?.filterNotNull()?.map { m ->
+                    LibraryEntry(
+                        id = 0,
+                        mediaId = m.id ?: 0,
+                        titleRomaji = m.title?.romaji,
+                        titleEnglish = m.title?.english,
+                        titleNative = m.title?.native,
+                        titleUserPreferred = m.title?.userPreferred ?: "Unknown",
+                        coverUrl = m.coverImage?.extraLarge,
+                        cover = com.anisync.android.domain.CoverImage.of(
+                            m.coverImage?.medium, m.coverImage?.large, m.coverImage?.extraLarge
+                        ),
+                        progress = 0,
+                        totalEpisodes = m.episodes,
+                        totalChapters = m.chapters,
+                        totalVolumes = m.volumes,
+                        type = m.type,
+                        format = m.format,
+                        status = LibraryStatus.UNKNOWN,
+                        mediaStatus = m.status?.name
+                    )
+                }.orEmpty()
+
+                val mangaEntries = data?.manga?.media?.filterNotNull()?.map { m ->
+                    LibraryEntry(
+                        id = 0,
+                        mediaId = m.id ?: 0,
+                        titleRomaji = m.title?.romaji,
+                        titleEnglish = m.title?.english,
+                        titleNative = m.title?.native,
+                        titleUserPreferred = m.title?.userPreferred ?: "Unknown",
+                        coverUrl = m.coverImage?.extraLarge,
+                        cover = com.anisync.android.domain.CoverImage.of(
+                            m.coverImage?.medium, m.coverImage?.large, m.coverImage?.extraLarge
+                        ),
+                        progress = 0,
+                        totalEpisodes = m.episodes,
+                        totalChapters = m.chapters,
+                        totalVolumes = m.volumes,
+                        type = m.type,
+                        format = m.format,
+                        status = LibraryStatus.UNKNOWN,
+                        mediaStatus = m.status?.name
+                    )
+                }.orEmpty()
+
+                val characters = data?.characters?.characters?.filterNotNull()?.map { c ->
+                    SearchResult.CharacterResult(
+                        id = c.id,
+                        displayName = c.name?.userPreferred ?: c.name?.full ?: "Unknown",
+                        nativeName = c.name?.native,
+                        imageUrl = c.image?.medium,
+                        favourites = c.favourites
+                    )
+                } ?: emptyList()
+
+                val staff = data?.staff?.staff?.filterNotNull()?.map { s ->
+                    SearchResult.StaffResult(
+                        id = s.id,
+                        displayName = s.name?.userPreferred ?: s.name?.full ?: "Unknown",
+                        nativeName = s.name?.native,
+                        imageUrl = s.image?.medium,
+                        primaryOccupations = s.primaryOccupations?.filterNotNull() ?: emptyList(),
+                        favourites = s.favourites
+                    )
+                } ?: emptyList()
+
+                val users = data?.users?.users?.filterNotNull()?.map { u ->
+                    SearchResult.UserResult(
+                        id = u.id,
+                        displayName = u.name,
+                        imageUrl = u.avatar?.medium
+                    )
+                } ?: emptyList()
+
+                val studios = data?.studios?.studios?.filterNotNull()?.map { s ->
+                    SearchResult.StudioResult(
+                        id = s.id,
+                        displayName = s.name,
+                        favourites = s.favourites
+                    )
+                } ?: emptyList()
+
+                SearchEverythingResult(
+                    anime = animeEntries,
+                    manga = mangaEntries,
+                    animeHasNextPage = data?.anime?.pageInfo?.hasNextPage ?: false,
+                    mangaHasNextPage = data?.manga?.pageInfo?.hasNextPage ?: false,
+                    grouped = GroupedSearchResults(
+                        characters = characters,
+                        staff = staff,
+                        users = users,
+                        studios = studios
+                    )
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/anisync/android/di/AuthorizationInterceptor.kt
+++ b/app/src/main/java/com/anisync/android/di/AuthorizationInterceptor.kt
@@ -1,5 +1,6 @@
 package com.anisync.android.di
 
+import android.os.SystemClock
 import android.util.Log
 import com.anisync.android.data.AuthRepository
 import com.anisync.android.data.network.TokenBucket
@@ -48,6 +49,13 @@ class AuthorizationInterceptor @Inject constructor(
         /** Delay in ms when proactively throttling (remaining < THROTTLE_THRESHOLD) */
         private const val THROTTLE_DELAY_MS = 2000L
 
+        /**
+         * If client-side pacing (token-bucket wait + proactive throttle) delays a
+         * request by at least this long before it even reaches the network, show a
+         * brief notice so the resulting slowness isn't mistaken for the app hanging.
+         */
+        private const val THROTTLE_NOTICE_THRESHOLD_MS = 800L
+
         /** Default wait time in seconds if 429 has no Retry-After header (AniList docs say "1 minute timeout") */
         private const val DEFAULT_RETRY_AFTER_SECONDS = 60L
 
@@ -83,6 +91,7 @@ class AuthorizationInterceptor @Inject constructor(
         // limiter. The post-response remaining-count throttle below cannot
         // help here because N parallel intercept() invocations all read the
         // same `remaining` before the first response updates it.
+        val pacingStart = SystemClock.elapsedRealtime()
         tokenBucket.acquire()
 
         // ── Step 1: Attach Bearer token ─────────────────────────────────
@@ -102,6 +111,12 @@ class AuthorizationInterceptor @Inject constructor(
         if (remaining in 1 until THROTTLE_THRESHOLD) {
             Log.w(TAG, "Rate limit low ($remaining remaining), throttling ${THROTTLE_DELAY_MS}ms")
             delay(THROTTLE_DELAY_MS)
+        }
+
+        // Client-side pacing just delayed this request perceptibly; surface a
+        // low-key notice so the wait reads as deliberate, not a frozen app.
+        if (SystemClock.elapsedRealtime() - pacingStart >= THROTTLE_NOTICE_THRESHOLD_MS) {
+            toastManager.showThrottleNotice()
         }
 
         // ── Step 3: Execute the request ─────────────────────────────────

--- a/app/src/main/java/com/anisync/android/domain/ProfileRepository.kt
+++ b/app/src/main/java/com/anisync/android/domain/ProfileRepository.kt
@@ -91,6 +91,16 @@ interface ProfileRepository {
     ): Result<UserReviewsPage>
 
     /**
+     * Fetch the user's full favourite-anime list (all pages). Loaded lazily when
+     * the Favorites tab opens; the profile fetch itself only carries page 1, so
+     * a normal profile load/refresh no longer fans out across favourite pages.
+     */
+    suspend fun getFavoriteAnime(
+        userId: Int,
+        policy: CachePolicy = CachePolicy.NetworkFirst
+    ): Result<List<LibraryEntry>>
+
+    /**
      * Fetch user's anime list.
      */
     suspend fun getUserAnimeList(username: String): Result<List<LibraryEntry>>

--- a/app/src/main/java/com/anisync/android/domain/SearchPage.kt
+++ b/app/src/main/java/com/anisync/android/domain/SearchPage.kt
@@ -14,3 +14,18 @@ data class SearchPage(
     val hasNextPage: Boolean,
     val currentPage: Int
 )
+
+/**
+ * Combined result of a single [SearchRepository.searchEverything] request. Carries
+ * the anime + manga media pages and the non-media entity buckets together so the
+ * universal search overlay renders from one round-trip instead of three. Buckets
+ * not requested for a given search (via the `want*` gates) come back empty.
+ */
+@Immutable
+data class SearchEverythingResult(
+    val anime: List<LibraryEntry> = emptyList(),
+    val manga: List<LibraryEntry> = emptyList(),
+    val animeHasNextPage: Boolean = false,
+    val mangaHasNextPage: Boolean = false,
+    val grouped: GroupedSearchResults = GroupedSearchResults()
+)

--- a/app/src/main/java/com/anisync/android/domain/SearchRepository.kt
+++ b/app/src/main/java/com/anisync/android/domain/SearchRepository.kt
@@ -20,6 +20,21 @@ interface SearchRepository {
 
     suspend fun searchAll(query: String): Result<GroupedSearchResults>
 
+    /**
+     * Universal search in a single request. Collapses the former 3-request fan-out
+     * (anime media + manga media + entity lookup) into one operation. The caller
+     * passes which buckets it wants; unrequested buckets are skipped server-side
+     * via @include and come back empty. Used by the discover search overlay.
+     */
+    suspend fun searchEverything(
+        query: String,
+        filters: SearchFilters = SearchFilters(),
+        perPage: Int = 20,
+        wantAnime: Boolean,
+        wantManga: Boolean,
+        wantEntities: Boolean
+    ): Result<SearchEverythingResult>
+
     /** AniList genre vocabulary. Cached aggressively — changes rarely. */
     suspend fun getGenres(): Result<List<String>>
 

--- a/app/src/main/java/com/anisync/android/presentation/activity/ActivityDetailViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/activity/ActivityDetailViewModel.kt
@@ -33,6 +33,36 @@ class ActivityDetailViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(ActivityDetailUiState())
     val uiState: StateFlow<ActivityDetailUiState> = _uiState.asStateFlow()
 
+    // Server-truth (isLiked, likeCount) for the activity so a coalesced like burst
+    // rolls back correctly on error. Each tap flips the optimistic UI instantly;
+    // the coalescer sends at most one toggle once the burst settles.
+    private var activityLikeServer: Pair<Boolean, Int>? = null
+    private val activityLikeCoalescer =
+        com.anisync.android.presentation.util.MutationCoalescer<Int, Boolean>(viewModelScope) { id, _ ->
+            when (val result = repository.toggleActivityLike(id)) {
+                is Result.Success -> {
+                    val s = result.data
+                    activityLikeServer = s.isLiked to s.likeCount
+                    _uiState.update { st ->
+                        st.copy(activity = st.activity?.copy(isLiked = s.isLiked, likeCount = s.likeCount))
+                    }
+                    true
+                }
+                is Result.Error -> {
+                    activityLikeServer?.let { (liked, count) ->
+                        _uiState.update { st ->
+                            st.copy(activity = st.activity?.copy(isLiked = liked, likeCount = count))
+                        }
+                    }
+                    false
+                }
+            }
+        }
+
+    // Reply ids with a like toggle in flight; a repeat tap is dropped until it
+    // completes so rapid tapping can't stack reply-like requests.
+    private val inFlightReplyLikes = java.util.concurrent.ConcurrentHashMap.newKeySet<Int>()
+
     private val _finishedEvents = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val finishedEvents: SharedFlow<Unit> = _finishedEvents.asSharedFlow()
 
@@ -158,29 +188,23 @@ class ActivityDetailViewModel @Inject constructor(
     private fun toggleActivityLike() {
         val current = _uiState.value.activity ?: return
         val wasLiked = current.isLiked
-        val optimistic = current.copy(
-            isLiked = !wasLiked,
-            likeCount = (if (wasLiked) current.likeCount - 1 else current.likeCount + 1).coerceAtLeast(0)
-        )
-        _uiState.update { it.copy(activity = optimistic) }
-        viewModelScope.launch {
-            when (val result = repository.toggleActivityLike(current.id)) {
-                is Result.Success -> _uiState.update { state ->
-                    state.copy(
-                        activity = state.activity?.copy(
-                            likeCount = result.data.likeCount,
-                            isLiked = result.data.isLiked
-                        )
-                    )
-                }
-                is Result.Error -> _uiState.update { it.copy(activity = current) }
-            }
+        if (activityLikeServer == null) activityLikeServer = wasLiked to current.likeCount
+        activityLikeCoalescer.seed(current.id, wasLiked)
+        _uiState.update {
+            it.copy(
+                activity = current.copy(
+                    isLiked = !wasLiked,
+                    likeCount = (if (wasLiked) current.likeCount - 1 else current.likeCount + 1).coerceAtLeast(0)
+                )
+            )
         }
+        activityLikeCoalescer.submit(current.id, !wasLiked)
     }
 
     private fun toggleReplyLike(replyId: Int) {
         val activity = _uiState.value.activity ?: return
         val original = activity.replies.firstOrNull { it.id == replyId } ?: return
+        if (!inFlightReplyLikes.add(replyId)) return
         val wasLiked = original.isLiked
         val flipped = original.copy(
             isLiked = !wasLiked,
@@ -189,11 +213,15 @@ class ActivityDetailViewModel @Inject constructor(
         applyReplyChange(replyId) { flipped }
 
         viewModelScope.launch {
-            when (val result = repository.toggleReplyLike(replyId)) {
-                is Result.Success -> applyReplyChange(replyId) {
-                    it.copy(isLiked = result.data.isLiked, likeCount = result.data.likeCount)
+            try {
+                when (val result = repository.toggleReplyLike(replyId)) {
+                    is Result.Success -> applyReplyChange(replyId) {
+                        it.copy(isLiked = result.data.isLiked, likeCount = result.data.likeCount)
+                    }
+                    is Result.Error -> applyReplyChange(replyId) { original }
                 }
-                is Result.Error -> applyReplyChange(replyId) { original }
+            } finally {
+                inFlightReplyLikes.remove(replyId)
             }
         }
     }

--- a/app/src/main/java/com/anisync/android/presentation/components/alert/ToastManager.kt
+++ b/app/src/main/java/com/anisync/android/presentation/components/alert/ToastManager.kt
@@ -1,5 +1,6 @@
 package com.anisync.android.presentation.components.alert
 
+import android.os.SystemClock
 import com.anisync.android.domain.Result
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -20,6 +21,9 @@ class ToastManager @Inject constructor() {
      */
     private val _isRateLimited = MutableStateFlow(false)
     val isRateLimited: StateFlow<Boolean> = _isRateLimited.asStateFlow()
+
+    /** Last time a throttle notice was shown; rate-limits the notice itself. */
+    @Volatile private var lastThrottleNoticeAt: Long = 0L
 
     fun showToast(type: ToastType, title: String? = null, message: String, countdownSeconds: Long? = null) {
         _toast.value = ToastMessage(type = type, title = title, message = message, countdownSeconds = countdownSeconds)
@@ -60,5 +64,26 @@ class ToastManager @Inject constructor() {
         } else {
             showToast(ToastType.INFO, message = error.message)
         }
+    }
+
+    /**
+     * Brief, non-blocking notice that the app is deliberately pacing requests to
+     * stay under AniList's rate limit. Unlike the 429 countdown toast it does NOT
+     * set [isRateLimited], so it never gates pull-to-refresh — it just explains a
+     * momentary slowdown instead of leaving the user on an unexplained spinner
+     * (the "feels broken/slow" complaint). Self-throttled to at most once per
+     * [THROTTLE_NOTICE_INTERVAL_MS], and suppressed while a 429 countdown is up so
+     * it never clobbers the more important rate-limit toast.
+     */
+    fun showThrottleNotice() {
+        if (_isRateLimited.value) return
+        val now = SystemClock.elapsedRealtime()
+        if (now - lastThrottleNoticeAt < THROTTLE_NOTICE_INTERVAL_MS) return
+        lastThrottleNoticeAt = now
+        showToast(ToastType.INFO, message = "Slowing down to stay within AniList's rate limit…")
+    }
+
+    private companion object {
+        const val THROTTLE_NOTICE_INTERVAL_MS = 6_000L
     }
 }

--- a/app/src/main/java/com/anisync/android/presentation/details/CharacterDetailsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/CharacterDetailsViewModel.kt
@@ -79,25 +79,35 @@ class CharacterDetailsViewModel @Inject constructor(
         }
     }
 
-    fun toggleFavourite() {
-        viewModelScope.launch {
-            val currentState =
-                _uiState.value as? CharacterDetailsUiState.Success ?: return@launch
-            val newState = !currentState.details.isFavourite
-            // Optimistic update
-            _uiState.value = CharacterDetailsUiState.Success(
-                currentState.details.copy(isFavourite = newState)
-            )
-            when (detailsRepository.toggleCharacterFavourite(characterId, newState)) {
-                is Result.Success -> {
-                    // Keep optimistic state. Mutation success is sufficient;
-                    // the paged response payload cannot be trusted to derive the new flag.
-                }
+    @Volatile private var isTogglingFavourite = false
 
-                is Result.Error -> {
-                    // Revert optimistic update
-                    _uiState.value = currentState
+    fun toggleFavourite() {
+        // Drop taps while a toggle is in flight; favourite is eventually-consistent
+        // on AniList, so stacking requests risks flip-flopping the state.
+        if (isTogglingFavourite) return
+        isTogglingFavourite = true
+        viewModelScope.launch {
+            try {
+                val currentState =
+                    _uiState.value as? CharacterDetailsUiState.Success ?: return@launch
+                val newState = !currentState.details.isFavourite
+                // Optimistic update
+                _uiState.value = CharacterDetailsUiState.Success(
+                    currentState.details.copy(isFavourite = newState)
+                )
+                when (detailsRepository.toggleCharacterFavourite(characterId, newState)) {
+                    is Result.Success -> {
+                        // Keep optimistic state. Mutation success is sufficient;
+                        // the paged response payload cannot be trusted to derive the new flag.
+                    }
+
+                    is Result.Error -> {
+                        // Revert optimistic update
+                        _uiState.value = currentState
+                    }
                 }
+            } finally {
+                isTogglingFavourite = false
             }
         }
     }

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsViewModel.kt
@@ -221,10 +221,32 @@ class MediaDetailsViewModel @Inject constructor(
         }
     }
 
+    // Coalesces rating taps so dragging through values sends one rate + one refresh
+    // instead of one pair per intermediate value. Ratings are absolute sets, so no
+    // baseline seeding is needed (a re-submit of the same value is a no-op).
+    private val reviewRatingCoalescer =
+        com.anisync.android.presentation.util.MutationCoalescer<Int, com.anisync.android.type.ReviewRating>(viewModelScope) { reviewId, rating ->
+            when (detailsRepository.rateReview(reviewId, rating)) {
+                is Result.Success -> { refresh(); true }
+                is Result.Error -> false
+            }
+        }
+    private val recommendationRatingCoalescer =
+        com.anisync.android.presentation.util.MutationCoalescer<Int, com.anisync.android.type.RecommendationRating>(viewModelScope) { recId, rating ->
+            when (detailsRepository.rateRecommendation(mediaId, recId, rating)) {
+                is Result.Success -> { refresh(); true }
+                is Result.Error -> false
+            }
+        }
+
     /**
      * Toggle favourite status for the current media.
      */
     fun toggleFavourite() {
+        // Favourite is a toggle endpoint and eventually-consistent on AniList, so
+        // stacking toggles risks flip-flopping. Drop taps while one is in flight —
+        // same in-flight guard the feed like button uses.
+        if (_isSaving.value) return
         viewModelScope.launch {
             val details = (uiState.value as? DetailsUiState.Success)?.details ?: return@launch
             val mediaType = details.type ?: return@launch
@@ -265,17 +287,7 @@ class MediaDetailsViewModel @Inject constructor(
      * Rate a review.
      */
     fun rateReview(reviewId: Int, rating: com.anisync.android.type.ReviewRating) {
-        viewModelScope.launch {
-            when (val result = detailsRepository.rateReview(reviewId, rating)) {
-                is Result.Success -> {
-                    // Update cache for immediate feedback
-                    refresh()
-                }
-                is Result.Error -> {
-                    // Handled implicitly or via snackbar later
-                }
-            }
-        }
+        reviewRatingCoalescer.submit(reviewId, rating)
     }
 
     companion object {
@@ -283,11 +295,6 @@ class MediaDetailsViewModel @Inject constructor(
     }
 
     fun rateRecommendation(recommendationId: Int, rating: com.anisync.android.type.RecommendationRating) {
-        viewModelScope.launch {
-            when (detailsRepository.rateRecommendation(mediaId, recommendationId, rating)) {
-                is Result.Success -> refresh()
-                is Result.Error -> {}
-            }
-        }
+        recommendationRatingCoalescer.submit(recommendationId, rating)
     }
 }

--- a/app/src/main/java/com/anisync/android/presentation/details/StaffDetailsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/StaffDetailsViewModel.kt
@@ -145,25 +145,35 @@ class StaffDetailsViewModel @Inject constructor(
         return oldList + newList.filter { seen.add("${it.mediaId}_${it.staffRole.orEmpty()}") }
     }
 
-    fun toggleFavourite() {
-        viewModelScope.launch {
-            val currentState =
-                _uiState.value as? StaffDetailsUiState.Success ?: return@launch
-            val newState = !currentState.details.isFavourite
-            // Optimistic update
-            _uiState.value = StaffDetailsUiState.Success(
-                currentState.details.copy(isFavourite = newState)
-            )
-            when (detailsRepository.toggleStaffFavourite(staffId, newState)) {
-                is Result.Success -> {
-                    // Keep optimistic state. Mutation success is sufficient;
-                    // the paged response payload cannot be trusted to derive the new flag.
-                }
+    @Volatile private var isTogglingFavourite = false
 
-                is Result.Error -> {
-                    // Revert optimistic update
-                    _uiState.value = currentState
+    fun toggleFavourite() {
+        // Drop taps while a toggle is in flight; favourite is eventually-consistent
+        // on AniList, so stacking requests risks flip-flopping the state.
+        if (isTogglingFavourite) return
+        isTogglingFavourite = true
+        viewModelScope.launch {
+            try {
+                val currentState =
+                    _uiState.value as? StaffDetailsUiState.Success ?: return@launch
+                val newState = !currentState.details.isFavourite
+                // Optimistic update
+                _uiState.value = StaffDetailsUiState.Success(
+                    currentState.details.copy(isFavourite = newState)
+                )
+                when (detailsRepository.toggleStaffFavourite(staffId, newState)) {
+                    is Result.Success -> {
+                        // Keep optimistic state. Mutation success is sufficient;
+                        // the paged response payload cannot be trusted to derive the new flag.
+                    }
+
+                    is Result.Error -> {
+                        // Revert optimistic update
+                        _uiState.value = currentState
+                    }
                 }
+            } finally {
+                isTogglingFavourite = false
             }
         }
     }

--- a/app/src/main/java/com/anisync/android/presentation/details/StudioDetailsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/StudioDetailsViewModel.kt
@@ -86,23 +86,33 @@ class StudioDetailsViewModel @Inject constructor(
         return oldList + newList.filter { seen.add(it.mediaId) }
     }
 
-    fun toggleFavourite() {
-        viewModelScope.launch {
-            val currentState =
-                _uiState.value as? StudioDetailsUiState.Success ?: return@launch
-            val newState = !currentState.details.isFavourite
-            _uiState.value = StudioDetailsUiState.Success(
-                currentState.details.copy(isFavourite = newState)
-            )
-            when (detailsRepository.toggleStudioFavourite(studioId, newState)) {
-                is Result.Success -> {
-                    // Keep optimistic state. Mutation success is sufficient;
-                    // the paged response payload cannot be trusted to derive the new flag.
-                }
+    @Volatile private var isTogglingFavourite = false
 
-                is Result.Error -> {
-                    _uiState.value = currentState
+    fun toggleFavourite() {
+        // Drop taps while a toggle is in flight; favourite is eventually-consistent
+        // on AniList, so stacking requests risks flip-flopping the state.
+        if (isTogglingFavourite) return
+        isTogglingFavourite = true
+        viewModelScope.launch {
+            try {
+                val currentState =
+                    _uiState.value as? StudioDetailsUiState.Success ?: return@launch
+                val newState = !currentState.details.isFavourite
+                _uiState.value = StudioDetailsUiState.Success(
+                    currentState.details.copy(isFavourite = newState)
+                )
+                when (detailsRepository.toggleStudioFavourite(studioId, newState)) {
+                    is Result.Success -> {
+                        // Keep optimistic state. Mutation success is sufficient;
+                        // the paged response payload cannot be trusted to derive the new flag.
+                    }
+
+                    is Result.Error -> {
+                        _uiState.value = currentState
+                    }
                 }
+            } finally {
+                isTogglingFavourite = false
             }
         }
     }

--- a/app/src/main/java/com/anisync/android/presentation/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/discover/DiscoverViewModel.kt
@@ -202,7 +202,7 @@ class DiscoverViewModel @Inject constructor(
     private fun observeSearchQuery() {
         viewModelScope.launch {
             searchTrigger
-                .debounce(300L)
+                .debounce(350L)
                 .distinctUntilChanged()
                 .collectLatest { trigger ->
                     val currentState =
@@ -224,54 +224,35 @@ class DiscoverViewModel @Inject constructor(
 
                     _uiState.update { currentState.copy(isSearching = true) }
 
-                    // Resolve which media buckets to fetch:
-                    //   ANIME explicit  → anime only
-                    //   MANGA explicit  → manga only
-                    //   non-media       → neither (searchAll handles those entities)
-                    //   null (Auto)     → BOTH, surfaced as two sections in the UI
+                    // Which buckets to surface — same gating as the old 3-request
+                    // fan-out, but it now rides a single SearchEverything request:
+                    //   ANIME/MANGA explicit → that media bucket only
+                    //   null (Auto)          → both media buckets + entities
+                    //   non-media type       → entities only (projected below)
+                    // Entities require an actual search string, so they're gated on
+                    // a non-blank query.
                     val wantAnime = filters.searchType == SearchType.ANIME ||
                         (filters.searchType == null && !filters.isNonMediaType)
                     val wantManga = filters.searchType == SearchType.MANGA ||
                         (filters.searchType == null && !filters.isNonMediaType)
-
-                    val animeDeferred = if (wantAnime) async {
-                        searchRepository.searchMedia(
-                            query = query,
-                            type = MediaType.ANIME,
-                            filters = filters
-                        )
-                    } else null
-                    val mangaDeferred = if (wantManga) async {
-                        searchRepository.searchMedia(
-                            query = query,
-                            type = MediaType.MANGA,
-                            filters = filters
-                        )
-                    } else null
-                    // SearchAll only kicks in once the user has typed something —
-                    // it's a multi-entity (character/staff/user/studio) lookup
-                    // that needs an actual search string. When the user has pinned
-                    // Type to ANIME or MANGA, the entity buckets must stay empty,
-                    // so skip the call entirely (saves a network roundtrip).
-                    val needsAll = query.isNotBlank() &&
+                    val wantEntities = query.isNotBlank() &&
                         filters.searchType != SearchType.ANIME &&
                         filters.searchType != SearchType.MANGA
-                    val allDeferred = if (needsAll) {
-                        async { searchRepository.searchAll(query) }
-                    } else null
 
-                    val animeResult = animeDeferred?.await()
-                    val mangaResult = mangaDeferred?.await()
-                    val allResult = allDeferred?.await()
+                    val result = searchRepository.searchEverything(
+                        query = query,
+                        filters = filters,
+                        wantAnime = wantAnime,
+                        wantManga = wantManga,
+                        wantEntities = wantEntities
+                    )
 
-                    val animeEntries = (animeResult as? Result.Success)?.data?.entries.orEmpty()
-                    val mangaEntries = (mangaResult as? Result.Success)?.data?.entries.orEmpty()
-                    val grouped = when (allResult) {
-                        is Result.Success -> allResult.data.projectFor(filters.searchType)
-                        is Result.Error, null -> GroupedSearchResults()
-                    }
-                    val error = (animeResult as? Result.Error)?.message
-                        ?: (mangaResult as? Result.Error)?.message
+                    val data = (result as? Result.Success)?.data
+                    val animeEntries = data?.anime.orEmpty()
+                    val mangaEntries = data?.manga.orEmpty()
+                    val grouped = (data?.grouped ?: GroupedSearchResults())
+                        .projectFor(filters.searchType)
+                    val error = (result as? Result.Error)?.message
 
                     _uiState.update { existing ->
                         (existing as? DiscoverUiState.Success)?.let { st ->
@@ -360,8 +341,15 @@ class DiscoverViewModel @Inject constructor(
     }
 
     private fun DiscoverUiState.Success.shouldSearch(): Boolean =
-        searchQuery.isNotBlank() || searchFilters.hasActiveFilters
+        searchQuery.trim().length >= MIN_SEARCH_QUERY_LENGTH || searchFilters.hasActiveFilters
 }
+
+/**
+ * Minimum query length before a text-driven search fires. Single-character queries
+ * match almost everything and just burn rate-limit budget; filters can still drive
+ * a search with a shorter/blank query.
+ */
+private const val MIN_SEARCH_QUERY_LENGTH = 2
 
 data class SearchTaxonomy(
     val genres: List<String> = emptyList(),

--- a/app/src/main/java/com/anisync/android/presentation/forum/ThreadDetailViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/forum/ThreadDetailViewModel.kt
@@ -419,7 +419,14 @@ class ThreadDetailViewModel @Inject constructor(
         }
     }
 
+    // Thread/comment targets with a like toggle in flight. A repeat tap on the same
+    // target is dropped until the first completes, so rapid tapping can't stack
+    // toggle requests (same guard the feed like button uses).
+    private val inFlightLikes = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
+
     private fun toggleLike(action: ThreadDetailAction.ToggleLike) {
+        val likeKey = (if (action.isThread) "t:" else "c:") + action.id
+        if (!inFlightLikes.add(likeKey)) return
         _uiState.update { state ->
             if (action.isThread) {
                 val thread = state.thread ?: return@update state
@@ -437,29 +444,33 @@ class ThreadDetailViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            val result = if (action.isThread) {
-                forumRepository.toggleLikeThread(action.id)
-            } else {
-                forumRepository.toggleLikeComment(action.id)
-            }
+            try {
+                val result = if (action.isThread) {
+                    forumRepository.toggleLikeThread(action.id)
+                } else {
+                    forumRepository.toggleLikeComment(action.id)
+                }
 
-            if (result is Result.Error) {
-                _uiState.update { state ->
-                    if (action.isThread) {
-                        val thread = state.thread ?: return@update state
-                        val revertedCount =
-                            if (action.currentLiked) thread.likeCount + 1 else thread.likeCount - 1
-                        state.copy(
-                            thread = thread.copy(
-                                isLiked = action.currentLiked,
-                                likeCount = revertedCount.coerceAtLeast(0)
+                if (result is Result.Error) {
+                    _uiState.update { state ->
+                        if (action.isThread) {
+                            val thread = state.thread ?: return@update state
+                            val revertedCount =
+                                if (action.currentLiked) thread.likeCount + 1 else thread.likeCount - 1
+                            state.copy(
+                                thread = thread.copy(
+                                    isLiked = action.currentLiked,
+                                    likeCount = revertedCount.coerceAtLeast(0)
+                                )
                             )
-                        )
-                    } else {
-                        val revertAction = action.copy(currentLiked = !action.currentLiked)
-                        state.copy(comments = state.comments.map { it.updateCommentLike(revertAction) })
+                        } else {
+                            val revertAction = action.copy(currentLiked = !action.currentLiked)
+                            state.copy(comments = state.comments.map { it.updateCommentLike(revertAction) })
+                        }
                     }
                 }
+            } finally {
+                inFlightLikes.remove(likeKey)
             }
         }
     }

--- a/app/src/main/java/com/anisync/android/presentation/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/library/LibraryViewModel.kt
@@ -344,15 +344,46 @@ class LibraryViewModel @Inject constructor(
         }
     }
 
+    // Coalesces rapid +/- taps on the same media into one SaveMediaListEntry of the
+    // settled value (was one network save per tap). Each tap updates the UI
+    // optimistically across every list the entry appears in; a +1 then −1 nets to a
+    // no-op. On failure the optimistic value rolls back to the last known-good one.
+    private val progressBaseline = java.util.concurrent.ConcurrentHashMap<Int, Int>()
+    private val progressCoalescer =
+        com.anisync.android.presentation.util.MutationCoalescer<Int, Int>(viewModelScope, debounceMs = 600L) { mediaId, progress ->
+            when (val result = libraryRepository.updateProgress(mediaId, progress)) {
+                is Result.Success -> {
+                    progressBaseline[mediaId] = progress
+                    true
+                }
+                is Result.Error -> {
+                    progressBaseline[mediaId]?.let { patchEntryProgress(mediaId, it) }
+                    showResultError(result)
+                    false
+                }
+            }
+        }
+
     private fun updateProgress(mediaId: Int, delta: Int) {
         val entry = _uiState.value.entries.find { it.mediaId == mediaId } ?: return
+        progressCoalescer.seed(mediaId, entry.progress)
+        progressBaseline.putIfAbsent(mediaId, entry.progress)
         val newProgress = (entry.progress + delta).coerceAtLeast(0)
+        patchEntryProgress(mediaId, newProgress)
+        progressCoalescer.submit(mediaId, newProgress)
+    }
 
-        viewModelScope.launch {
-            when (val result = libraryRepository.updateProgress(mediaId, newProgress)) {
-                is Result.Success -> {}
-                is Result.Error -> showResultError(result)
-            }
+    /** Optimistically set [mediaId]'s progress across every list it appears in. */
+    private fun patchEntryProgress(mediaId: Int, newProgress: Int) {
+        fun List<LibraryEntry>.patched(): List<LibraryEntry> =
+            map { if (it.mediaId == mediaId) it.copy(progress = newProgress) else it }
+        _uiState.update { st ->
+            st.copy(
+                entries = st.entries.patched(),
+                groupedEntries = st.groupedEntries.mapValues { it.value.patched() },
+                customListEntries = st.customListEntries.mapValues { it.value.patched() },
+                favoriteEntries = st.favoriteEntries.patched()
+            )
         }
     }
 

--- a/app/src/main/java/com/anisync/android/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/ProfileViewModel.kt
@@ -188,12 +188,45 @@ class ProfileViewModel @Inject constructor(
 
     private val mediaListState = MutableStateFlow(MediaListState())
 
+    /**
+     * Full favourite-anime list, loaded lazily when the Favorites tab opens. Null
+     * until first fetch — the UI falls back to the page-1 preview the profile
+     * itself carries. Keeping it out of the profile until populated means a normal
+     * profile load/refresh never fans out across favourite pages.
+     */
+    private data class FavoritesState(
+        val fullAnime: List<LibraryEntry>? = null,
+        val isLoading: Boolean = false,
+        val hasFetched: Boolean = false
+    )
+
+    private val favoritesState = MutableStateFlow(FavoritesState())
+
     // Overlay for optimistic activity subscription toggles: activityId -> isSubscribed
     private val activitySubscriptionOverrides = MutableStateFlow<Map<Int, Boolean>>(emptyMap())
 
     // Overlay for optimistic activity like toggles: activityId -> (isLiked, likeCount).
     private val activityLikeOverrides =
         MutableStateFlow<Map<Int, Pair<Boolean, Int>>>(emptyMap())
+
+    // Coalesces rapid like taps into a single network toggle. Each tap flips the
+    // optimistic override instantly; only the settled state is sent, so a
+    // like→unlike→like burst hits the network at most once (or not at all).
+    private val activityLikeCoalescer =
+        com.anisync.android.presentation.util.MutationCoalescer<Int, Boolean>(viewModelScope) { activityId, _ ->
+            when (val result = activityRepository.toggleActivityLike(activityId)) {
+                is Result.Success -> {
+                    val server = result.data
+                    activityLikeOverrides.update { it + (activityId to (server.isLiked to server.likeCount)) }
+                    true
+                }
+                is Result.Error -> {
+                    activityLikeOverrides.update { it - activityId }
+                    toastManager.showResultError(result)
+                    false
+                }
+            }
+        }
 
     // Optimistically-deleted activity ids hidden from the UI until confirmed.
     private val deletedActivityIds = MutableStateFlow<Set<Int>>(emptySet())
@@ -258,7 +291,8 @@ class ProfileViewModel @Inject constructor(
         activityLikeOverrides,
         deletedActivityIds,
         viewerIdFlow,
-        notificationBadgeStore.unreadCount
+        notificationBadgeStore.unreadCount,
+        favoritesState
     ) { params ->
         val remote = params[0] as ProfileUiState
         val local = params[1] as ProfileUiLocalState
@@ -274,6 +308,7 @@ class ProfileViewModel @Inject constructor(
         val deletedIds = params[8] as Set<Int>
         val viewerId = params[9] as Int?
         val unreadCount = params[10] as Int
+        val favoritesOverlay = params[11] as FavoritesState
 
         val needsOverlay = remote.profile != null &&
             (subOverrides.isNotEmpty() || likeOverrides.isNotEmpty() || deletedIds.isNotEmpty())
@@ -296,7 +331,15 @@ class ProfileViewModel @Inject constructor(
             remote.copy(profile = profile.copy(activities = patched))
         }
 
-        remoteWithOverrides.copy(
+        // Swap in the lazily-loaded full favourite-anime list once available;
+        // until then the page-1 preview carried by the profile fetch stands.
+        val withFavorites = favoritesOverlay.fullAnime?.let { full ->
+            remoteWithOverrides.profile?.let { p ->
+                remoteWithOverrides.copy(profile = p.copy(favoriteAnime = full))
+            }
+        } ?: remoteWithOverrides
+
+        withFavorites.copy(
             isRefreshing = local.isRefreshing,
             isFollowingUser = local.isFollowingUser,
             isFollowLoading = local.isFollowLoading,
@@ -401,6 +444,8 @@ class ProfileViewModel @Inject constructor(
                     fetchReviews()
                 } else if (action.tab == ProfileTab.STATS && !statsState.value.hasFetchedStats) {
                     fetchStats()
+                } else if (action.tab == ProfileTab.FAVORITES && !favoritesState.value.hasFetched) {
+                    fetchFullFavoriteAnime()
                 } else if (action.tab == ProfileTab.ANIME &&
                     shouldRefreshAnimeList() &&
                     !mediaListState.value.isUserAnimeListLoading
@@ -558,24 +603,13 @@ class ProfileViewModel @Inject constructor(
     private fun toggleActivityLike(activityId: Int) {
         val current = uiState.value.profile?.activities?.firstOrNull { it.id == activityId } ?: return
         val wasLiked = current.isLiked
+        // Baseline = server-side liked state (recorded once); each tap flips the
+        // optimistic override and the coalescer sends only the settled result.
+        activityLikeCoalescer.seed(activityId, wasLiked)
         val nextLiked = !wasLiked
         val nextCount = (current.likeCount + if (wasLiked) -1 else 1).coerceAtLeast(0)
         activityLikeOverrides.update { it + (activityId to (nextLiked to nextCount)) }
-
-        viewModelScope.launch {
-            when (val result = activityRepository.toggleActivityLike(activityId)) {
-                is Result.Success -> {
-                    val server = result.data
-                    activityLikeOverrides.update {
-                        it + (activityId to (server.isLiked to server.likeCount))
-                    }
-                }
-            is Result.Error -> {
-                activityLikeOverrides.update { it - activityId }
-                toastManager.showResultError(result)
-            }
-            }
-        }
+        activityLikeCoalescer.submit(activityId, nextLiked)
     }
 
     private fun deleteActivity(activityId: Int) {
@@ -687,6 +721,7 @@ class ProfileViewModel @Inject constructor(
                             ProfileTab.SOCIAL -> fetchSocialData(forceRefresh = true)
                             ProfileTab.REVIEWS -> fetchReviews(forceRefresh = true)
                             ProfileTab.STATS -> fetchStats(forceRefresh = true)
+                            ProfileTab.FAVORITES -> fetchFullFavoriteAnime(forceRefresh = true)
                             ProfileTab.ANIME -> fetchUserAnimeList(forceRefresh = shouldRefreshAnimeList())
                             ProfileTab.MANGA -> fetchUserMangaList(forceRefresh = shouldRefreshMangaList())
                             else -> Unit
@@ -857,6 +892,31 @@ class ProfileViewModel @Inject constructor(
                 }
                 is Result.Error -> {
                     reviewsState.update { it.copy(isReviewsPaginating = false) }
+                }
+            }
+        }
+    }
+
+    /**
+     * Loads the full favourite-anime list (all pages) on demand. Triggered when the
+     * Favorites tab is first opened, or re-run on pull-to-refresh while that tab is
+     * active. The overview/profile fetch only carries page 1, so this is the only
+     * place the favourites fan-out runs — never on the common load/refresh path.
+     */
+    private fun fetchFullFavoriteAnime(forceRefresh: Boolean = false) {
+        if (favoritesState.value.isLoading) return
+        if (!forceRefresh && favoritesState.value.hasFetched) return
+
+        viewModelScope.launch {
+            val userId = uiState.value.profile?.id?.takeIf { it > 0 } ?: return@launch
+            favoritesState.update { it.copy(isLoading = true) }
+            val policy = if (forceRefresh) CachePolicy.NetworkOnly else CachePolicy.NetworkFirst
+            when (val result = profileRepository.getFavoriteAnime(userId, policy)) {
+                is Result.Success -> favoritesState.update {
+                    it.copy(fullAnime = result.data, isLoading = false, hasFetched = true)
+                }
+                is Result.Error -> favoritesState.update {
+                    it.copy(isLoading = false, hasFetched = true)
                 }
             }
         }

--- a/app/src/main/java/com/anisync/android/presentation/util/MutationCoalescer.kt
+++ b/app/src/main/java/com/anisync/android/presentation/util/MutationCoalescer.kt
@@ -1,0 +1,77 @@
+package com.anisync.android.presentation.util
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Coalesces rapid, idempotent mutations (likes, favourites, ratings, progress)
+ * keyed by entity id, so a burst of taps collapses into at most one network call.
+ *
+ * Each [submit] cancels the pending flush for that key and reschedules; only the
+ * value that survives [debounceMs] of quiet is committed. If the settled value
+ * equals the last server-committed value — e.g. like → unlike → like, or +1 then
+ * −1 on progress — **nothing** is sent. Optimistic UI updates happen at the call
+ * site, immediately; this class only governs when (and whether) the network fires.
+ *
+ * The ViewModel owns optimistic state and error rollback. This is deliberately the
+ * single throttle primitive shared across like/favourite/rating/progress sites
+ * (see P5) instead of each ViewModel hand-rolling its own debounce.
+ *
+ * @param V the desired settled value. For toggle endpoints (ToggleLike,
+ *   ToggleFavourite) use [Boolean] and have [commit] issue a single toggle when the
+ *   target differs from committed. For absolute endpoints (SaveMediaListEntry) use
+ *   the absolute value (e.g. progress as [Int]).
+ */
+class MutationCoalescer<K : Any, V>(
+    private val scope: CoroutineScope,
+    private val debounceMs: Long = 500L,
+    /**
+     * Sends the settled [value] for [key]; returns true if it reached the server.
+     * Returning false (e.g. the call errored and the site rolled back) leaves the
+     * committed baseline unchanged so the next [submit] re-evaluates and retries.
+     */
+    private val commit: suspend (key: K, value: V) -> Boolean
+) {
+    private val jobs = ConcurrentHashMap<K, Job>()
+    private val committed = ConcurrentHashMap<K, V>()
+
+    /**
+     * Record the value currently in sync with the server for [key] so a coalesced
+     * no-op (return-to-original) can be detected. Call when the entity first loads.
+     * Does not overwrite a value already being tracked.
+     */
+    fun seed(key: K, value: V) {
+        committed.putIfAbsent(key, value)
+    }
+
+    /** Force [key]'s committed baseline to [value] (e.g. after an external refresh). */
+    fun reset(key: K, value: V) {
+        committed[key] = value
+    }
+
+    /**
+     * Schedule [target] as the new desired value for [key], replacing any pending
+     * flush. After [debounceMs] of quiet it is committed via [commit] — unless it
+     * already matches the committed value, in which case the burst was a no-op.
+     */
+    fun submit(key: K, target: V) {
+        jobs.remove(key)?.cancel()
+        jobs[key] = scope.launch {
+            delay(debounceMs)
+            if (committed[key] == target) {
+                jobs.remove(key)
+                return@launch
+            }
+            if (commit(key, target)) committed[key] = target
+            jobs.remove(key)
+        }
+    }
+
+    /** Cancel any pending flush for [key] without committing (e.g. on entity removal). */
+    fun cancel(key: K) {
+        jobs.remove(key)?.cancel()
+    }
+}


### PR DESCRIPTION
## Why

Profiles and search felt slow. Root cause was request-volume amplification plus silent client-side throttling, not missing 429 handling (that infra already exists). This cuts the volume.

## Changes

- **Profile:** new `GetFullUserProfile` folds profile + stats + favourites(p1) + activity feeds into one request (activity pages `@include`-gated on a known userId). Own warm path: `2 + (N-1)` requests -> 1. The all-pages favourites fan-out is removed from the load/refresh hot path and now loads lazily only when the Favorites tab opens.
- **Search:** new `SearchEverything` collapses the Auto-mode anime+manga+entity fan-out (3 requests -> 1), aliased + `@include`-gated. Adds a 2-char min-query gate, 350ms debounce, `NetworkFirst` cache reuse, and in-flight dedup.
- **Throttle UX:** the interceptor surfaces a brief, non-blocking notice when client-side pacing delays a request >800ms, so deliberate slowdowns no longer read as a frozen app.
- **Tap-mutation spam:** new `MutationCoalescer` + in-flight guards across activity/forum likes, media/character/staff/studio favourites, review/recommendation ratings, and library progress +/- so bursts collapse to <=1 network call.
- **Cleanup:** extract shared `MediaCardFields` fragment across the media queries (better cache normalization).

## Verification (on-device, degraded 30/min)

- Profile cold open: `profileQuery=875ms activities=0ms favoritesPages=1 forceNetwork=false` — 1 unified op.
- Pull-to-refresh x3 spam -> 1 refresh (mutex+cooldown drop extras), no fan-out, no 429.
- Favourites fan-out now fires only on the Favorites tab (off the hot path), TokenBucket-paced.
- Search "naruto" -> 1 request (was 3); all buckets populate.
- Library progress net-zero burst (+2/-2) -> 0 writes (coalesced no-op).
- `./gradlew assembleStableDebug testStableDebugUnitTest` green.

Closes #30