### PR TITLE
feat(discover): add Newly Added and Recent Reviews sections

### DIFF
--- a/app/src/main/graphql/GetRecentReviews.graphql
+++ b/app/src/main/graphql/GetRecentReviews.graphql
@@ -1,0 +1,39 @@
+query GetRecentReviews($mediaType: MediaType, $page: Int = 1) {
+  Page(page: $page, perPage: 20) {
+    pageInfo {
+      hasNextPage
+      total
+    }
+    reviews(mediaType: $mediaType, sort: CREATED_AT_DESC) {
+      id
+      summary
+      body(asHtml: true)
+      rating
+      ratingAmount
+      userRating
+      score
+      createdAt
+      updatedAt
+      media {
+        id
+        title {
+          userPreferred
+        }
+        coverImage {
+          medium
+          large
+          extraLarge
+        }
+        type
+        bannerImage
+      }
+      user {
+        id
+        name
+        avatar {
+          large
+        }
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/anisync/android/data/DiscoverRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/DiscoverRepositoryImpl.kt
@@ -31,6 +31,58 @@ class DiscoverRepositoryImpl @Inject constructor(
         return fetchMedia(listOf(MediaSort.POPULARITY_DESC), type)
     }
 
+    override suspend fun getNewlyAdded(type: MediaType): Result<List<LibraryEntry>> {
+        return fetchMedia(listOf(MediaSort.ID_DESC), type)
+    }
+
+    override suspend fun getRecentReviews(
+        mediaType: MediaType?,
+        page: Int
+    ): Result<com.anisync.android.domain.UserReviewsPage> {
+        return safeApiCall {
+            val response = apolloClient.query(
+                com.anisync.android.GetRecentReviewsQuery(
+                    mediaType = mediaType?.let { Optional.present(it) } ?: Optional.absent(),
+                    page = Optional.present(page)
+                )
+            )
+            .fetchPolicy(FetchPolicy.NetworkOnly)
+            .execute()
+
+            if (response.hasErrors()) {
+                throw Exception(response.errors?.first()?.message ?: "Failed to fetch recent reviews")
+            }
+
+            val reviews = response.data?.Page?.reviews?.filterNotNull()?.map { review ->
+                com.anisync.android.domain.MediaReview(
+                    id = review.id,
+                    summary = review.summary ?: "",
+                    body = review.body,
+                    score = review.score ?: 0,
+                    rating = review.rating ?: 0,
+                    ratingAmount = review.ratingAmount ?: 0,
+                    userRating = review.userRating?.name,
+                    userName = review.user?.name ?: "Unknown",
+                    userAvatarUrl = review.user?.avatar?.large,
+                    createdAt = review.createdAt.toLong(),
+                    mediaTitle = review.media?.title?.userPreferred,
+                    mediaCoverUrl = review.media?.coverImage?.large,
+                    mediaCover = com.anisync.android.domain.CoverImage.of(
+                        review.media?.coverImage?.medium,
+                        review.media?.coverImage?.large,
+                        review.media?.coverImage?.extraLarge
+                    ),
+                    mediaBannerUrl = review.media?.bannerImage
+                )
+            } ?: emptyList()
+
+            com.anisync.android.domain.UserReviewsPage(
+                reviews = reviews,
+                hasNextPage = response.data?.Page?.pageInfo?.hasNextPage == true
+            )
+        }
+    }
+
     override suspend fun getUpcoming(type: MediaType): Result<List<LibraryEntry>> {
         return safeApiCall {
             val response = apolloClient.query(
@@ -82,6 +134,7 @@ class DiscoverRepositoryImpl @Inject constructor(
                 "popular" -> listOf(MediaSort.POPULARITY_DESC) to null
                 "upcoming" -> listOf(MediaSort.POPULARITY_DESC) to MediaStatus.NOT_YET_RELEASED
                 "tba" -> listOf(MediaSort.POPULARITY_DESC) to MediaStatus.NOT_YET_RELEASED
+                "newly_added" -> listOf(MediaSort.ID_DESC) to null
                 else -> listOf(MediaSort.POPULARITY_DESC) to null
             }
 

--- a/app/src/main/java/com/anisync/android/domain/DiscoverRepository.kt
+++ b/app/src/main/java/com/anisync/android/domain/DiscoverRepository.kt
@@ -35,6 +35,22 @@ interface DiscoverRepository {
      * @return List of TBA entries or error
      */
     suspend fun getTBA(type: MediaType): Result<List<LibraryEntry>>
+
+    /**
+     * Get newly added media by type — the entries most recently added to AniList
+     * (sorted by descending database id).
+     * @param type Media type (ANIME or MANGA)
+     * @return List of newly added entries or error
+     */
+    suspend fun getNewlyAdded(type: MediaType): Result<List<LibraryEntry>>
+
+    /**
+     * Get the most recently published reviews across AniList, newest first.
+     * @param mediaType Optional filter (ANIME or MANGA); null returns reviews for both
+     * @param page Page number (1-indexed)
+     * @return Paginated reviews or error
+     */
+    suspend fun getRecentReviews(mediaType: MediaType?, page: Int): Result<UserReviewsPage>
     
     /**
      * Fetches paginated media for grid screens with optional format filtering.

--- a/app/src/main/java/com/anisync/android/presentation/discover/DiscoverScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/discover/DiscoverScreen.kt
@@ -87,6 +87,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.anisync.android.R
 import com.anisync.android.domain.LibraryEntry
+import com.anisync.android.domain.MediaReview
 import com.anisync.android.presentation.components.CustomPullToRefreshIndicator
 import com.anisync.android.presentation.components.HeaderLevel
 import com.anisync.android.presentation.components.MediaTypeSelector
@@ -95,6 +96,7 @@ import com.anisync.android.presentation.components.alert.rememberRateLimitedRefr
 import com.anisync.android.presentation.discover.components.DiscoverHeroCarousel
 import com.anisync.android.presentation.discover.components.DiscoverShimmer
 import com.anisync.android.presentation.discover.components.HorizontalMediaList
+import com.anisync.android.presentation.discover.components.RecentReviewsRow
 import com.anisync.android.presentation.discover.components.SearchResultItem
 import com.anisync.android.presentation.util.LocalMainNavBarInset
 import com.anisync.android.type.MediaType
@@ -108,6 +110,8 @@ import androidx.compose.foundation.lazy.grid.items as gridItems
 private const val TAG = "DiscoverScreen"
 
 private val TrendingIconColor = Color(0xFFFF5722)
+private val NewlyAddedIconColor = Color(0xFF26C6DA)
+private val RecentReviewsIconColor = Color(0xFFAB47BC)
 private val TbaIconColor = Color(0xFF9E9E9E)
 
 @OptIn(
@@ -124,6 +128,8 @@ fun DiscoverScreen(
     onStudioClick: (Int) -> Unit = {},
     onUserClick: (String) -> Unit = {},
     onSectionSeeAllClick: (title: String, sectionType: String, mediaType: MediaType) -> Unit,
+    onReviewClick: (Int) -> Unit = {},
+    onRecentReviewsSeeAllClick: (MediaType) -> Unit = {},
     viewModel: DiscoverViewModel = hiltViewModel(),
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedVisibilityScope
@@ -232,6 +238,8 @@ fun DiscoverScreen(
     val trendingTitle = stringResource(R.string.section_trending_now)
     val popularTitle = stringResource(R.string.section_all_time_popular)
     val upcomingTitle = stringResource(R.string.section_upcoming_season)
+    val newlyAddedTitle = stringResource(R.string.section_newly_added)
+    val recentReviewsTitle = stringResource(R.string.section_recent_reviews)
     val tbaTitle = stringResource(R.string.section_tba)
 
     LaunchedEffect(textFieldState) {
@@ -309,7 +317,9 @@ fun DiscoverScreen(
             trending = successState?.trending ?: emptyList(),
             popular = successState?.popular ?: emptyList(),
             upcoming = successState?.upcoming ?: emptyList(),
+            newlyAdded = successState?.newlyAdded ?: emptyList(),
             tba = successState?.tba ?: emptyList(),
+            recentReviews = successState?.recentReviews ?: emptyList(),
             mediaType = currentMediaType,
             titleLanguage = titleLanguage,
             isRefreshing = successState?.isRefreshing ?: false,
@@ -321,10 +331,14 @@ fun DiscoverScreen(
             trendingTitle = trendingTitle,
             popularTitle = popularTitle,
             upcomingTitle = upcomingTitle,
+            newlyAddedTitle = newlyAddedTitle,
+            recentReviewsTitle = recentReviewsTitle,
             tbaTitle = tbaTitle,
             onRefresh = onRefresh,
             onMediaClick = navigateToMediaDetails,
             onSectionSeeAllClick = onSectionSeeAllClick,
+            onReviewClick = onReviewClick,
+            onRecentReviewsSeeAllClick = onRecentReviewsSeeAllClick,
             sharedTransitionScope = sharedTransitionScope,
             animatedVisibilityScope = animatedVisibilityScope
         )
@@ -539,7 +553,9 @@ private fun DiscoverContent(
     trending: List<LibraryEntry>,
     popular: List<LibraryEntry>,
     upcoming: List<LibraryEntry>,
+    newlyAdded: List<LibraryEntry>,
     tba: List<LibraryEntry>,
+    recentReviews: List<MediaReview>,
     mediaType: MediaType,
     titleLanguage: com.anisync.android.data.TitleLanguage,
     isRefreshing: Boolean,
@@ -549,10 +565,14 @@ private fun DiscoverContent(
     trendingTitle: String,
     popularTitle: String,
     upcomingTitle: String,
+    newlyAddedTitle: String,
+    recentReviewsTitle: String,
     tbaTitle: String,
     onRefresh: () -> Unit,
     onMediaClick: (Int) -> Unit,
     onSectionSeeAllClick: (title: String, sectionType: String, mediaType: MediaType) -> Unit,
+    onReviewClick: (Int) -> Unit,
+    onRecentReviewsSeeAllClick: (MediaType) -> Unit,
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedVisibilityScope
 ) {
@@ -673,6 +693,56 @@ private fun DiscoverContent(
                                 titleLanguage = titleLanguage,
                                 sharedTransitionScope = sharedTransitionScope,
                                 animatedVisibilityScope = animatedVisibilityScope
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                        }
+                    }
+
+                    item(key = "newly_added_header", contentType = "section_header") {
+                        Spacer(modifier = Modifier.height(48.dp))
+                        SectionHeader(
+                            title = newlyAddedTitle,
+                            iconColor = NewlyAddedIconColor,
+                            onActionClick = {
+                                onSectionSeeAllClick(
+                                    newlyAddedTitle,
+                                    "newly_added",
+                                    mediaType
+                                )
+                            },
+                            level = HeaderLevel.Section
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                    }
+
+                    item(key = "newly_added_list", contentType = "media_list") {
+                        val newlyAddedItems = remember(newlyAdded) { newlyAdded.take(10) }
+                        HorizontalMediaList(
+                            items = newlyAddedItems,
+                            onItemClick = onMediaClick,
+                            titleLanguage = titleLanguage,
+                            sharedTransitionScope = sharedTransitionScope,
+                            animatedVisibilityScope = animatedVisibilityScope
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+
+                    if (recentReviews.isNotEmpty()) {
+                        item(key = "recent_reviews_header", contentType = "section_header") {
+                            Spacer(modifier = Modifier.height(48.dp))
+                            SectionHeader(
+                                title = recentReviewsTitle,
+                                iconColor = RecentReviewsIconColor,
+                                onActionClick = { onRecentReviewsSeeAllClick(mediaType) },
+                                level = HeaderLevel.Section
+                            )
+                            Spacer(modifier = Modifier.height(16.dp))
+                        }
+
+                        item(key = "recent_reviews_row", contentType = "review_row") {
+                            RecentReviewsRow(
+                                reviews = recentReviews.take(10),
+                                onReviewClick = onReviewClick
                             )
                             Spacer(modifier = Modifier.height(8.dp))
                         }

--- a/app/src/main/java/com/anisync/android/presentation/discover/DiscoverUiState.kt
+++ b/app/src/main/java/com/anisync/android/presentation/discover/DiscoverUiState.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Stable
 import com.anisync.android.data.DiscoverViewMode
 import com.anisync.android.domain.GroupedSearchResults
 import com.anisync.android.domain.LibraryEntry
+import com.anisync.android.domain.MediaReview
 import com.anisync.android.domain.SearchFilters
 import com.anisync.android.type.MediaType
 
@@ -22,7 +23,10 @@ sealed interface DiscoverUiState {
         val trending: List<LibraryEntry> = emptyList(),
         val popular: List<LibraryEntry> = emptyList(),
         val upcoming: List<LibraryEntry> = emptyList(),
+        val newlyAdded: List<LibraryEntry> = emptyList(),
         val tba: List<LibraryEntry> = emptyList(),
+        // Short "Recent Reviews" strip fetched alongside the media feed.
+        val recentReviews: List<MediaReview> = emptyList(),
         val mediaType: MediaType = MediaType.ANIME,
         val isRefreshing: Boolean = false,
         val searchQuery: String = "",

--- a/app/src/main/java/com/anisync/android/presentation/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/discover/DiscoverViewModel.kt
@@ -290,16 +290,24 @@ class DiscoverViewModel @Inject constructor(
             val trendingDeferred = async { discoverRepository.getTrending(mediaType) }
             val popularDeferred = async { discoverRepository.getPopular(mediaType) }
             val upcomingDeferred = async { discoverRepository.getUpcoming(mediaType) }
+            val newlyAddedDeferred = async { discoverRepository.getNewlyAdded(mediaType) }
             val tbaDeferred = async { discoverRepository.getTBA(mediaType) }
+            // Recent reviews ride alongside the media sections but never gate the
+            // screen — a reviews failure just hides that one section.
+            val recentReviewsDeferred = async { discoverRepository.getRecentReviews(mediaType, 1) }
 
             val trendingResult = trendingDeferred.await()
             val popularResult = popularDeferred.await()
             val upcomingResult = upcomingDeferred.await()
+            val newlyAddedResult = newlyAddedDeferred.await()
             val tbaResult = tbaDeferred.await()
+            val recentReviews =
+                (recentReviewsDeferred.await() as? Result.Success)?.data?.reviews ?: emptyList()
 
             if (trendingResult is Result.Success &&
                 popularResult is Result.Success &&
                 upcomingResult is Result.Success &&
+                newlyAddedResult is Result.Success &&
                 tbaResult is Result.Success
             ) {
 
@@ -311,7 +319,9 @@ class DiscoverViewModel @Inject constructor(
                         trending = trendingResult.data,
                         popular = popularResult.data,
                         upcoming = upcomingResult.data,
+                        newlyAdded = newlyAddedResult.data,
                         tba = tbaResult.data,
+                        recentReviews = recentReviews,
                         mediaType = mediaType,
                         isRefreshing = false
                     )
@@ -321,6 +331,7 @@ class DiscoverViewModel @Inject constructor(
                     trendingResult is Result.Error -> trendingResult.message
                     popularResult is Result.Error -> popularResult.message
                     upcomingResult is Result.Error -> upcomingResult.message
+                    newlyAddedResult is Result.Error -> newlyAddedResult.message
                     tbaResult is Result.Error -> tbaResult.message
                     else -> "Unknown error"
                 }

--- a/app/src/main/java/com/anisync/android/presentation/discover/components/RecentReviewsRow.kt
+++ b/app/src/main/java/com/anisync/android/presentation/discover/components/RecentReviewsRow.kt
@@ -1,0 +1,208 @@
+package com.anisync.android.presentation.discover.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.anisync.android.R
+import com.anisync.android.domain.MediaReview
+import com.anisync.android.presentation.components.UserAvatar
+import com.anisync.android.ui.theme.emphasis
+
+private val CardWidth = 300.dp
+private val CardHeight = 248.dp
+
+/**
+ * Horizontally scrolling row of recent reviews, mirroring the media carousels on
+ * Discover. Cards are fixed-size so the row stays tidy regardless of summary length.
+ */
+@Composable
+fun RecentReviewsRow(
+    reviews: List<MediaReview>,
+    onReviewClick: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyRow(
+        modifier = modifier,
+        contentPadding = PaddingValues(horizontal = 24.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        items(
+            items = reviews,
+            key = { "recent_review_${it.id}" },
+            contentType = { "recent_review_card" }
+        ) { review ->
+            HorizontalReviewCard(
+                review = review,
+                onClick = { onReviewClick(review.id) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun HorizontalReviewCard(
+    review: MediaReview,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val scoreColor = remember(review.score) {
+        when {
+            review.score >= 75 -> Color(0xFF4CAF50)
+            review.score >= 50 -> Color(0xFFFFC107)
+            else -> Color(0xFFFF5722)
+        }
+    }
+    val headerImageUrl = remember(review.mediaBannerUrl, review.mediaCoverUrl) {
+        review.mediaBannerUrl ?: review.mediaCoverUrl
+    }
+
+    Card(
+        modifier = modifier
+            .width(CardWidth)
+            .height(CardHeight),
+        shape = RoundedCornerShape(16.dp),
+        onClick = onClick,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+        )
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            if (headerImageUrl != null) {
+                AsyncImage(
+                    model = headerImageUrl,
+                    contentDescription = review.mediaTitle,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(96.dp)
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(96.dp)
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                )
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 12.dp, vertical = 10.dp)
+            ) {
+                if (review.mediaTitle != null) {
+                    Text(
+                        text = review.mediaTitle,
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Spacer(modifier = Modifier.height(6.dp))
+                }
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    UserAvatar(
+                        url = review.userAvatarUrl,
+                        contentDescription = null,
+                        size = 24.dp
+                    )
+                    Text(
+                        text = review.userName,
+                        style = MaterialTheme.typography.labelMedium.emphasis(),
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Box(
+                        modifier = Modifier
+                            .background(scoreColor.copy(alpha = 0.15f), RoundedCornerShape(8.dp))
+                            .padding(horizontal = 6.dp, vertical = 3.dp)
+                    ) {
+                        Text(
+                            text = "${review.score}/100",
+                            style = MaterialTheme.typography.labelSmall.emphasis(),
+                            color = scoreColor
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = review.summary,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    overflow = TextOverflow.Ellipsis,
+                    lineHeight = 16.sp,
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.height(6.dp))
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Star,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(14.dp)
+                    )
+                    Text(
+                        text = "${review.rating}/${review.ratingAmount}",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = stringResource(R.string.found_helpful),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/anisync/android/presentation/navigation/NavHost.kt
+++ b/app/src/main/java/com/anisync/android/presentation/navigation/NavHost.kt
@@ -48,6 +48,7 @@ import com.anisync.android.presentation.library.LibraryScreen
 import com.anisync.android.presentation.login.LoginScreen
 import com.anisync.android.presentation.notifications.NotificationsScreen
 import com.anisync.android.presentation.profile.ProfileScreen
+import com.anisync.android.presentation.review.RecentReviewsScreen
 import com.anisync.android.presentation.review.ReviewDetailScreen
 import com.anisync.android.presentation.review.WriteReviewScreen
 import com.anisync.android.presentation.settings.AboutScreen
@@ -330,6 +331,12 @@ fun AniSyncNavHost(
                     },
                     onUserClick = navigateToUserProfile,
                     onSectionSeeAllClick = onSectionClick,
+                    onReviewClick = { reviewId ->
+                        navController.navigate(ReviewDetail(reviewId))
+                    },
+                    onRecentReviewsSeeAllClick = { mediaType ->
+                        navController.navigate(RecentReviews(mediaType.name))
+                    },
                     sharedTransitionScope = this@SharedTransitionLayout,
                     animatedVisibilityScope = this
                 )
@@ -668,6 +675,24 @@ fun AniSyncNavHost(
                     onMediaClick = { mediaId ->
                         navController.navigate(MediaDetails(mediaId, "review"))
                     }
+                )
+            }
+
+            // =================================================================
+            // RECENT REVIEWS SCREEN - Shared Axis Z (Depth)
+            // =================================================================
+            composable<RecentReviews>(
+                enterTransition = { sharedAxisZEnter() },
+                exitTransition = { sharedAxisZExit() },
+                popEnterTransition = { sharedAxisZPopEnter() },
+                popExitTransition = { sharedAxisZPopExit() }
+            ) {
+                RecentReviewsScreen(
+                    onBackClick = { navController.popBackStack() },
+                    onReviewClick = { reviewId ->
+                        navController.navigate(ReviewDetail(reviewId))
+                    },
+                    onUserClick = navigateToUserProfile
                 )
             }
 

--- a/app/src/main/java/com/anisync/android/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/navigation/Screen.kt
@@ -220,6 +220,14 @@ object CreateThread
 data class ReviewDetail(val reviewId: Int)
 
 /**
+ * Recent reviews list — AniList's newest reviews, filterable by media type.
+ * Reached from the "Recent Reviews" section on Discover.
+ * @param mediaType Initial filter: "ANIME", "MANGA", or "ALL".
+ */
+@Serializable
+data class RecentReviews(val mediaType: String = "ANIME")
+
+/**
  * Review editor — write a new review or edit the viewer's existing one for a media.
  * @param mediaId The media being reviewed
  * @param mediaTitle The media title (for display in app bar)

--- a/app/src/main/java/com/anisync/android/presentation/review/RecentReviewsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/review/RecentReviewsScreen.kt
@@ -1,0 +1,204 @@
+package com.anisync.android.presentation.review
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.anisync.android.R
+import com.anisync.android.presentation.components.CollapsingTopBarScaffold
+import com.anisync.android.presentation.components.ReviewCard
+
+@Composable
+fun RecentReviewsScreen(
+    onBackClick: () -> Unit,
+    onReviewClick: (Int) -> Unit,
+    onUserClick: (String) -> Unit,
+    viewModel: RecentReviewsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val listState = rememberLazyListState()
+
+    val shouldLoadMore by remember {
+        derivedStateOf {
+            val layoutInfo = listState.layoutInfo
+            val total = layoutInfo.totalItemsCount
+            val lastVisible = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            total > 0 && lastVisible >= total - 3
+        }
+    }
+
+    LaunchedEffect(shouldLoadMore) {
+        if (shouldLoadMore && !uiState.isLoadingMore && uiState.hasNextPage && !uiState.isLoading) {
+            viewModel.onAction(RecentReviewsAction.LoadNextPage)
+        }
+    }
+
+    CollapsingTopBarScaffold(
+        title = stringResource(R.string.recent_reviews_title),
+        onBackClick = onBackClick,
+        scrollableState = listState,
+        scrolledContainerColor = MaterialTheme.colorScheme.background,
+        belowBar = {
+            ReviewFilterChipRow(
+                selected = uiState.filter,
+                onSelect = { viewModel.onAction(RecentReviewsAction.SetFilter(it)) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+            )
+        }
+    ) { topContentPadding ->
+        Box(modifier = Modifier.fillMaxSize()) {
+            when {
+                uiState.isLoading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(top = topContentPadding),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+
+                uiState.errorMessage != null && uiState.reviews.isEmpty() -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(top = topContentPadding),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = uiState.errorMessage!!,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
+                }
+
+                uiState.reviews.isEmpty() -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(top = topContentPadding),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = stringResource(R.string.recent_reviews_empty),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+
+                else -> {
+                    LazyColumn(
+                        state = listState,
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(
+                            start = 16.dp,
+                            end = 16.dp,
+                            top = topContentPadding + 8.dp,
+                            bottom = WindowInsets.navigationBars.asPaddingValues()
+                                .calculateBottomPadding() + 16.dp
+                        ),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        itemsIndexed(
+                            items = uiState.reviews,
+                            key = { _, review -> "recent_review_${review.id}" },
+                            contentType = { _, _ -> "review" }
+                        ) { _, review ->
+                            ReviewCard(
+                                review = review,
+                                onClick = { onReviewClick(review.id) },
+                                onUserClick = onUserClick,
+                                modifier = Modifier.animateItem()
+                            )
+                        }
+
+                        if (uiState.isLoadingMore) {
+                            item(key = "loading_more") {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(16.dp),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.width(24.dp),
+                                        strokeWidth = 2.dp
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Media-type filter rendered as the chip row used by the expanded Section grids
+ * ([com.anisync.android.presentation.discover.components.SearchFiltersRow]).
+ */
+@Composable
+private fun ReviewFilterChipRow(
+    selected: ReviewMediaFilter,
+    onSelect: (ReviewMediaFilter) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val options = remember {
+        listOf(
+            ReviewMediaFilter.ALL to R.string.reviews_filter_all,
+            ReviewMediaFilter.ANIME to R.string.media_type_anime,
+            ReviewMediaFilter.MANGA to R.string.media_type_manga
+        )
+    }
+
+    Row(
+        modifier = modifier
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        options.forEach { (filter, labelRes) ->
+            FilterChip(
+                selected = selected == filter,
+                onClick = { onSelect(filter) },
+                label = { Text(stringResource(labelRes)) },
+                colors = FilterChipDefaults.filterChipColors(
+                    selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                    selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/anisync/android/presentation/review/RecentReviewsUiState.kt
+++ b/app/src/main/java/com/anisync/android/presentation/review/RecentReviewsUiState.kt
@@ -1,0 +1,21 @@
+package com.anisync.android.presentation.review
+
+import androidx.compose.runtime.Stable
+import com.anisync.android.domain.MediaReview
+
+@Stable
+data class RecentReviewsUiState(
+    val filter: ReviewMediaFilter = ReviewMediaFilter.ANIME,
+    val reviews: List<MediaReview> = emptyList(),
+    val isLoading: Boolean = true,
+    val isLoadingMore: Boolean = false,
+    val hasNextPage: Boolean = true,
+    val errorMessage: String? = null,
+    val currentPage: Int = 1
+)
+
+sealed interface RecentReviewsAction {
+    data object LoadNextPage : RecentReviewsAction
+    data class SetFilter(val filter: ReviewMediaFilter) : RecentReviewsAction
+    data object Retry : RecentReviewsAction
+}

--- a/app/src/main/java/com/anisync/android/presentation/review/RecentReviewsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/review/RecentReviewsViewModel.kt
@@ -1,0 +1,121 @@
+package com.anisync.android.presentation.review
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.anisync.android.domain.DiscoverRepository
+import com.anisync.android.domain.Result
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class RecentReviewsViewModel @Inject constructor(
+    private val discoverRepository: DiscoverRepository,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val initialFilter =
+        ReviewMediaFilter.fromRouteArg(savedStateHandle.get<String>("mediaType"))
+
+    private val _uiState = MutableStateFlow(RecentReviewsUiState(filter = initialFilter))
+    val uiState: StateFlow<RecentReviewsUiState> = _uiState.asStateFlow()
+
+    // Reviews can shift between pages as new ones are published; dedupe by id so a
+    // review fetched on page 1 doesn't reappear when page 2 loads.
+    private var knownIds: Set<Int> = emptySet()
+
+    init {
+        loadInitial()
+    }
+
+    fun onAction(action: RecentReviewsAction) {
+        when (action) {
+            is RecentReviewsAction.LoadNextPage -> loadNextPage()
+            is RecentReviewsAction.SetFilter -> setFilter(action.filter)
+            is RecentReviewsAction.Retry -> loadInitial()
+        }
+    }
+
+    private fun loadInitial() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+            knownIds = emptySet()
+
+            when (
+                val result = discoverRepository.getRecentReviews(
+                    mediaType = _uiState.value.filter.toMediaType(),
+                    page = 1
+                )
+            ) {
+                is Result.Success -> {
+                    knownIds = result.data.reviews.map { it.id }.toSet()
+                    _uiState.update {
+                        it.copy(
+                            reviews = result.data.reviews,
+                            hasNextPage = result.data.hasNextPage,
+                            currentPage = 1,
+                            isLoading = false
+                        )
+                    }
+                }
+
+                is Result.Error -> {
+                    _uiState.update {
+                        it.copy(isLoading = false, errorMessage = result.message)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun loadNextPage() {
+        val current = _uiState.value
+        if (current.isLoadingMore || !current.hasNextPage || current.isLoading) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoadingMore = true) }
+
+            when (
+                val result = discoverRepository.getRecentReviews(
+                    mediaType = current.filter.toMediaType(),
+                    page = current.currentPage + 1
+                )
+            ) {
+                is Result.Success -> {
+                    val newReviews = result.data.reviews.filter { it.id !in knownIds }
+                    knownIds = knownIds + newReviews.map { it.id }
+                    _uiState.update {
+                        it.copy(
+                            reviews = it.reviews + newReviews,
+                            hasNextPage = result.data.hasNextPage,
+                            currentPage = current.currentPage + 1,
+                            isLoadingMore = false
+                        )
+                    }
+                }
+
+                is Result.Error -> {
+                    _uiState.update { it.copy(isLoadingMore = false) }
+                }
+            }
+        }
+    }
+
+    private fun setFilter(filter: ReviewMediaFilter) {
+        if (_uiState.value.filter == filter) return
+        _uiState.update {
+            it.copy(
+                filter = filter,
+                reviews = emptyList(),
+                currentPage = 1,
+                hasNextPage = true
+            )
+        }
+        loadInitial()
+    }
+}

--- a/app/src/main/java/com/anisync/android/presentation/review/ReviewMediaFilter.kt
+++ b/app/src/main/java/com/anisync/android/presentation/review/ReviewMediaFilter.kt
@@ -1,0 +1,27 @@
+package com.anisync.android.presentation.review
+
+import com.anisync.android.type.MediaType
+
+/**
+ * Media-type filter for review lists. [ALL] maps to a null AniList media-type
+ * filter (both anime and manga reviews).
+ */
+enum class ReviewMediaFilter {
+    ALL,
+    ANIME,
+    MANGA;
+
+    fun toMediaType(): MediaType? = when (this) {
+        ALL -> null
+        ANIME -> MediaType.ANIME
+        MANGA -> MediaType.MANGA
+    }
+
+    companion object {
+        fun fromRouteArg(arg: String?): ReviewMediaFilter = when (arg) {
+            "MANGA" -> MANGA
+            "ALL" -> ALL
+            else -> ANIME
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,7 +100,12 @@
     <string name="section_trending_now">Trending Now</string>
     <string name="section_all_time_popular">All Time Popular</string>
     <string name="section_upcoming_season">Upcoming Season</string>
+    <string name="section_newly_added">Newly Added</string>
+    <string name="section_recent_reviews">Recent Reviews</string>
     <string name="section_tba">TBA</string>
+    <string name="recent_reviews_title">Recent Reviews</string>
+    <string name="recent_reviews_empty">No reviews found.</string>
+    <string name="reviews_filter_all">All</string>
     <string name="error_failed_to_load">Failed to load content</string>
     <string name="search_no_results">No results found.</string>
 


### PR DESCRIPTION
## Summary
Two new Discover sections backed by the AniList API:

- **Newly Added** — most recently added media (`MediaSort.ID_DESC`), shown for both anime and manga before the TBA section, with a "See all" grid (new `newly_added` paginated section type).
- **Recent Reviews** — a horizontal carousel of the newest reviews for the current media type, fetched alongside the media feed (non-gating: a reviews failure just hides the section). "See all" opens a new paginated Recent Reviews screen with an All / Anime / Manga filter.

Adds a `GetRecentReviews` GraphQL query and `DiscoverRepository.getRecentReviews`.

## Testing
- `./gradlew compileStableDebugKotlin` ✓
- Installed on a physical device; verified both sections render, the dedicated Recent Reviews screen, and the media-type filter.