### PR TITLE
feat(media-upload): add Catbox account userhash

### DIFF
--- a/app/src/main/java/com/anisync/android/data/AppSettings.kt
+++ b/app/src/main/java/com/anisync/android/data/AppSettings.kt
@@ -403,6 +403,11 @@ class AppSettings @Inject constructor(
     )
     val customHostResponseJsonPath: StateFlow<String> = _customHostResponseJsonPath.asStateFlow()
 
+    // Optional Catbox account userhash. When set, uploads are bound to the user's
+    // Catbox account so they can view/manage them at catbox.moe; blank = anonymous.
+    private val _catboxUserHash = MutableStateFlow(prefs.getString(KEY_CATBOX_USERHASH, "").orEmpty())
+    val catboxUserHash: StateFlow<String> = _catboxUserHash.asStateFlow()
+
     private fun readMediaHost(): MediaHost {
         val name = runCatching { prefs.getString(KEY_MEDIA_HOST, null) }.getOrNull()
         return runCatching { MediaHost.valueOf(name ?: MediaHost.CATBOX.name) }
@@ -803,6 +808,11 @@ class AppSettings @Inject constructor(
         prefs.edit().putString(KEY_CUSTOM_HOST_JSON_PATH, value).apply()
     }
 
+    fun setCatboxUserHash(value: String) {
+        _catboxUserHash.value = value
+        prefs.edit().putString(KEY_CATBOX_USERHASH, value).apply()
+    }
+
     /**
      * Get the preferred streaming service directly from SharedPreferences.
      * Use this for widgets to ensure the latest value is always read.
@@ -909,6 +919,7 @@ companion object {
         private const val KEY_CUSTOM_HOST_FIELD = "custom_host_field"
         private const val KEY_CUSTOM_HOST_AUTH = "custom_host_auth"
         private const val KEY_CUSTOM_HOST_JSON_PATH = "custom_host_json_path"
+        private const val KEY_CATBOX_USERHASH = "catbox_userhash"
     }
 }
 

--- a/app/src/main/java/com/anisync/android/data/media/CatboxUploader.kt
+++ b/app/src/main/java/com/anisync/android/data/media/CatboxUploader.kt
@@ -23,6 +23,9 @@ class CatboxUploader @Inject constructor(
     private val client: OkHttpClient
 ) : MediaUploader {
 
+    /** Set by the factory before each upload — binds the upload to a Catbox account when non-blank. */
+    var userhash: String = ""
+
     override suspend fun upload(
         uri: Uri,
         mime: String,
@@ -34,6 +37,7 @@ class CatboxUploader @Inject constructor(
             val body = MultipartBody.Builder()
                 .setType(MultipartBody.FORM)
                 .addFormDataPart("reqtype", "fileupload")
+                .apply { if (userhash.isNotBlank()) addFormDataPart("userhash", userhash) }
                 .addFormDataPart("fileToUpload", filename, fileBody)
                 .build()
             val request = Request.Builder()

--- a/app/src/main/java/com/anisync/android/data/media/MediaUploaderFactory.kt
+++ b/app/src/main/java/com/anisync/android/data/media/MediaUploaderFactory.kt
@@ -20,7 +20,9 @@ class MediaUploaderFactory @Inject constructor(
 ) {
     fun current(): MediaUploader {
         return when (settings.mediaHost.value) {
-            MediaHost.CATBOX -> catbox.get()
+            MediaHost.CATBOX -> catbox.get().apply {
+                userhash = settings.catboxUserHash.value.trim()
+            }
             MediaHost.LITTERBOX -> litterbox.get().apply {
                 time = settings.litterboxDuration.value.ifBlank { "1h" }
             }

--- a/app/src/main/java/com/anisync/android/presentation/settings/MediaUploadSettingsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/MediaUploadSettingsScreen.kt
@@ -19,22 +19,32 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Cloud
+import androidx.compose.material.icons.outlined.CloudDone
 import androidx.compose.material.icons.outlined.CloudUpload
 import androidx.compose.material.icons.outlined.Code
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material.icons.outlined.UploadFile
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -59,6 +69,8 @@ fun MediaUploadSettingsScreen(
     val customField by viewModel.customHostFileField.collectAsStateWithLifecycle()
     val customAuth by viewModel.customHostAuthHeader.collectAsStateWithLifecycle()
     val customJsonPath by viewModel.customHostResponseJsonPath.collectAsStateWithLifecycle()
+    val catboxUserHash by viewModel.catboxUserHash.collectAsStateWithLifecycle()
+    var showHashDialog by rememberSaveable { mutableStateOf(false) }
 
     SettingsScreenScaffold(
         title = stringResource(R.string.settings_media_upload),
@@ -70,14 +82,32 @@ fun MediaUploadSettingsScreen(
         Spacer(Modifier.height(8.dp))
 
         SettingsGroup {
-            HostRow(
-                current = host,
-                value = MediaHost.CATBOX,
-                titleRes = R.string.media_upload_host_catbox,
-                subtitleRes = R.string.media_upload_host_catbox_desc,
-                icon = Icons.Outlined.Cloud,
-                onSelect = viewModel::setMediaHost
-            )
+            Column {
+                HostRow(
+                    current = host,
+                    value = MediaHost.CATBOX,
+                    titleRes = R.string.media_upload_host_catbox,
+                    subtitleRes = R.string.media_upload_host_catbox_desc,
+                    icon = Icons.Outlined.Cloud,
+                    onSelect = viewModel::setMediaHost
+                )
+                AnimatedVisibility(
+                    visible = host == MediaHost.CATBOX,
+                    enter = fadeIn() + expandVertically(),
+                    exit = fadeOut() + shrinkVertically()
+                ) {
+                    Surface(
+                        onClick = { showHashDialog = true },
+                        color = MaterialTheme.colorScheme.surfaceContainer,
+                        shape = RoundedCornerShape(10.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 4.dp, vertical = 2.dp)
+                    ) {
+                        CatboxAccountRow(userHash = catboxUserHash)
+                    }
+                }
+            }
             SettingsDivider()
             Column {
                 HostRow(
@@ -145,6 +175,17 @@ fun MediaUploadSettingsScreen(
         }
 
         Spacer(Modifier.height(8.dp))
+    }
+
+    if (showHashDialog) {
+        CatboxUserHashDialog(
+            initial = catboxUserHash,
+            onSave = {
+                viewModel.setCatboxUserHash(it)
+                showHashDialog = false
+            },
+            onDismiss = { showHashDialog = false }
+        )
     }
 }
 
@@ -284,6 +325,110 @@ private fun CustomHostCard(
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
+}
+
+/**
+ * Status row revealed under the Catbox host. Shows whether uploads are bound to an account and,
+ * when they are, a masked preview of the hash. Tapping the row (handled by the parent [Surface])
+ * opens [CatboxUserHashDialog] to edit or clear it.
+ */
+@Composable
+private fun CatboxAccountRow(userHash: String) {
+    val connected = userHash.isNotBlank()
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        Icon(
+            imageVector = if (connected) Icons.Outlined.CloudDone else Icons.Outlined.Lock,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(24.dp)
+        )
+        Spacer(Modifier.width(16.dp))
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.media_upload_catbox_account),
+                style = MaterialTheme.typography.titleMedium
+            )
+            Text(
+                text = if (connected) {
+                    stringResource(R.string.media_upload_catbox_account_connected, maskUserHash(userHash))
+                } else {
+                    stringResource(R.string.media_upload_catbox_account_anonymous)
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Spacer(Modifier.width(8.dp))
+        Icon(
+            imageVector = Icons.Outlined.Edit,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(20.dp)
+        )
+    }
+}
+
+/** Show only the head and tail so the full credential is never rendered in the settings list. */
+private fun maskUserHash(hash: String): String =
+    if (hash.length <= 8) hash else "${hash.take(4)}…${hash.takeLast(4)}"
+
+@Composable
+private fun CatboxUserHashDialog(
+    initial: String,
+    onSave: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var draft by remember(initial) { mutableStateOf(initial) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Outlined.Lock, contentDescription = null) },
+        title = { Text(stringResource(R.string.media_upload_catbox_dialog_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = draft,
+                    onValueChange = { draft = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    label = { Text(stringResource(R.string.media_upload_catbox_userhash)) },
+                    placeholder = { Text(stringResource(R.string.media_upload_catbox_userhash_hint)) },
+                    trailingIcon = {
+                        if (draft.isNotEmpty()) {
+                            IconButton(onClick = { draft = "" }) {
+                                Icon(
+                                    imageVector = Icons.Outlined.Close,
+                                    contentDescription = stringResource(R.string.clear)
+                                )
+                            }
+                        }
+                    }
+                )
+                Text(
+                    text = stringResource(R.string.media_upload_catbox_userhash_help),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onSave(draft.trim()) }) {
+                Text(stringResource(R.string.save))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/anisync/android/presentation/settings/MediaUploadSettingsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/MediaUploadSettingsViewModel.kt
@@ -18,6 +18,7 @@ class MediaUploadSettingsViewModel @Inject constructor(
     val customHostFileField: StateFlow<String> = settings.customHostFileField
     val customHostAuthHeader: StateFlow<String> = settings.customHostAuthHeader
     val customHostResponseJsonPath: StateFlow<String> = settings.customHostResponseJsonPath
+    val catboxUserHash: StateFlow<String> = settings.catboxUserHash
 
     fun setMediaHost(host: MediaHost) = settings.setMediaHost(host)
     fun setLitterboxDuration(duration: String) = settings.setLitterboxDuration(duration)
@@ -25,4 +26,5 @@ class MediaUploadSettingsViewModel @Inject constructor(
     fun setCustomHostFileField(value: String) = settings.setCustomHostFileField(value)
     fun setCustomHostAuthHeader(value: String) = settings.setCustomHostAuthHeader(value)
     fun setCustomHostResponseJsonPath(value: String) = settings.setCustomHostResponseJsonPath(value)
+    fun setCatboxUserHash(value: String) = settings.setCatboxUserHash(value)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -843,6 +843,13 @@
     <string name="media_upload_intro">AniList does not host uploads. Pick a third-party host to use when attaching media inside threads, replies, status posts, messages, and bios.</string>
     <string name="media_upload_host_catbox">Catbox.moe</string>
     <string name="media_upload_host_catbox_desc">Permanent free hosting, up to 200 MB per file</string>
+    <string name="media_upload_catbox_account">Account userhash</string>
+    <string name="media_upload_catbox_account_connected">Connected · %1$s</string>
+    <string name="media_upload_catbox_account_anonymous">Not connected · uploads are anonymous</string>
+    <string name="media_upload_catbox_dialog_title">Catbox account</string>
+    <string name="media_upload_catbox_userhash">Userhash</string>
+    <string name="media_upload_catbox_userhash_hint">Find it under Manage Account on catbox.moe</string>
+    <string name="media_upload_catbox_userhash_help">Bind uploads to your Catbox account so you can view and delete them later. Leave empty to upload anonymously.</string>
     <string name="media_upload_host_litterbox">Litterbox</string>
     <string name="media_upload_host_litterbox_desc">Temporary hosting on the same network as Catbox</string>
     <string name="media_upload_host_custom">Custom host</string>


### PR DESCRIPTION
## What

Adds optional **Catbox account userhash** support to Media upload settings. When set, uploads to Catbox are bound to the user's account (viewable/deletable at catbox.moe); left blank, uploads stay anonymous exactly as before.

This implements the agreed scope from #43 (option 2 — authenticate via userhash so uploads are tracked), not an in-app gallery.

## Changes

- `AppSettings`: persist `catboxUserHash` (+ flow/setter)
- `CatboxUploader`: send `userhash` form part when non-blank (mirrors Litterbox's `time`)
- `MediaUploaderFactory`: inject the saved hash into the Catbox uploader
- `MediaUploadSettingsScreen`: status row (connected/anonymous, masked hash) that opens an `AlertDialog` to edit/clear the hash
- strings (reuses existing `clear`/`cancel`/`save`)

## Verified on device

- Upload through composer with userhash set → returned a Catbox URL; `deletefiles` with the userhash succeeded and the URL went `200 → 404`, proving the file was account-bound (anonymous files can't be deleted by userhash)
- Dialog paths: clear ✕, save-empty → anonymous, save-hash → connected/masked

Closes #43