### PR TITLE
Multi-account support (#45)

### DIFF
--- a/app/schemas/com.anisync.android.data.local.AppDatabase/18.json
+++ b/app/schemas/com.anisync.android.data.local.AppDatabase/18.json
@@ -1,0 +1,972 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 18,
+    "identityHash": "d6e2b9cdc9afb2628ee1a9511a370014",
+    "entities": [
+      {
+        "tableName": "library_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL DEFAULT 0, `mediaId` INTEGER NOT NULL, `titleRomaji` TEXT, `titleEnglish` TEXT, `titleNative` TEXT, `titleUserPreferred` TEXT NOT NULL, `coverUrl` TEXT, `coverMedium` TEXT DEFAULT NULL, `coverLarge` TEXT DEFAULT NULL, `coverExtraLarge` TEXT DEFAULT NULL, `progress` INTEGER NOT NULL, `totalEpisodes` INTEGER, `totalChapters` INTEGER, `totalVolumes` INTEGER, `mediaType` TEXT, `status` TEXT NOT NULL, `nextAiringEpisode` INTEGER, `timeUntilAiring` INTEGER, `mediaStatus` TEXT, `nextAiringEpisodeTime` INTEGER, `score` REAL, `rewatches` INTEGER NOT NULL, `notes` TEXT, `startedAt` INTEGER, `completedAt` INTEGER, `updatedAt` INTEGER, `createdAt` INTEGER, `mediaStartDate` INTEGER, `customLists` TEXT NOT NULL DEFAULT '[]', `isPrivate` INTEGER NOT NULL DEFAULT 0, `hiddenFromStatusLists` INTEGER NOT NULL DEFAULT 0, `lastUpdated` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "mediaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleRomaji",
+            "columnName": "titleRomaji",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "titleEnglish",
+            "columnName": "titleEnglish",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "titleNative",
+            "columnName": "titleNative",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "titleUserPreferred",
+            "columnName": "titleUserPreferred",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverMedium",
+            "columnName": "coverMedium",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "coverLarge",
+            "columnName": "coverLarge",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "coverExtraLarge",
+            "columnName": "coverExtraLarge",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalEpisodes",
+            "columnName": "totalEpisodes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalChapters",
+            "columnName": "totalChapters",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalVolumes",
+            "columnName": "totalVolumes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextAiringEpisode",
+            "columnName": "nextAiringEpisode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timeUntilAiring",
+            "columnName": "timeUntilAiring",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mediaStatus",
+            "columnName": "mediaStatus",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nextAiringEpisodeTime",
+            "columnName": "nextAiringEpisodeTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "rewatches",
+            "columnName": "rewatches",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mediaStartDate",
+            "columnName": "mediaStartDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "customLists",
+            "columnName": "customLists",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "isPrivate",
+            "columnName": "isPrivate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hiddenFromStatusLists",
+            "columnName": "hiddenFromStatusLists",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_entries_ownerId",
+            "unique": false,
+            "columnNames": [
+              "ownerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_ownerId` ON `${TABLE_NAME}` (`ownerId`)"
+          },
+          {
+            "name": "index_library_entries_ownerId_mediaType",
+            "unique": false,
+            "columnNames": [
+              "ownerId",
+              "mediaType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_ownerId_mediaType` ON `${TABLE_NAME}` (`ownerId`, `mediaType`)"
+          },
+          {
+            "name": "index_library_entries_mediaType",
+            "unique": false,
+            "columnNames": [
+              "mediaType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_mediaType` ON `${TABLE_NAME}` (`mediaType`)"
+          },
+          {
+            "name": "index_library_entries_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_library_entries_mediaType_status",
+            "unique": false,
+            "columnNames": [
+              "mediaType",
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_mediaType_status` ON `${TABLE_NAME}` (`mediaType`, `status`)"
+          },
+          {
+            "name": "index_library_entries_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          },
+          {
+            "name": "index_library_entries_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_library_entries_timeUntilAiring",
+            "unique": false,
+            "columnNames": [
+              "timeUntilAiring"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_timeUntilAiring` ON `${TABLE_NAME}` (`timeUntilAiring`)"
+          },
+          {
+            "name": "index_library_entries_score",
+            "unique": false,
+            "columnNames": [
+              "score"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_score` ON `${TABLE_NAME}` (`score`)"
+          },
+          {
+            "name": "index_library_entries_progress",
+            "unique": false,
+            "columnNames": [
+              "progress"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_progress` ON `${TABLE_NAME}` (`progress`)"
+          },
+          {
+            "name": "index_library_entries_mediaStartDate",
+            "unique": false,
+            "columnNames": [
+              "mediaStartDate"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_mediaStartDate` ON `${TABLE_NAME}` (`mediaStartDate`)"
+          }
+        ]
+      },
+      {
+        "tableName": "media_details",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `titleRomaji` TEXT, `titleEnglish` TEXT, `titleNative` TEXT, `titleUserPreferred` TEXT NOT NULL, `coverUrl` TEXT, `coverMedium` TEXT DEFAULT NULL, `coverLarge` TEXT DEFAULT NULL, `coverExtraLarge` TEXT DEFAULT NULL, `coverColor` TEXT DEFAULT NULL, `bannerUrl` TEXT, `description` TEXT NOT NULL, `score` INTEGER, `popularity` INTEGER DEFAULT NULL, `favourites` INTEGER DEFAULT NULL, `episodes` INTEGER, `nextAiringEpisode` INTEGER, `nextAiringEpisodeTime` INTEGER, `nextAiringTimeUntil` INTEGER DEFAULT NULL, `chapters` INTEGER, `volumes` INTEGER, `mediaType` TEXT, `status` TEXT NOT NULL, `format` TEXT, `genres` TEXT NOT NULL, `source` TEXT, `studio` TEXT, `studioId` INTEGER DEFAULT NULL, `year` INTEGER, `startDate` TEXT, `endDate` TEXT, `season` TEXT, `seasonYear` INTEGER, `duration` INTEGER, `tags` TEXT NOT NULL, `trailer` TEXT, `listEntryId` INTEGER, `listStatus` TEXT, `listProgress` INTEGER, `listEntryPrivate` INTEGER, `listEntryHiddenFromStatusLists` INTEGER, `characters` TEXT NOT NULL, `staff` TEXT NOT NULL DEFAULT '[]', `relations` TEXT NOT NULL, `externalLinks` TEXT NOT NULL, `recommendations` TEXT NOT NULL DEFAULT '[]', `reviews` TEXT NOT NULL DEFAULT '[]', `isFavourite` INTEGER NOT NULL, `isRecommendationBlocked` INTEGER DEFAULT NULL, `isReviewBlocked` INTEGER DEFAULT NULL, `lastUpdated` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleRomaji",
+            "columnName": "titleRomaji",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "titleEnglish",
+            "columnName": "titleEnglish",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "titleNative",
+            "columnName": "titleNative",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "titleUserPreferred",
+            "columnName": "titleUserPreferred",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverMedium",
+            "columnName": "coverMedium",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "coverLarge",
+            "columnName": "coverLarge",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "coverExtraLarge",
+            "columnName": "coverExtraLarge",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "coverColor",
+            "columnName": "coverColor",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "bannerUrl",
+            "columnName": "bannerUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "popularity",
+            "columnName": "popularity",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "favourites",
+            "columnName": "favourites",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "episodes",
+            "columnName": "episodes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "nextAiringEpisode",
+            "columnName": "nextAiringEpisode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "nextAiringEpisodeTime",
+            "columnName": "nextAiringEpisodeTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "nextAiringTimeUntil",
+            "columnName": "nextAiringTimeUntil",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "chapters",
+            "columnName": "chapters",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "volumes",
+            "columnName": "volumes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "studio",
+            "columnName": "studio",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "studioId",
+            "columnName": "studioId",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "season",
+            "columnName": "season",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonYear",
+            "columnName": "seasonYear",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trailer",
+            "columnName": "trailer",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "listEntryId",
+            "columnName": "listEntryId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "listStatus",
+            "columnName": "listStatus",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "listProgress",
+            "columnName": "listProgress",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "listEntryPrivate",
+            "columnName": "listEntryPrivate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "listEntryHiddenFromStatusLists",
+            "columnName": "listEntryHiddenFromStatusLists",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "characters",
+            "columnName": "characters",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "staff",
+            "columnName": "staff",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "relations",
+            "columnName": "relations",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "externalLinks",
+            "columnName": "externalLinks",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recommendations",
+            "columnName": "recommendations",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "reviews",
+            "columnName": "reviews",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "isFavourite",
+            "columnName": "isFavourite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRecommendationBlocked",
+            "columnName": "isRecommendationBlocked",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "isReviewBlocked",
+            "columnName": "isReviewBlocked",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `avatarUrl` TEXT, `bannerUrl` TEXT, `about` TEXT, `activeAt` INTEGER, `animeCount` INTEGER NOT NULL, `daysWatched` REAL NOT NULL, `mangaCount` INTEGER NOT NULL, `chaptersRead` INTEGER NOT NULL, `meanScore` REAL NOT NULL, `animeStatusCounts` TEXT NOT NULL, `favoriteAnime` TEXT NOT NULL, `activities` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL, `topGenres` TEXT NOT NULL DEFAULT '[]', `favoriteMangaOverview` TEXT NOT NULL DEFAULT '[]', `favoriteCharactersOverview` TEXT NOT NULL DEFAULT '[]', `favoriteStaffOverview` TEXT NOT NULL DEFAULT '[]', `favoriteStudiosOverview` TEXT NOT NULL DEFAULT '[]', `donatorTier` INTEGER NOT NULL DEFAULT 0, `donatorBadge` TEXT DEFAULT '', `moderatorRoles` TEXT NOT NULL DEFAULT '[]', `createdAt` INTEGER DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bannerUrl",
+            "columnName": "bannerUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "about",
+            "columnName": "about",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "activeAt",
+            "columnName": "activeAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "animeCount",
+            "columnName": "animeCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "daysWatched",
+            "columnName": "daysWatched",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaCount",
+            "columnName": "mangaCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersRead",
+            "columnName": "chaptersRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meanScore",
+            "columnName": "meanScore",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "animeStatusCounts",
+            "columnName": "animeStatusCounts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteAnime",
+            "columnName": "favoriteAnime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activities",
+            "columnName": "activities",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topGenres",
+            "columnName": "topGenres",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "favoriteMangaOverview",
+            "columnName": "favoriteMangaOverview",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "favoriteCharactersOverview",
+            "columnName": "favoriteCharactersOverview",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "favoriteStaffOverview",
+            "columnName": "favoriteStaffOverview",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "favoriteStudiosOverview",
+            "columnName": "favoriteStudiosOverview",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "donatorTier",
+            "columnName": "donatorTier",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "donatorBadge",
+            "columnName": "donatorBadge",
+            "affinity": "TEXT",
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "moderatorRoles",
+            "columnName": "moderatorRoles",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "airing_schedule",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `mediaId` INTEGER NOT NULL, `airingAt` INTEGER NOT NULL, `episode` INTEGER NOT NULL, `titleUserPreferred` TEXT NOT NULL, `coverUrl` TEXT, `format` TEXT, `isWatching` INTEGER NOT NULL, `streamingSeriesUrl` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "mediaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "airingAt",
+            "columnName": "airingAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episode",
+            "columnName": "episode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleUserPreferred",
+            "columnName": "titleUserPreferred",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isWatching",
+            "columnName": "isWatching",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamingSeriesUrl",
+            "columnName": "streamingSeriesUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "trending_media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `titleUserPreferred` TEXT NOT NULL, `coverUrl` TEXT, `averageScore` INTEGER, `rank` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleUserPreferred",
+            "columnName": "titleUserPreferred",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "averageScore",
+            "columnName": "averageScore",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rank",
+            "columnName": "rank",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "saved_forum_threads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`threadId` INTEGER NOT NULL, `title` TEXT NOT NULL, `authorName` TEXT NOT NULL, `authorAvatarUrl` TEXT, `replyCount` INTEGER NOT NULL, `viewCount` INTEGER NOT NULL, `likeCount` INTEGER NOT NULL, `isLiked` INTEGER NOT NULL DEFAULT 0, `isLocked` INTEGER NOT NULL DEFAULT 0, `repliedAt` INTEGER, `replyUserName` TEXT, `replyUserAvatarUrl` TEXT, `categories` TEXT NOT NULL DEFAULT '[]', `mediaTitle` TEXT, `mediaCoverUrl` TEXT, `savedAt` INTEGER NOT NULL, PRIMARY KEY(`threadId`))",
+        "fields": [
+          {
+            "fieldPath": "threadId",
+            "columnName": "threadId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorName",
+            "columnName": "authorName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorAvatarUrl",
+            "columnName": "authorAvatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "replyCount",
+            "columnName": "replyCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewCount",
+            "columnName": "viewCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "likeCount",
+            "columnName": "likeCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isLiked",
+            "columnName": "isLiked",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isLocked",
+            "columnName": "isLocked",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "repliedAt",
+            "columnName": "repliedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "replyUserName",
+            "columnName": "replyUserName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "replyUserAvatarUrl",
+            "columnName": "replyUserAvatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "categories",
+            "columnName": "categories",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "mediaTitle",
+            "columnName": "mediaTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaCoverUrl",
+            "columnName": "mediaCoverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "threadId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd6e2b9cdc9afb2628ee1a9511a370014')"
+    ]
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,6 +69,9 @@
                 <data
                     android:scheme="anisync"
                     android:host="activity" />
+                <data
+                    android:scheme="anisync"
+                    android:host="notifications" />
             </intent-filter>
             <!-- AniList URL deep links for sharing -->
             <intent-filter>

--- a/app/src/main/graphql/Viewer.graphql
+++ b/app/src/main/graphql/Viewer.graphql
@@ -2,6 +2,9 @@ query GetViewer {
   Viewer {
     id
     name
+    avatar {
+      large
+    }
     unreadNotificationCount
     mediaListOptions {
       scoreFormat

--- a/app/src/main/java/com/anisync/android/MainActivity.kt
+++ b/app/src/main/java/com/anisync/android/MainActivity.kt
@@ -70,6 +70,9 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.system.measureTimeMillis
 
+/** A notification deep link to be handled by the MainScreen built at [epoch] (post-account-switch). */
+data class PendingDeepLink(val intent: Intent, val epoch: Int)
+
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
 
@@ -95,11 +98,13 @@ class MainActivity : AppCompatActivity() {
     val newIntents: SharedFlow<Intent> = _newIntents.asSharedFlow()
 
     /**
-     * Account-tagged notification deep link, held until the right account is active and the
-     * (possibly rebuilt) MainScreen consumes it. Retained so it survives the switch's subtree rebuild.
+     * Cross-account notification deep link, delivered after the switch settles and tagged with the
+     * **session epoch** of the rebuilt MainScreen that should handle it. Retained (StateFlow) so it
+     * survives the switch's subtree rebuild; the epoch tag ensures the pre-switch MainScreen (older
+     * epoch) doesn't consume it first.
      */
-    private val _pendingDeepLink = MutableStateFlow<Intent?>(null)
-    val pendingDeepLink: StateFlow<Intent?> = _pendingDeepLink.asStateFlow()
+    private val _pendingDeepLink = MutableStateFlow<PendingDeepLink?>(null)
+    val pendingDeepLink: StateFlow<PendingDeepLink?> = _pendingDeepLink.asStateFlow()
 
     fun consumePendingDeepLink() { _pendingDeepLink.value = null }
 
@@ -267,7 +272,7 @@ class MainActivity : AppCompatActivity() {
                             val sessionEpoch by accountManager.sessionEpoch.collectAsStateWithLifecycle()
                             if (isLoggedIn) {
                                 key(sessionEpoch) {
-                                    MainScreen()
+                                    MainScreen(builtAtEpoch = sessionEpoch)
                                 }
                             } else {
                                 LoginScreen()
@@ -335,12 +340,14 @@ class MainActivity : AppCompatActivity() {
             return false
         }
 
-        // Cross-account: don't auto-handle in the wrong account; switch, then replay once settled.
+        // Cross-account: don't auto-handle in the wrong account; switch, then replay once the
+        // subtree has rebuilt — tagged with the new epoch so only the post-switch MainScreen handles it.
         intent.data = null
+        val epochBefore = accountManager.sessionEpoch.value
         lifecycleScope.launch {
             accountManager.switch(target!!)
-            accountManager.activeAccount.first { it?.id == target }
-            _pendingDeepLink.value = Intent(Intent.ACTION_VIEW, cleanedUri)
+            val newEpoch = accountManager.sessionEpoch.first { it != epochBefore }
+            _pendingDeepLink.value = PendingDeepLink(Intent(Intent.ACTION_VIEW, cleanedUri), newEpoch)
         }
         return true
     }

--- a/app/src/main/java/com/anisync/android/MainActivity.kt
+++ b/app/src/main/java/com/anisync/android/MainActivity.kt
@@ -58,10 +58,14 @@ import com.anisync.android.ui.theme.PresetPalettes
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.system.measureTimeMillis
@@ -90,6 +94,15 @@ class MainActivity : AppCompatActivity() {
     private val _newIntents = MutableSharedFlow<Intent>(extraBufferCapacity = 4)
     val newIntents: SharedFlow<Intent> = _newIntents.asSharedFlow()
 
+    /**
+     * Account-tagged notification deep link, held until the right account is active and the
+     * (possibly rebuilt) MainScreen consumes it. Retained so it survives the switch's subtree rebuild.
+     */
+    private val _pendingDeepLink = MutableStateFlow<Intent?>(null)
+    val pendingDeepLink: StateFlow<Intent?> = _pendingDeepLink.asStateFlow()
+
+    fun consumePendingDeepLink() { _pendingDeepLink.value = null }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         val onCreateTime = measureTimeMillis {
             super.onCreate(savedInstanceState)
@@ -104,6 +117,7 @@ class MainActivity : AppCompatActivity() {
             }
 
             handleAuthRedirect(intent)
+            routeAccountDeepLink(intent)
 
             // Resolve a migrated legacy login + claim its pre-ownerId library rows for the account.
             lifecycleScope.launch(Dispatchers.IO) {
@@ -289,7 +303,48 @@ class MainActivity : AppCompatActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
         handleAuthRedirect(intent)
-        _newIntents.tryEmit(intent)
+        if (!routeAccountDeepLink(intent)) {
+            _newIntents.tryEmit(intent)
+        }
+    }
+
+    /**
+     * Routes a notification deep link tagged with an `account` query param: makes that account
+     * active (switching if needed), then hands the cleaned link to [MainScreen] via [pendingDeepLink]
+     * once the switch settles. Returns true if it consumed the intent; non-tagged links fall through.
+     */
+    private fun routeAccountDeepLink(intent: Intent?): Boolean {
+        val data = intent?.data ?: return false
+        if (data.scheme != "anisync" || data.host == "auth") return false
+        if (data.getQueryParameter("account") == null) return false
+
+        val target = data.getQueryParameter("account")?.toIntOrNull()
+        val cleaned = Intent(Intent.ACTION_VIEW, stripAccountParam(data))
+        // Prevent the account-tagged link from being auto-handled in the wrong account on cold start.
+        intent.data = null
+
+        val known = target != null && accountManager.accounts.value.any { it.id == target }
+        val active = accountManager.activeAccount.value?.id
+        if (!known || target == active) {
+            _pendingDeepLink.value = cleaned
+        } else {
+            lifecycleScope.launch {
+                accountManager.switch(target!!)
+                // Deliver only once the switch has settled, so the rebuilt MainScreen handles it.
+                accountManager.activeAccount.first { it?.id == target }
+                _pendingDeepLink.value = cleaned
+            }
+        }
+        return true
+    }
+
+    private fun stripAccountParam(uri: Uri): Uri {
+        val builder = uri.buildUpon().clearQuery()
+        for (name in uri.queryParameterNames) {
+            if (name == "account") continue
+            for (value in uri.getQueryParameters(name)) builder.appendQueryParameter(name, value)
+        }
+        return builder.build()
     }
 
     private fun handleAuthRedirect(intent: Intent?) {

--- a/app/src/main/java/com/anisync/android/MainActivity.kt
+++ b/app/src/main/java/com/anisync/android/MainActivity.kt
@@ -309,31 +309,38 @@ class MainActivity : AppCompatActivity() {
     }
 
     /**
-     * Routes a notification deep link tagged with an `account` query param: makes that account
-     * active (switching if needed), then hands the cleaned link to [MainScreen] via [pendingDeepLink]
-     * once the switch settles. Returns true if it consumed the intent; non-tagged links fall through.
+     * Handles a notification deep link tagged with an `account` query param.
+     *
+     * Only **diverts** when a different account must become active first: in that case it switches,
+     * waits for the switch to settle, then replays the cleaned link into the rebuilt [MainScreen] via
+     * [pendingDeepLink], and returns true (consumed).
+     *
+     * When the target account is already active (or unknown), it just strips the `account` param and
+     * returns false, leaving the cleaned `intent.data` for the proven native paths — Compose's
+     * cold-start auto-handle and [onNewIntent]'s `newIntents` — so same-account taps land on the
+     * exact target reliably.
      */
     private fun routeAccountDeepLink(intent: Intent?): Boolean {
         val data = intent?.data ?: return false
         if (data.scheme != "anisync" || data.host == "auth") return false
-        if (data.getQueryParameter("account") == null) return false
+        val target = (data.getQueryParameter("account") ?: return false).toIntOrNull()
 
-        val target = data.getQueryParameter("account")?.toIntOrNull()
-        val cleaned = Intent(Intent.ACTION_VIEW, stripAccountParam(data))
-        // Prevent the account-tagged link from being auto-handled in the wrong account on cold start.
-        intent.data = null
-
+        val cleanedUri = stripAccountParam(data)
         val known = target != null && accountManager.accounts.value.any { it.id == target }
         val active = accountManager.activeAccount.value?.id
+
         if (!known || target == active) {
-            _pendingDeepLink.value = cleaned
-        } else {
-            lifecycleScope.launch {
-                accountManager.switch(target!!)
-                // Deliver only once the switch has settled, so the rebuilt MainScreen handles it.
-                accountManager.activeAccount.first { it?.id == target }
-                _pendingDeepLink.value = cleaned
-            }
+            // Right account already active — let the native deep-link handlers take the cleaned link.
+            intent.data = cleanedUri
+            return false
+        }
+
+        // Cross-account: don't auto-handle in the wrong account; switch, then replay once settled.
+        intent.data = null
+        lifecycleScope.launch {
+            accountManager.switch(target!!)
+            accountManager.activeAccount.first { it?.id == target }
+            _pendingDeepLink.value = Intent(Intent.ACTION_VIEW, cleanedUri)
         }
         return true
     }

--- a/app/src/main/java/com/anisync/android/MainActivity.kt
+++ b/app/src/main/java/com/anisync/android/MainActivity.kt
@@ -6,17 +6,21 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -26,9 +30,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.os.LocaleListCompat
@@ -38,6 +44,7 @@ import com.anisync.android.data.AppLocale
 import com.anisync.android.data.AppSettings
 import com.anisync.android.data.AuthRepository
 import com.anisync.android.data.ThemeMode
+import com.anisync.android.data.account.AccountManager
 import com.anisync.android.data.update.UpdateManager
 import com.anisync.android.data.update.UpdateState
 import com.anisync.android.domain.LinkPreviewProvider
@@ -64,6 +71,9 @@ class MainActivity : AppCompatActivity() {
 
     @Inject
     lateinit var authRepository: AuthRepository
+
+    @Inject
+    lateinit var accountManager: AccountManager
 
     @Inject
     lateinit var appSettings: AppSettings
@@ -94,6 +104,12 @@ class MainActivity : AppCompatActivity() {
             }
 
             handleAuthRedirect(intent)
+
+            // Promote a migrated legacy login (provisional account) to its real identity once online.
+            lifecycleScope.launch(Dispatchers.IO) {
+                accountManager.reconcileActiveIfProvisional()
+            }
+
             lifecycleScope.launch(Dispatchers.IO) {
                 combine(
                     appSettings.notificationsEnabled,
@@ -231,13 +247,36 @@ class MainActivity : AppCompatActivity() {
                                 )
                             }
 
+                            // Keyed on the account session epoch: switching accounts bumps the
+                            // epoch, which tears down and rebuilds the entire MainScreen subtree
+                            // (fresh NavController + ViewModels) so screens refetch the new account.
+                            val sessionEpoch by accountManager.sessionEpoch.collectAsStateWithLifecycle()
                             if (isLoggedIn) {
-                                MainScreen()
+                                key(sessionEpoch) {
+                                    MainScreen()
+                                }
                             } else {
                                 LoginScreen()
                             }
 
                             AppUpdateHandler(updateManager = updateManager)
+
+                            // Blocking loader while an account add/switch/remove is in flight.
+                            val isAccountBusy by accountManager.isBusy.collectAsStateWithLifecycle(
+                                initialValue = false
+                            )
+                            if (isAccountBusy) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .background(
+                                            MaterialTheme.colorScheme.scrim.copy(alpha = 0.4f)
+                                        ),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    CircularProgressIndicator()
+                                }
+                            }
                         }
                     }
                 }
@@ -255,40 +294,35 @@ class MainActivity : AppCompatActivity() {
 
     private fun handleAuthRedirect(intent: Intent?) {
         val uri = intent?.data ?: return
+        if (uri.scheme != "anisync" || uri.host != "auth") return
 
-        if (uri.scheme == "anisync" && uri.host == "auth") {
-            val fragment = uri.fragment
-            if (fragment != null) {
-                val startNanos = System.nanoTime()
+        val fragment = uri.fragment ?: return
+        val params = parseFragment(fragment)
+        val accessToken = params["access_token"] ?: return
+        val expiresIn = params["expires_in"]?.toLongOrNull() ?: 0L
 
-                var accessToken: String? = null
-                val tokenKey = "access_token="
-                var tokenIndex = fragment.indexOf(tokenKey)
-
-                while (tokenIndex != -1) {
-                    if (tokenIndex == 0 || fragment[tokenIndex - 1] == '&') {
-                        val valueStart = tokenIndex + tokenKey.length
-                        val valueEnd = fragment.indexOf('&', valueStart)
-
-                        accessToken = if (valueEnd == -1) {
-                            fragment.substring(valueStart)
-                        } else {
-                            fragment.substring(valueStart, valueEnd)
-                        }
-                        break
-                    }
-                    tokenIndex = fragment.indexOf(tokenKey, tokenIndex + 1)
+        // addAccount activates the new account and bumps the session epoch; the keyed MainScreen
+        // subtree rebuilds itself, so no activity recreate is needed here.
+        lifecycleScope.launch {
+            when (accountManager.addAccount(accessToken, expiresIn)) {
+                is AccountManager.AddResult.Success -> Unit
+                AccountManager.AddResult.Failed -> {
+                    Toast.makeText(
+                        this@MainActivity,
+                        getString(R.string.account_sign_in_failed),
+                        Toast.LENGTH_LONG
+                    ).show()
                 }
-
-                if (accessToken != null) {
-                    authRepository.saveToken(accessToken)
-                }
-
-                val parseTimeMs = (System.nanoTime() - startNanos) / 1_000_000.0
-                Log.d("PerfMetrics", "Auth token parsing took $parseTimeMs ms")
             }
         }
     }
+
+    /** Parses an OAuth implicit-grant URL fragment (`a=1&b=2`) into a key→value map. */
+    private fun parseFragment(fragment: String): Map<String, String> =
+        fragment.split('&').mapNotNull { part ->
+            val eq = part.indexOf('=')
+            if (eq <= 0) null else part.substring(0, eq) to Uri.decode(part.substring(eq + 1))
+        }.toMap()
 }
 
 @Composable

--- a/app/src/main/java/com/anisync/android/MainActivity.kt
+++ b/app/src/main/java/com/anisync/android/MainActivity.kt
@@ -105,9 +105,9 @@ class MainActivity : AppCompatActivity() {
 
             handleAuthRedirect(intent)
 
-            // Promote a migrated legacy login (provisional account) to its real identity once online.
+            // Resolve a migrated legacy login + claim its pre-ownerId library rows for the account.
             lifecycleScope.launch(Dispatchers.IO) {
-                accountManager.reconcileActiveIfProvisional()
+                accountManager.reconcileActiveAccount()
             }
 
             lifecycleScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/anisync/android/data/ActivityRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/ActivityRepositoryImpl.kt
@@ -32,6 +32,10 @@ class ActivityRepositoryImpl @Inject constructor(
 
     @Volatile private var cachedViewerId: Int? = null
 
+    override fun clearViewerCache() {
+        cachedViewerId = null
+    }
+
     override suspend fun getActivity(id: Int): Result<ActivityDetail> = safeApiCall {
         val response = apolloClient
             .query(GetActivityQuery(id))

--- a/app/src/main/java/com/anisync/android/data/AppSettings.kt
+++ b/app/src/main/java/com/anisync/android/data/AppSettings.kt
@@ -849,6 +849,33 @@ class AppSettings @Inject constructor(
         }
     }
     
+    /**
+     * Resets the per-account view preferences on account switch so one account's custom-list
+     * layout / hidden lists / last-opened tabs don't bleed into another. Account-agnostic
+     * preferences (theme, locale, cover quality, nav bar, etc.) are left untouched.
+     *
+     * Score format is intentionally NOT reset here — it self-heals from the next library load,
+     * which reads the new account's MediaListOptions (see LibraryRepositoryImpl).
+     */
+    fun clearAccountScoped() {
+        _hiddenAnimeLists.value = emptySet()
+        _hiddenMangaLists.value = emptySet()
+        _animeListOrder.value = emptyList()
+        _mangaListOrder.value = emptyList()
+        _lastSelectedAnimeTab.value = null
+        _lastSelectedMangaTab.value = null
+        _showPrivateEntries.value = true
+        prefs.edit()
+            .remove(KEY_HIDDEN_ANIME_LISTS)
+            .remove(KEY_HIDDEN_MANGA_LISTS)
+            .remove(KEY_ANIME_LIST_ORDER)
+            .remove(KEY_MANGA_LIST_ORDER)
+            .remove(KEY_LAST_SELECTED_ANIME_TAB)
+            .remove(KEY_LAST_SELECTED_MANGA_TAB)
+            .remove(KEY_SHOW_PRIVATE_ENTRIES)
+            .apply()
+    }
+
 companion object {
         private const val PREFS_NAME = "anisync_settings"
         private const val KEY_THEME_MODE = "theme_mode"

--- a/app/src/main/java/com/anisync/android/data/AppSettings.kt
+++ b/app/src/main/java/com/anisync/android/data/AppSettings.kt
@@ -865,7 +865,10 @@ class AppSettings @Inject constructor(
         _lastSelectedAnimeTab.value = null
         _lastSelectedMangaTab.value = null
         _showPrivateEntries.value = true
+        // Land on the default home tab after a switch instead of the other account's last tab.
+        _lastMainTab.value = null
         prefs.edit()
+            .remove(KEY_LAST_MAIN_TAB)
             .remove(KEY_HIDDEN_ANIME_LISTS)
             .remove(KEY_HIDDEN_MANGA_LISTS)
             .remove(KEY_ANIME_LIST_ORDER)

--- a/app/src/main/java/com/anisync/android/data/AuthRepository.kt
+++ b/app/src/main/java/com/anisync/android/data/AuthRepository.kt
@@ -1,120 +1,46 @@
-@file:Suppress("DEPRECATION")
-
 package com.anisync.android.data
 
-import android.content.Context
-import android.content.SharedPreferences
-import android.util.Log
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
-import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.Dispatchers
+import com.anisync.android.data.account.AccountStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.withContext
-
-import java.security.KeyStore
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Auth facade over [AccountStore]. Kept as the single dependency for the auth/session surface
+ * ([com.anisync.android.di.AuthorizationInterceptor], the notification worker, [com.anisync.android.MainActivity])
+ * so those call sites are unaffected by multi-account support.
+ *
+ * Intentionally depends **only** on [AccountStore] (no Apollo/Room) to stay out of the
+ * ApolloClient → AuthorizationInterceptor → AuthRepository cycle. Account mutations that need the
+ * network or cache clearing live in [com.anisync.android.data.account.AccountManager].
+ */
 @Singleton
 class AuthRepository @Inject constructor(
-    @ApplicationContext private val context: Context
+    private val accountStore: AccountStore,
 ) {
-    private val sharedPreferences: SharedPreferences = createPrefs()
-
-    private fun buildMasterKey(): MasterKey =
-        MasterKey.Builder(context)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-
-    private fun createPrefs(): SharedPreferences {
-        return try {
-            EncryptedSharedPreferences.create(
-                context,
-                PREFS_NAME,
-                buildMasterKey(),
-                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-            ).also { it.contains(KEY_ACCESS_TOKEN) } // force decrypt to surface AEADBadTagException now
-        } catch (t: Throwable) {
-            // Keystore key invalidated (OS upgrade, backup/restore, lockscreen change, etc.)
-            // Wipe corrupt prefs file + master key alias, then recreate. Token is lost; user re-logs in.
-            Log.w(TAG, "EncryptedSharedPreferences unreadable, resetting", t)
-            resetEncryptedStore()
-            EncryptedSharedPreferences.create(
-                context,
-                PREFS_NAME,
-                buildMasterKey(),
-                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-            )
-        }
-    }
-
-    private fun resetEncryptedStore() {
-        runCatching { context.deleteSharedPreferences(PREFS_NAME) }
-        runCatching {
-            val ks = KeyStore.getInstance("AndroidKeyStore")
-            ks.load(null)
-            if (ks.containsAlias(MASTER_KEY_ALIAS)) ks.deleteEntry(MASTER_KEY_ALIAS)
-        }
-    }
-
-    private val _isLoggedIn = MutableStateFlow(getToken() != null)
-    val isLoggedIn: Flow<Boolean> = _isLoggedIn.asStateFlow()
+    /** True whenever there is an active account. Drives the Login ↔ Main swap in MainActivity. */
+    val isLoggedIn: Flow<Boolean> = accountStore.activeAccount.map { it != null }
 
     /**
-     * Emitted when the API returns HTTP 401 (token expired/revoked).
-     * The UI should collect this to show a "session expired" dialog
-     * and redirect the user to the login screen.
+     * Emitted when the API returns HTTP 401 for the active account (token expired/revoked).
+     * The UI collects this to show a "session expired" dialog and drop to the login/account picker.
      */
     private val _sessionExpired = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val sessionExpired: SharedFlow<Unit> = _sessionExpired.asSharedFlow()
 
+    /** Active account's bearer token, or null when logged out. Read per-request by the interceptor. */
+    fun getToken(): String? = accountStore.activeToken()
+
     /**
-     * Called by [AuthorizationInterceptor] when a 401 is received.
-     * Clears the stored token and emits a session-expired event.
+     * Called by the interceptor on a 401. Marks **only the active** account expired and clears the
+     * active slot (other accounts are kept), then emits the session-expired event.
      */
     fun onSessionExpired() {
-        clearToken()
+        accountStore.markActiveExpired()
         _sessionExpired.tryEmit(Unit)
-    }
-
-    fun saveToken(token: String) {
-        sharedPreferences.edit().putString(KEY_ACCESS_TOKEN, token).apply()
-        _isLoggedIn.value = true
-    }
-
-    fun getToken(): String? {
-        return sharedPreferences.getString(KEY_ACCESS_TOKEN, null)
-    }
-
-    fun clearToken() {
-        sharedPreferences.edit().remove(KEY_ACCESS_TOKEN).apply()
-        _isLoggedIn.value = false
-    }
-
-    /**
-     * Full logout: clears token and resets login state.
-     * Note: Apollo cache is not cleared here as we don't use normalized caching.
-     */
-    suspend fun logout() = withContext(Dispatchers.IO) {
-        // Clear encrypted preferences
-        sharedPreferences.edit().clear().apply()
-        
-        // Reset login state
-        _isLoggedIn.value = false
-    }
-
-    companion object {
-        private const val TAG = "AuthRepository"
-        private const val PREFS_NAME = "auth_prefs"
-        private const val MASTER_KEY_ALIAS = MasterKey.DEFAULT_MASTER_KEY_ALIAS
-        private const val KEY_ACCESS_TOKEN = "access_token"
     }
 }

--- a/app/src/main/java/com/anisync/android/data/DetailsRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/DetailsRepositoryImpl.kt
@@ -74,8 +74,11 @@ class DetailsRepositoryImpl @Inject constructor(
     private val apolloClient: ApolloClient,
     private val mediaDetailsDao: MediaDetailsDao,
     private val libraryDao: LibraryDao,
-    private val favouriteOverrideStore: FavouriteOverrideStore
+    private val favouriteOverrideStore: FavouriteOverrideStore,
+    private val accountStore: com.anisync.android.data.account.AccountStore
 ) : DetailsRepository {
+
+    private fun currentOwnerId(): Int = accountStore.activeAccount.value?.id ?: -1
 
     override fun observeMediaDetails(id: Int): Flow<MediaDetails?> {
         return mediaDetailsDao.observeById(id)
@@ -299,10 +302,11 @@ class DetailsRepositoryImpl @Inject constructor(
 
             if (response.data?.SaveMediaListEntry != null && !response.hasErrors()) {
                 refreshMediaDetails(mediaId)
-                val existingEntry = libraryDao.getEntry(mediaId)
+                val owner = currentOwnerId()
+                val existingEntry = libraryDao.getEntry(owner, mediaId)
 
                 if (existingEntry != null) {
-                    libraryDao.updateStatusAndProgress(mediaId, status, progress)
+                    libraryDao.updateStatusAndProgress(owner, mediaId, status, progress)
                 } else {
                     val savedEntry = response.data?.SaveMediaListEntry
                     val cachedMedia = mediaDetailsDao.getById(mediaId)
@@ -310,6 +314,7 @@ class DetailsRepositoryImpl @Inject constructor(
                     if (cachedMedia != null) {
                         val newEntry = com.anisync.android.data.local.entity.LibraryEntryEntity(
                             id = savedEntry?.id ?: 0,
+                            ownerId = owner,
                             mediaId = mediaId,
                             titleRomaji = cachedMedia.titleRomaji,
                             titleEnglish = cachedMedia.titleEnglish,
@@ -352,7 +357,7 @@ class DetailsRepositoryImpl @Inject constructor(
             ).execute()
 
             if (response.data?.DeleteMediaListEntry?.deleted == true && !response.hasErrors()) {
-                libraryDao.deleteByMediaId(mediaId)
+                libraryDao.deleteByMediaId(currentOwnerId(), mediaId)
             } else {
                 val errorMessage = response.errors?.firstOrNull()?.message ?: "Delete failed"
                 throw Exception(errorMessage)

--- a/app/src/main/java/com/anisync/android/data/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/LibraryRepositoryImpl.kt
@@ -14,16 +14,21 @@ import com.anisync.android.domain.LibraryEntry
 import com.anisync.android.domain.LibraryRepository
 import com.anisync.android.domain.LibraryStatus
 import com.anisync.android.domain.Result
+import com.anisync.android.data.account.AccountStore
 import com.anisync.android.type.MediaListStatus
 import com.anisync.android.type.MediaType
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.cache.normalized.FetchPolicy
 import com.apollographql.apollo.cache.normalized.fetchPolicy
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
+/** Owner id that matches no rows — used when there is no active account. */
+private const val NO_OWNER = -1
 
 private val SCORE_FORMAT_BY_NAME: Map<String, com.anisync.android.domain.ScoreFormat> = mapOf(
     "POINT_100" to com.anisync.android.domain.ScoreFormat.POINT_100,
@@ -39,15 +44,22 @@ internal fun mapScoreFormat(name: String?): com.anisync.android.domain.ScoreForm
 class LibraryRepositoryImpl @Inject constructor(
     private val apolloClient: ApolloClient,
     private val libraryDao: LibraryDao,
-    private val appSettings: AppSettings
+    private val appSettings: AppSettings,
+    private val accountStore: AccountStore
 ) : LibraryRepository {
 
+    private fun currentOwnerId(): Int = accountStore.activeAccount.value?.id ?: NO_OWNER
+
     /**
-     * Observe library from local Room database (SSOT).
-     * UI updates automatically when cache changes.
+     * Observe the active account's library from Room (SSOT). Re-subscribes when the active account
+     * changes, so switching accounts immediately shows the new account's cached entries.
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     override fun observeLibrary(username: String, type: MediaType): Flow<List<LibraryEntry>> {
-        return libraryDao.observeByType(type)
+        return accountStore.activeAccount
+            .flatMapLatest { account ->
+                libraryDao.observeByType(account?.id ?: NO_OWNER, type)
+            }
             .map { entities -> entities.map { it.toDomain() } }
     }
 
@@ -167,9 +179,11 @@ class LibraryRepositoryImpl @Inject constructor(
             }
 
             val entries = entryMap.values.toList()
-            
-            // Smart merge to preserve locally-added entries during API sync delay
-            libraryDao.smartMergeByType(type, entries.map { it.toEntity(type) })
+
+            // Smart merge to preserve locally-added entries during API sync delay.
+            // Tag rows with the active account so each account's library persists independently.
+            val owner = currentOwnerId()
+            libraryDao.smartMergeByType(owner, type, entries.map { it.toEntity(type).copy(ownerId = owner) })
         }
     }
 
@@ -190,7 +204,7 @@ class LibraryRepositoryImpl @Inject constructor(
 
         // 2. Need to recalculate completion status for Sync parameters
         // (Refetching entry or duplicating logic - refetching is safer)
-        val entry = libraryDao.getEntry(mediaId) ?: return Result.Error("Entry not found")
+        val entry = libraryDao.getEntry(currentOwnerId(), mediaId) ?: return Result.Error("Entry not found")
         val isCompleted = entry.status == LibraryStatus.COMPLETED
         val now = System.currentTimeMillis()
 
@@ -213,32 +227,35 @@ class LibraryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun updateProgressLocal(mediaId: Int, progress: Int): Result<Unit> {
-        val entry = libraryDao.getEntry(mediaId) ?: return Result.Error("Entry not found")
-        
+        val owner = currentOwnerId()
+        val entry = libraryDao.getEntry(owner, mediaId) ?: return Result.Error("Entry not found")
+
         // Determine the total based on media type
         val total = if (entry.mediaType == MediaType.MANGA) entry.totalChapters else entry.totalEpisodes
-        
+
         // Check if this progress update completes the media
         val isCompleted = total != null && total > 0 && progress >= total
         val now = System.currentTimeMillis()
-        
+
         if (isCompleted) {
             // Auto-set completedAt when finishing
             libraryDao.updateStatusProgressAndCompletedAt(
+                ownerId = owner,
                 mediaId = mediaId,
                 status = LibraryStatus.COMPLETED,
                 progress = progress,
                 completedAt = now
             )
         } else {
-            libraryDao.updateProgress(mediaId, progress)
+            libraryDao.updateProgress(owner, mediaId, progress)
         }
         return Result.Success(Unit)
     }
 
     override suspend fun updateEntry(entry: LibraryEntry): Result<Unit> {
+        val owner = currentOwnerId()
         // Get original entry to detect status changes
-        val originalEntry = libraryDao.getEntry(entry.mediaId)
+        val originalEntry = libraryDao.getEntry(owner, entry.mediaId)
         val now = System.currentTimeMillis()
         
         // Auto-fill dates based on status changes
@@ -260,7 +277,7 @@ class LibraryRepositoryImpl @Inject constructor(
         
         // 1. Update local DB
         // We assume media type is present or default to ANIME logic for entity mapping
-        libraryDao.updateEntry(updatedEntry.toEntity(updatedEntry.type ?: MediaType.ANIME))
+        libraryDao.updateEntry(updatedEntry.toEntity(updatedEntry.type ?: MediaType.ANIME).copy(ownerId = owner))
 
         // 2. Sync to network
         return safeApiCall {
@@ -293,7 +310,7 @@ class LibraryRepositoryImpl @Inject constructor(
 
     override suspend fun deleteEntry(entryId: Int, mediaId: Int): Result<Unit> {
         // 1. Delete from local DB immediately (optimistic)
-        libraryDao.deleteByMediaId(mediaId)
+        libraryDao.deleteByMediaId(currentOwnerId(), mediaId)
 
         // 2. Delete from network
         return safeApiCall {

--- a/app/src/main/java/com/anisync/android/data/NotificationBadgeStore.kt
+++ b/app/src/main/java/com/anisync/android/data/NotificationBadgeStore.kt
@@ -74,6 +74,13 @@ class NotificationBadgeStore @Inject constructor(
         recompute()
     }
 
+    /** Clears all counts when switching accounts so the badge doesn't carry over. */
+    fun reset() {
+        _serverCount.value = 0
+        _debugCount.value = 0
+        recompute()
+    }
+
     /** Debug-only: simulate a new unread notification so the badge can be verified. */
     fun bumpForDebug(by: Int = 1) {
         _debugCount.value = (_debugCount.value + by).coerceAtLeast(0)

--- a/app/src/main/java/com/anisync/android/data/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/NotificationRepositoryImpl.kt
@@ -38,7 +38,8 @@ import com.apollographql.apollo.cache.normalized.fetchPolicy
 import javax.inject.Inject
 
 class NotificationRepositoryImpl @Inject constructor(
-    private val apolloClient: ApolloClient
+    private val apolloClient: ApolloClient,
+    private val tokenedClientFactory: com.anisync.android.data.account.TokenedApolloClientFactory
 ) : NotificationRepository {
 
     companion object {
@@ -47,9 +48,11 @@ class NotificationRepositoryImpl @Inject constructor(
         private const val SECONDS_PER_DAY = 24 * 60 * 60
     }
 
-    override suspend fun getNotifications(page: Int): Result<List<Notification>> {
+    override suspend fun getNotifications(page: Int, token: String?): Result<List<Notification>> {
         return safeApiCall {
-            val response = apolloClient.query(
+            // token != null polls a specific (possibly non-active) account via its own client.
+            val client = token?.let(tokenedClientFactory::create) ?: apolloClient
+            val response = client.query(
                 GetNotificationsQuery(
                     page = Optional.present(page),
                     perPage = Optional.present(20),

--- a/app/src/main/java/com/anisync/android/data/ProfileRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/ProfileRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.anisync.android.GetUserFavoritesQuery
 import com.anisync.android.GetUserFollowStateQuery
 import com.anisync.android.GetViewerQuery
 import com.anisync.android.ToggleUserFollowMutation
+import com.anisync.android.data.account.AccountStore
 import com.anisync.android.data.local.dao.UserProfileDao
 import com.anisync.android.data.local.toDomain
 import com.anisync.android.data.local.toEntity
@@ -25,10 +26,12 @@ import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.cache.normalized.FetchPolicy
 import com.apollographql.apollo.cache.normalized.fetchPolicy
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.Semaphore
@@ -41,7 +44,8 @@ import com.anisync.android.data.mapper.toDomain as activityFieldsToDomain
 class ProfileRepositoryImpl @Inject constructor(
     private val apolloClient: ApolloClient,
     private val userProfileDao: UserProfileDao,
-    private val notificationBadgeStore: NotificationBadgeStore
+    private val notificationBadgeStore: NotificationBadgeStore,
+    private val accountStore: AccountStore
 ) : ProfileRepository {
 
     /**
@@ -67,8 +71,14 @@ class ProfileRepositoryImpl @Inject constructor(
         CachePolicy.NetworkFirst -> FetchPolicy.NetworkFirst
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     override fun observeProfile(): Flow<UserProfile?> {
-        return userProfileDao.observe()
+        // Re-subscribe per active account so the own-profile cache is account-scoped (the row's
+        // primary key is the user id), and switching accounts shows the right cached profile.
+        return accountStore.activeAccount
+            .flatMapLatest { account ->
+                userProfileDao.observe(account?.id ?: -1)
+            }
             .map { entity -> entity?.toDomain() }
     }
 
@@ -97,7 +107,7 @@ class ProfileRepositoryImpl @Inject constructor(
             var knownUserId: Int? = null
             var queryName: String? = null
             if (isOwnProfile) {
-                knownUserId = userProfileDao.get()?.id?.takeIf { it > 0 }
+                knownUserId = accountStore.activeAccount.value?.id?.takeIf { it > 0 }
                 if (knownUserId == null) {
                     val viewerResponse = apolloClient.query(GetViewerQuery())
                         .fetchPolicy(FetchPolicy.NetworkOnly)

--- a/app/src/main/java/com/anisync/android/data/account/Account.kt
+++ b/app/src/main/java/com/anisync/android/data/account/Account.kt
@@ -1,0 +1,33 @@
+package com.anisync.android.data.account
+
+/**
+ * A single signed-in AniList account.
+ *
+ * [token] is the OAuth access token and is **never** persisted in plain storage — it lives in
+ * EncryptedSharedPreferences keyed by [id] (see [AccountStore]). The remaining fields are lightweight
+ * metadata persisted as JSON so the account list can render without a network call.
+ */
+data class Account(
+    val id: Int,
+    val name: String,
+    val avatarUrl: String?,
+    /** Epoch millis when the token expires, or `0` if unknown (e.g. a migrated legacy token). */
+    val expiresAt: Long,
+    val token: String,
+) {
+    /** True once the stored expiry has passed. Unknown expiry (`0`) is treated as not-expired. */
+    val isExpired: Boolean
+        get() = expiresAt in 1 until System.currentTimeMillis()
+
+    /**
+     * A migrated legacy login whose real AniList id/name/avatar haven't been resolved yet.
+     * Reconciled on the next successful `GetViewer` (see [AccountManager.reconcileActiveIfProvisional]).
+     */
+    val isProvisional: Boolean
+        get() = id == PROVISIONAL_ID
+
+    companion object {
+        /** Placeholder id for a migrated legacy token before its real Viewer id is known. */
+        const val PROVISIONAL_ID = 0
+    }
+}

--- a/app/src/main/java/com/anisync/android/data/account/AccountManager.kt
+++ b/app/src/main/java/com/anisync/android/data/account/AccountManager.kt
@@ -8,7 +8,6 @@ import com.anisync.android.data.NotificationBadgeStore
 import com.anisync.android.data.local.dao.AiringScheduleDao
 import com.anisync.android.data.local.dao.LibraryDao
 import com.anisync.android.data.local.dao.SavedForumThreadDao
-import com.anisync.android.data.local.dao.UserProfileDao
 import com.anisync.android.domain.ActivityRepository
 import com.anisync.android.domain.PreferencesRepository
 import com.anisync.android.widget.AiringTodayWidget
@@ -48,7 +47,6 @@ class AccountManager @Inject constructor(
     private val accountStore: AccountStore,
     private val apolloClient: ApolloClient,
     private val libraryDao: LibraryDao,
-    private val userProfileDao: UserProfileDao,
     private val savedForumThreadDao: SavedForumThreadDao,
     private val airingScheduleDao: AiringScheduleDao,
     private val preferencesRepository: PreferencesRepository,
@@ -148,6 +146,8 @@ class AccountManager @Inject constructor(
         if (!active.isProvisional) return
         val resolved = resolveAccount(active.token, expiresInSeconds = 0L) ?: return
         accountStore.reconcileProvisional(resolved)
+        // Promote the migrated legacy library (written under the provisional owner) to the real id.
+        runCatching { libraryDao.reassignOwner(Account.PROVISIONAL_ID, resolved.id) }
     }
 
     private fun bumpEpoch() {
@@ -193,12 +193,15 @@ class AccountManager @Inject constructor(
         }
     }
 
-    /** Clears every account-scoped local store so the rebuilt ViewModels fetch the new account clean. */
+    /**
+     * Clears the cross-account caches on switch. Library and own-profile are NOT wiped — they are
+     * account-scoped in Room (by ownerId / user id) so each account's data persists and shows
+     * instantly on switch-back. The Apollo cache is cleared to avoid the no-variable `GetViewer`
+     * entry bleeding the wrong identity; library/profile read from Room so that's harmless.
+     */
     private suspend fun clearLocalState() {
         withContext(Dispatchers.IO) {
             runCatching { apolloClient.apolloStore.clearAll() }
-            libraryDao.deleteAll()
-            userProfileDao.clear()
             savedForumThreadDao.deleteAll()
             airingScheduleDao.clearAll()
             preferencesRepository.clearAll()

--- a/app/src/main/java/com/anisync/android/data/account/AccountManager.kt
+++ b/app/src/main/java/com/anisync/android/data/account/AccountManager.kt
@@ -138,16 +138,25 @@ class AccountManager @Inject constructor(
     }
 
     /**
-     * If the active account is a migrated legacy login (provisional id), resolves its real identity
-     * and promotes it. Same session (same token), so this does NOT bump [sessionEpoch].
+     * Startup reconcile (same session, so it does NOT bump [sessionEpoch]):
+     *  - If the active account is a migrated legacy login (provisional id), resolve its real
+     *    identity and promote it.
+     *  - Claim any legacy library rows written before the per-account `ownerId` existed (they
+     *    default to [Account.PROVISIONAL_ID] after the v18 migration) for the active account, so
+     *    an upgrading user's existing library isn't stranded under owner 0.
      */
-    suspend fun reconcileActiveIfProvisional() {
+    suspend fun reconcileActiveAccount() {
         val active = accountStore.activeAccount.value ?: return
-        if (!active.isProvisional) return
-        val resolved = resolveAccount(active.token, expiresInSeconds = 0L) ?: return
-        accountStore.reconcileProvisional(resolved)
-        // Promote the migrated legacy library (written under the provisional owner) to the real id.
-        runCatching { libraryDao.reassignOwner(Account.PROVISIONAL_ID, resolved.id) }
+        val realId = if (active.isProvisional) {
+            val resolved = resolveAccount(active.token, expiresInSeconds = 0L) ?: return
+            accountStore.reconcileProvisional(resolved)
+            resolved.id
+        } else {
+            active.id
+        }
+        if (realId > 0) {
+            runCatching { libraryDao.reassignOwner(Account.PROVISIONAL_ID, realId) }
+        }
     }
 
     private fun bumpEpoch() {

--- a/app/src/main/java/com/anisync/android/data/account/AccountManager.kt
+++ b/app/src/main/java/com/anisync/android/data/account/AccountManager.kt
@@ -53,6 +53,7 @@ class AccountManager @Inject constructor(
     private val appSettings: AppSettings,
     private val notificationBadgeStore: NotificationBadgeStore,
     private val activityRepository: ActivityRepository,
+    private val tokenedClientFactory: TokenedApolloClientFactory,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
@@ -117,6 +118,7 @@ class AccountManager @Inject constructor(
     fun removeAccount(id: Int) {
         scope.launch {
             busy {
+                val token = accountStore.accounts.value.firstOrNull { it.id == id }?.token
                 if (accountStore.activeAccount.value?.id == id) {
                     val next = accountStore.accounts.value.firstOrNull { it.id != id }
                     clearLocalState()
@@ -127,6 +129,9 @@ class AccountManager @Inject constructor(
                 } else {
                     accountStore.remove(id)
                 }
+                // Drop the removed account's notification dedup state and cached token client.
+                preferencesRepository.clearForAccount(id)
+                token?.let(tokenedClientFactory::evict)
             }
         }
     }
@@ -178,10 +183,7 @@ class AccountManager @Inject constructor(
      * of the active account's cache).
      */
     private suspend fun resolveAccount(token: String, expiresInSeconds: Long): Account? {
-        val client = ApolloClient.Builder()
-            .serverUrl(ANILIST_URL)
-            .addHttpHeader("Authorization", "Bearer $token")
-            .build()
+        val client = tokenedClientFactory.create(token)
         return try {
             val viewer = client.query(GetViewerQuery()).execute().data?.Viewer ?: return null
             Account(
@@ -197,8 +199,6 @@ class AccountManager @Inject constructor(
             )
         } catch (_: Exception) {
             null
-        } finally {
-            client.close()
         }
     }
 
@@ -213,7 +213,7 @@ class AccountManager @Inject constructor(
             runCatching { apolloClient.apolloStore.clearAll() }
             savedForumThreadDao.deleteAll()
             airingScheduleDao.clearAll()
-            preferencesRepository.clearAll()
+            // Notification dedup is per-account now (kept across switches) — not wiped here.
             appSettings.clearAccountScoped()
             activityRepository.clearViewerCache()
             notificationBadgeStore.reset()
@@ -229,7 +229,6 @@ class AccountManager @Inject constructor(
     }
 
     companion object {
-        private const val ANILIST_URL = "https://graphql.anilist.co"
         private const val ONE_DAY_SECONDS = 86_400L
     }
 }

--- a/app/src/main/java/com/anisync/android/data/account/AccountManager.kt
+++ b/app/src/main/java/com/anisync/android/data/account/AccountManager.kt
@@ -1,0 +1,223 @@
+package com.anisync.android.data.account
+
+import android.content.Context
+import androidx.glance.appwidget.updateAll
+import com.anisync.android.GetViewerQuery
+import com.anisync.android.data.AppSettings
+import com.anisync.android.data.NotificationBadgeStore
+import com.anisync.android.data.local.dao.AiringScheduleDao
+import com.anisync.android.data.local.dao.LibraryDao
+import com.anisync.android.data.local.dao.SavedForumThreadDao
+import com.anisync.android.data.local.dao.UserProfileDao
+import com.anisync.android.domain.ActivityRepository
+import com.anisync.android.domain.PreferencesRepository
+import com.anisync.android.widget.AiringTodayWidget
+import com.anisync.android.widget.UpNextWidget
+import com.anisync.android.widget.WeeklyCalendarWidget
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.cache.normalized.apolloStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Orchestrates account add / switch / remove and the local-state reset that makes switching safe.
+ *
+ * Switching is "reset + rebuild": local stores for the outgoing account are cleared (Apollo
+ * normalized cache, account-scoped Room tables, notification dedup, per-account prefs, in-memory
+ * caches), then the new account is activated and [sessionEpoch] is bumped. The UI keys the whole
+ * `MainScreen` subtree on [sessionEpoch], so a bump tears down the NavController and every screen
+ * ViewModel and rebuilds them — they then refetch the new account's data from network. `recreate()`
+ * is intentionally NOT used: it preserves the ViewModelStore, so surviving ViewModels would sit on
+ * the freshly-cleared (empty) caches and never refetch.
+ *
+ * Mutations run on an internal [scope] (not a caller's viewModelScope) so the subtree rebuild they
+ * trigger can't cancel them mid-flight and strand the busy loader.
+ */
+@Singleton
+class AccountManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val accountStore: AccountStore,
+    private val apolloClient: ApolloClient,
+    private val libraryDao: LibraryDao,
+    private val userProfileDao: UserProfileDao,
+    private val savedForumThreadDao: SavedForumThreadDao,
+    private val airingScheduleDao: AiringScheduleDao,
+    private val preferencesRepository: PreferencesRepository,
+    private val appSettings: AppSettings,
+    private val notificationBadgeStore: NotificationBadgeStore,
+    private val activityRepository: ActivityRepository,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    val accounts: StateFlow<List<Account>> get() = accountStore.accounts
+    val activeAccount: StateFlow<Account?> get() = accountStore.activeAccount
+
+    /**
+     * Increments on every explicit active-account change (switch / add-new / remove-active / logout).
+     * The UI keys `MainScreen` on this to force a full ViewModel rebuild + refetch. A silent identity
+     * reconcile of the same session (see [reconcileActiveIfProvisional]) does NOT bump it.
+     */
+    private val _sessionEpoch = MutableStateFlow(0)
+    val sessionEpoch: StateFlow<Int> = _sessionEpoch.asStateFlow()
+
+    /** True while an add/switch/remove is in flight, so the UI can show a blocking loader. */
+    private val _isBusy = MutableStateFlow(false)
+    val isBusy: StateFlow<Boolean> = _isBusy.asStateFlow()
+
+    sealed interface AddResult {
+        data class Success(val accountId: Int) : AddResult
+        data object Failed : AddResult
+    }
+
+    /**
+     * Resolves the token's identity, stores the account, and makes it active (clearing the previous
+     * account's local state first) unless it is a re-auth of the already-active account. Used for
+     * both first login and adding a second account.
+     *
+     * Suspends so the caller (MainActivity) can surface a failure; runs on the activity's
+     * lifecycleScope, which survives the subtree rebuild because the activity itself is not recreated.
+     */
+    suspend fun addAccount(token: String, expiresInSeconds: Long): AddResult = busy {
+        val resolved = resolveAccount(token, expiresInSeconds) ?: return@busy AddResult.Failed
+        val wasActive = accountStore.activeAccount.value?.id == resolved.id
+        accountStore.addOrReplace(resolved)
+        if (!wasActive) {
+            clearLocalState()
+            accountStore.switchTo(resolved.id)
+            bumpEpoch()
+            scope.launch { refreshWidgets() }
+        }
+        AddResult.Success(resolved.id)
+    }
+
+    /** Switches the active account (clears the outgoing account's local state first). Fire-and-forget. */
+    fun switch(id: Int) {
+        if (accountStore.activeAccount.value?.id == id) return
+        scope.launch {
+            busy {
+                clearLocalState()
+                accountStore.switchTo(id)
+                bumpEpoch()
+            }
+            refreshWidgets()
+        }
+    }
+
+    /**
+     * Removes an account. If it is the active one, switches to another (or to "none") first and
+     * resets local state; otherwise just drops it (the active account is untouched). Fire-and-forget.
+     */
+    fun removeAccount(id: Int) {
+        scope.launch {
+            busy {
+                if (accountStore.activeAccount.value?.id == id) {
+                    val next = accountStore.accounts.value.firstOrNull { it.id != id }
+                    clearLocalState()
+                    accountStore.switchTo(next?.id)
+                    accountStore.remove(id)
+                    bumpEpoch()
+                    scope.launch { refreshWidgets() }
+                } else {
+                    accountStore.remove(id)
+                }
+            }
+        }
+    }
+
+    /** Logs out the active account (switches to another if present, else to the login screen). */
+    fun logoutActive() {
+        val active = accountStore.activeAccount.value ?: return
+        removeAccount(active.id)
+    }
+
+    /**
+     * If the active account is a migrated legacy login (provisional id), resolves its real identity
+     * and promotes it. Same session (same token), so this does NOT bump [sessionEpoch].
+     */
+    suspend fun reconcileActiveIfProvisional() {
+        val active = accountStore.activeAccount.value ?: return
+        if (!active.isProvisional) return
+        val resolved = resolveAccount(active.token, expiresInSeconds = 0L) ?: return
+        accountStore.reconcileProvisional(resolved)
+    }
+
+    private fun bumpEpoch() {
+        _sessionEpoch.value += 1
+    }
+
+    private suspend fun <T> busy(block: suspend () -> T): T {
+        _isBusy.value = true
+        return try {
+            block()
+        } finally {
+            _isBusy.value = false
+        }
+    }
+
+    /**
+     * Identity resolution: runs `GetViewer` with the candidate token on a throwaway client that has
+     * no shared interceptor (no duplicate Authorization header) and no normalized cache (no pollution
+     * of the active account's cache).
+     */
+    private suspend fun resolveAccount(token: String, expiresInSeconds: Long): Account? {
+        val client = ApolloClient.Builder()
+            .serverUrl(ANILIST_URL)
+            .addHttpHeader("Authorization", "Bearer $token")
+            .build()
+        return try {
+            val viewer = client.query(GetViewerQuery()).execute().data?.Viewer ?: return null
+            Account(
+                id = viewer.id,
+                name = viewer.name ?: "",
+                avatarUrl = viewer.avatar?.large,
+                expiresAt = if (expiresInSeconds > 0) {
+                    System.currentTimeMillis() + (expiresInSeconds - ONE_DAY_SECONDS) * 1000L
+                } else {
+                    0L
+                },
+                token = token,
+            )
+        } catch (_: Exception) {
+            null
+        } finally {
+            client.close()
+        }
+    }
+
+    /** Clears every account-scoped local store so the rebuilt ViewModels fetch the new account clean. */
+    private suspend fun clearLocalState() {
+        withContext(Dispatchers.IO) {
+            runCatching { apolloClient.apolloStore.clearAll() }
+            libraryDao.deleteAll()
+            userProfileDao.clear()
+            savedForumThreadDao.deleteAll()
+            airingScheduleDao.clearAll()
+            preferencesRepository.clearAll()
+            appSettings.clearAccountScoped()
+            activityRepository.clearViewerCache()
+            notificationBadgeStore.reset()
+        }
+    }
+
+    private suspend fun refreshWidgets() {
+        runCatching {
+            UpNextWidget().updateAll(context)
+            AiringTodayWidget().updateAll(context)
+            WeeklyCalendarWidget().updateAll(context)
+        }
+    }
+
+    companion object {
+        private const val ANILIST_URL = "https://graphql.anilist.co"
+        private const val ONE_DAY_SECONDS = 86_400L
+    }
+}

--- a/app/src/main/java/com/anisync/android/data/account/AccountStore.kt
+++ b/app/src/main/java/com/anisync/android/data/account/AccountStore.kt
@@ -1,0 +1,254 @@
+@file:Suppress("DEPRECATION")
+
+package com.anisync.android.data.account
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.security.KeyStore
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Single source of truth for signed-in accounts and which one is active.
+ *
+ * Storage split:
+ *  - **Tokens** live in EncryptedSharedPreferences (`auth_prefs`), one key per account
+ *    (`auth_token_<id>`). Secrets stay encrypted.
+ *  - **Metadata** (id / name / avatar / expiry) and the active id live in a plain prefs file
+ *    (`anisync_accounts`) as JSON, so the account list renders without decrypting or hitting network.
+ *
+ * Pure persistence — no network, no Apollo, no Room. That keeps it free of the
+ * ApolloClient → AuthorizationInterceptor → AuthRepository dependency chain, so [AuthRepository]
+ * can depend on it without a DI cycle. Network/cache orchestration lives in [AccountManager].
+ */
+@Singleton
+class AccountStore @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val secure: SharedPreferences = createSecurePrefs()
+    private val metaPrefs: SharedPreferences =
+        context.getSharedPreferences(META_PREFS, Context.MODE_PRIVATE)
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val _accounts = MutableStateFlow<List<Account>>(emptyList())
+    val accounts: StateFlow<List<Account>> = _accounts.asStateFlow()
+
+    private val _activeAccount = MutableStateFlow<Account?>(null)
+    val activeAccount: StateFlow<Account?> = _activeAccount.asStateFlow()
+
+    private var activeId: Int? = null
+
+    init {
+        load()
+    }
+
+    /** Synchronous active-token read for [AuthorizationInterceptor]. */
+    fun activeToken(): String? = _activeAccount.value?.token
+
+    /**
+     * Inserts a new account or replaces an existing one with the same id (re-auth). Does not change
+     * which account is active — callers switch explicitly via [switchTo].
+     */
+    fun addOrReplace(account: Account) {
+        secure.edit().putString(tokenKey(account.id), account.token).apply()
+        val list = _accounts.value.toMutableList()
+        val idx = list.indexOfFirst { it.id == account.id }
+        if (idx >= 0) list[idx] = account else list.add(account)
+        _accounts.value = list
+        persistMeta()
+        recompute()
+    }
+
+    /** Sets the active account. `null` means "no active account" (drops to login/picker). */
+    fun switchTo(id: Int?) {
+        if (id != null && _accounts.value.none { it.id == id }) return
+        activeId = id
+        metaPrefs.edit().putInt(KEY_ACTIVE_ID, id ?: NO_ACTIVE).apply()
+        recompute()
+    }
+
+    /**
+     * Removes an account and its token. Refuses to remove the **active** account — the caller must
+     * [switchTo] another (or `null`) first, so the app never ends up active-on-a-deleted-account.
+     */
+    fun remove(id: Int) {
+        if (id == activeId) return
+        secure.edit().remove(tokenKey(id)).apply()
+        _accounts.value = _accounts.value.filterNot { it.id == id }
+        persistMeta()
+    }
+
+    /** Marks the active account's token expired and clears the active slot (used on HTTP 401). */
+    fun markActiveExpired() {
+        val active = _activeAccount.value ?: return
+        replaceById(active.copy(expiresAt = 1L))
+        switchTo(null)
+    }
+
+    /** Updates the cached name/avatar of the active account (e.g. after an Edit Profile save). */
+    fun updateActiveDetails(name: String, avatarUrl: String?) {
+        val active = _activeAccount.value ?: return
+        if (active.name == name && active.avatarUrl == avatarUrl) return
+        replaceById(active.copy(name = name, avatarUrl = avatarUrl))
+    }
+
+    /**
+     * Promotes the migrated provisional account (id [Account.PROVISIONAL_ID]) to its real identity,
+     * re-keying the stored token from the placeholder id to the real one.
+     */
+    fun reconcileProvisional(real: Account) {
+        val active = _activeAccount.value ?: return
+        if (!active.isProvisional) return
+        // A real account with this id already exists (rare): just drop the provisional.
+        secure.edit()
+            .remove(tokenKey(Account.PROVISIONAL_ID))
+            .putString(tokenKey(real.id), real.token)
+            .apply()
+        val list = _accounts.value
+            .filterNot { it.id == Account.PROVISIONAL_ID || it.id == real.id }
+            .toMutableList()
+        list.add(real)
+        _accounts.value = list
+        activeId = real.id
+        metaPrefs.edit().putInt(KEY_ACTIVE_ID, real.id).apply()
+        persistMeta()
+        recompute()
+    }
+
+    private fun replaceById(updated: Account) {
+        if (updated.token.isNotEmpty()) {
+            secure.edit().putString(tokenKey(updated.id), updated.token).apply()
+        }
+        _accounts.value = _accounts.value.map { if (it.id == updated.id) updated else it }
+        persistMeta()
+        recompute()
+    }
+
+    private fun recompute() {
+        _activeAccount.value = _accounts.value.firstOrNull { it.id == activeId }
+    }
+
+    private fun persistMeta() {
+        val metas = _accounts.value.map { AccountMeta(it.id, it.name, it.avatarUrl, it.expiresAt) }
+        metaPrefs.edit().putString(KEY_ACCOUNTS, json.encodeToString(metas)).apply()
+    }
+
+    private fun load() {
+        migrateLegacyTokenIfNeeded()
+
+        val metasJson = metaPrefs.getString(KEY_ACCOUNTS, null)
+        val metas = if (metasJson != null) {
+            runCatching { json.decodeFromString<List<AccountMeta>>(metasJson) }.getOrDefault(emptyList())
+        } else {
+            emptyList()
+        }
+
+        // Drop any metadata whose token is missing (e.g. the encrypted store was reset).
+        val loaded = metas.mapNotNull { m ->
+            val token = secure.getString(tokenKey(m.id), null) ?: return@mapNotNull null
+            Account(m.id, m.name, m.avatarUrl, m.expiresAt, token)
+        }
+        _accounts.value = loaded
+
+        val storedActive = metaPrefs.getInt(KEY_ACTIVE_ID, NO_ACTIVE)
+            .takeIf { it != NO_ACTIVE && loaded.any { a -> a.id == it } }
+        // Can't start active on an expired token — force re-auth but keep the account listed.
+        activeId = storedActive?.takeUnless { id -> loaded.first { it.id == id }.isExpired }
+
+        recompute()
+        // Rewrite metadata in case pruning removed orphaned entries.
+        if (loaded.size != metas.size) persistMeta()
+    }
+
+    /**
+     * Migrates the pre-multi-account single token (`auth_prefs/access_token`) into a provisional
+     * account so existing users are not logged out. The real identity is resolved later.
+     */
+    private fun migrateLegacyTokenIfNeeded() {
+        val legacy = secure.getString(LEGACY_TOKEN_KEY, null) ?: return
+        if (metaPrefs.contains(KEY_ACCOUNTS)) {
+            // Already on the new format; just retire the stale legacy key.
+            secure.edit().remove(LEGACY_TOKEN_KEY).apply()
+            return
+        }
+        secure.edit()
+            .putString(tokenKey(Account.PROVISIONAL_ID), legacy)
+            .remove(LEGACY_TOKEN_KEY)
+            .apply()
+        val meta = listOf(AccountMeta(Account.PROVISIONAL_ID, "", null, 0L))
+        metaPrefs.edit()
+            .putString(KEY_ACCOUNTS, json.encodeToString(meta))
+            .putInt(KEY_ACTIVE_ID, Account.PROVISIONAL_ID)
+            .apply()
+    }
+
+    // ── Encrypted store creation (with keystore-invalidation recovery) ──────────────────────────
+
+    private fun buildMasterKey(): MasterKey =
+        MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+
+    private fun createSecurePrefs(): SharedPreferences {
+        return try {
+            EncryptedSharedPreferences.create(
+                context,
+                SECURE_PREFS,
+                buildMasterKey(),
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+            ).also { it.contains(LEGACY_TOKEN_KEY) } // force decrypt to surface AEADBadTagException now
+        } catch (t: Throwable) {
+            // Keystore key invalidated (OS upgrade, backup/restore, lockscreen change, etc.).
+            // Wipe corrupt prefs + master key alias, then recreate. Tokens are lost; user re-logs in.
+            Log.w(TAG, "EncryptedSharedPreferences unreadable, resetting", t)
+            resetEncryptedStore()
+            EncryptedSharedPreferences.create(
+                context,
+                SECURE_PREFS,
+                buildMasterKey(),
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+            )
+        }
+    }
+
+    private fun resetEncryptedStore() {
+        runCatching { context.deleteSharedPreferences(SECURE_PREFS) }
+        runCatching {
+            val ks = KeyStore.getInstance("AndroidKeyStore")
+            ks.load(null)
+            if (ks.containsAlias(MASTER_KEY_ALIAS)) ks.deleteEntry(MASTER_KEY_ALIAS)
+        }
+    }
+
+    @Serializable
+    private data class AccountMeta(
+        val id: Int,
+        val name: String,
+        val avatarUrl: String?,
+        val expiresAt: Long,
+    )
+
+    companion object {
+        private const val TAG = "AccountStore"
+        private const val SECURE_PREFS = "auth_prefs"
+        private const val META_PREFS = "anisync_accounts"
+        private const val MASTER_KEY_ALIAS = MasterKey.DEFAULT_MASTER_KEY_ALIAS
+        private const val LEGACY_TOKEN_KEY = "access_token"
+        private const val KEY_ACCOUNTS = "accounts"
+        private const val KEY_ACTIVE_ID = "active_id"
+        private const val NO_ACTIVE = Int.MIN_VALUE
+
+        private fun tokenKey(id: Int) = "auth_token_$id"
+    }
+}

--- a/app/src/main/java/com/anisync/android/data/account/AccountStore.kt
+++ b/app/src/main/java/com/anisync/android/data/account/AccountStore.kt
@@ -90,8 +90,18 @@ class AccountStore @Inject constructor(
     /** Marks the active account's token expired and clears the active slot (used on HTTP 401). */
     fun markActiveExpired() {
         val active = _activeAccount.value ?: return
-        replaceById(active.copy(expiresAt = 1L))
-        switchTo(null)
+        markExpired(active.id)
+    }
+
+    /**
+     * Marks a specific account's token expired. If it is the active account, also clears the active
+     * slot (drops to login/picker). A non-active account is just flagged — the active session is
+     * untouched (used by the background notification worker on a per-account 401).
+     */
+    fun markExpired(id: Int) {
+        val account = _accounts.value.firstOrNull { it.id == id } ?: return
+        replaceById(account.copy(expiresAt = 1L))
+        if (id == activeId) switchTo(null)
     }
 
     /** Updates the cached name/avatar of the active account (e.g. after an Edit Profile save). */

--- a/app/src/main/java/com/anisync/android/data/account/TokenedApolloClientFactory.kt
+++ b/app/src/main/java/com/anisync/android/data/account/TokenedApolloClientFactory.kt
@@ -1,0 +1,47 @@
+package com.anisync.android.data.account
+
+import com.anisync.android.di.AuthorizationInterceptor
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.cache.normalized.api.MemoryCacheFactory
+import com.apollographql.apollo.cache.normalized.normalizedCache
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Builds [ApolloClient]s bound to a specific account's bearer token, for talking to AniList as an
+ * account that is **not** the active one (background notification polling, add-time identity resolve).
+ *
+ * Each client carries its own `Authorization` header and a small, **isolated** in-memory normalized
+ * cache (no SQLite) so cross-account data can't bleed into the active account's persistent cache.
+ * It still installs the shared [AuthorizationInterceptor] so per-account requests are paced by the
+ * same rate-limit / token-bucket logic — the interceptor skips adding/clearing auth and skips the
+ * global session-expired trigger when a request already carries an `Authorization` header.
+ *
+ * Clients are cached by token (accounts are few and tokens stable); [evict] closes one on removal.
+ */
+@Singleton
+class TokenedApolloClientFactory @Inject constructor(
+    private val authorizationInterceptor: AuthorizationInterceptor,
+) {
+    private val clients = ConcurrentHashMap<String, ApolloClient>()
+
+    fun create(token: String): ApolloClient = clients.getOrPut(token) {
+        ApolloClient.Builder()
+            .serverUrl(ANILIST_URL)
+            .addHttpInterceptor(authorizationInterceptor)
+            .addHttpHeader("Authorization", "Bearer $token")
+            .normalizedCache(MemoryCacheFactory(maxSizeBytes = MEMORY_CACHE_SIZE))
+            .build()
+    }
+
+    /** Closes and drops the cached client for [token] (call when its account is removed). */
+    fun evict(token: String) {
+        clients.remove(token)?.close()
+    }
+
+    companion object {
+        private const val ANILIST_URL = "https://graphql.anilist.co"
+        private const val MEMORY_CACHE_SIZE = 1 * 1024 * 1024 // 1 MB, throwaway
+    }
+}

--- a/app/src/main/java/com/anisync/android/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/anisync/android/data/local/AppDatabase.kt
@@ -19,6 +19,13 @@ import com.anisync.android.data.local.entity.UserProfileEntity
  *
  * Version History:
  * ─────────────────────────────────────────────────────────────────────────────
+ * v18 (Jun 2026):
+ *   - Added field to library_entries:
+ *     • ownerId - AniList user id the entry belongs to, so multiple accounts'
+ *       libraries persist side by side (instant switch from cache, no bleed).
+ *       Existing rows default to 0 and are re-tagged to the real id on first
+ *       account reconcile.
+ *
  * v17 (Jun 2026):
  *   - Added fields to media_details:
  *     • isRecommendationBlocked - hides the "add recommendation" action when true
@@ -81,7 +88,7 @@ import com.anisync.android.data.local.entity.UserProfileEntity
         TrendingEntity::class,
         SavedForumThreadEntity::class
     ],
-    version = 17,
+    version = 18,
     exportSchema = true,
     autoMigrations = [
         androidx.room.AutoMigration(from = 2, to = 3),
@@ -97,7 +104,8 @@ import com.anisync.android.data.local.entity.UserProfileEntity
         androidx.room.AutoMigration(from = 13, to = 14),
         androidx.room.AutoMigration(from = 14, to = 15),
         androidx.room.AutoMigration(from = 15, to = 16),
-        androidx.room.AutoMigration(from = 16, to = 17)
+        androidx.room.AutoMigration(from = 16, to = 17),
+        androidx.room.AutoMigration(from = 17, to = 18)
     ]
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/anisync/android/data/local/dao/LibraryDao.kt
+++ b/app/src/main/java/com/anisync/android/data/local/dao/LibraryDao.kt
@@ -116,6 +116,13 @@ interface LibraryDao {
     suspend fun deleteByMediaIds(mediaIds: List<Int>)
 
     /**
+     * Delete every library entry. Used when switching accounts to drop the previous
+     * account's list before the new account's data is fetched.
+     */
+    @Query("DELETE FROM library_entries")
+    suspend fun deleteAll()
+
+    /**
      * Update status and progress for a specific media entry.
      * Used when status is changed from DetailsScreen.
      */

--- a/app/src/main/java/com/anisync/android/data/local/dao/LibraryDao.kt
+++ b/app/src/main/java/com/anisync/android/data/local/dao/LibraryDao.kt
@@ -12,81 +12,84 @@ import kotlinx.coroutines.flow.Flow
 
 /**
  * DAO for library entry operations with reactive Flow support.
+ *
+ * All reads/writes are scoped to an `ownerId` (the AniList user id) so multiple accounts'
+ * libraries coexist in one table — switching accounts shows the right account's entries instantly
+ * from cache instead of wiping and refetching.
  */
 @Dao
 interface LibraryDao {
-    
-    /**
-     * Observe all library entries by media type.
-     * Emits new list whenever data changes.
-     */
-    @Query("SELECT * FROM library_entries WHERE mediaType = :type ORDER BY titleUserPreferred ASC")
-    fun observeByType(type: MediaType): Flow<List<LibraryEntryEntity>>
 
     /**
-     * Get all entries by type (non-reactive, for one-time reads).
+     * Observe an account's library entries by media type.
+     * Emits a new list whenever that account's data changes.
      */
-    @Query("SELECT * FROM library_entries WHERE mediaType = :type")
-    suspend fun getByType(type: MediaType): List<LibraryEntryEntity>
+    @Query("SELECT * FROM library_entries WHERE ownerId = :ownerId AND mediaType = :type ORDER BY titleUserPreferred ASC")
+    fun observeByType(ownerId: Int, type: MediaType): Flow<List<LibraryEntryEntity>>
 
     /**
-     * Get "Up Next" entries: Watching status and not completed.
+     * Get an account's entries by type (non-reactive, for one-time reads).
+     */
+    @Query("SELECT * FROM library_entries WHERE ownerId = :ownerId AND mediaType = :type")
+    suspend fun getByType(ownerId: Int, type: MediaType): List<LibraryEntryEntity>
+
+    /**
+     * Get "Up Next" entries for an account: Watching status and not completed.
      * Sorted by last updated to show most recently watched first.
      */
-    @Query("SELECT * FROM library_entries WHERE status = 'CURRENT' AND (totalEpisodes IS NULL OR progress < totalEpisodes) ORDER BY lastUpdated DESC")
-    suspend fun getUpNext(): List<LibraryEntryEntity>
+    @Query("SELECT * FROM library_entries WHERE ownerId = :ownerId AND status = 'CURRENT' AND (totalEpisodes IS NULL OR progress < totalEpisodes) ORDER BY lastUpdated DESC")
+    suspend fun getUpNext(ownerId: Int): List<LibraryEntryEntity>
 
-    @Query("SELECT * FROM library_entries WHERE status = 'CURRENT' AND (totalEpisodes IS NULL OR progress < totalEpisodes) ORDER BY lastUpdated DESC LIMIT 1")
-    suspend fun getMostRecentWatching(): LibraryEntryEntity?
+    @Query("SELECT * FROM library_entries WHERE ownerId = :ownerId AND status = 'CURRENT' AND (totalEpisodes IS NULL OR progress < totalEpisodes) ORDER BY lastUpdated DESC LIMIT 1")
+    suspend fun getMostRecentWatching(ownerId: Int): LibraryEntryEntity?
 
     /**
-     * Get a single entry by mediaId.
+     * Get a single entry by mediaId for a specific account.
      */
-    @Query("SELECT * FROM library_entries WHERE mediaId = :mediaId LIMIT 1")
-    suspend fun getEntry(mediaId: Int): LibraryEntryEntity?
+    @Query("SELECT * FROM library_entries WHERE ownerId = :ownerId AND mediaId = :mediaId LIMIT 1")
+    suspend fun getEntry(ownerId: Int, mediaId: Int): LibraryEntryEntity?
 
     /**
-     * Insert or replace entries.
+     * Insert or replace entries. The entities carry their own [LibraryEntryEntity.ownerId].
      */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(entries: List<LibraryEntryEntity>)
 
     /**
-     * Insert or replace a single entry.
+     * Insert or replace a single entry (entity carries its ownerId).
      * Used when adding new media to library from details screen.
      */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertOrReplace(entry: LibraryEntryEntity)
 
     /**
-     * Delete all entries by media type.
+     * Delete all entries of a media type for an account.
      */
-    @Query("DELETE FROM library_entries WHERE mediaType = :type")
-    suspend fun deleteByType(type: MediaType)
+    @Query("DELETE FROM library_entries WHERE ownerId = :ownerId AND mediaType = :type")
+    suspend fun deleteByType(ownerId: Int, type: MediaType)
 
     /**
-     * Update progress for a specific media.
+     * Update progress for a specific media in an account.
      */
-    @Query("UPDATE library_entries SET progress = :progress, lastUpdated = :timestamp WHERE mediaId = :mediaId")
-    suspend fun updateProgress(mediaId: Int, progress: Int, timestamp: Long = System.currentTimeMillis())
+    @Query("UPDATE library_entries SET progress = :progress, lastUpdated = :timestamp WHERE ownerId = :ownerId AND mediaId = :mediaId")
+    suspend fun updateProgress(ownerId: Int, mediaId: Int, progress: Int, timestamp: Long = System.currentTimeMillis())
 
     /**
-     * Atomic transaction: delete old entries and insert new ones.
-     * Prevents UI flicker from empty state between delete and insert.
+     * Atomic transaction: delete an account's old entries of a type and insert new ones.
      * @deprecated Use smartMergeByType instead to preserve locally-added entries
      */
     @Transaction
-    suspend fun replaceByType(type: MediaType, entries: List<LibraryEntryEntity>) {
-        deleteByType(type)
+    suspend fun replaceByType(ownerId: Int, type: MediaType, entries: List<LibraryEntryEntity>) {
+        deleteByType(ownerId, type)
         insertAll(entries)
     }
 
     /**
-     * Smart merge: preserves locally-added entries while syncing with API.
+     * Smart merge: preserves locally-added entries while syncing with API, scoped to one account.
      */
     @Transaction
-    suspend fun smartMergeByType(type: MediaType, apiEntries: List<LibraryEntryEntity>) {
-        val localEntries = getByType(type)
+    suspend fun smartMergeByType(ownerId: Int, type: MediaType, apiEntries: List<LibraryEntryEntity>) {
+        val localEntries = getByType(ownerId, type)
         val apiMediaIds = apiEntries.mapTo(HashSet(apiEntries.size)) { it.mediaId }
         val now = System.currentTimeMillis()
         val recentThreshold = 5 * 60 * 1000L
@@ -104,7 +107,7 @@ interface LibraryDao {
         }
 
         if (toDeleteIds.isNotEmpty()) {
-            deleteByMediaIds(toDeleteIds)
+            deleteByMediaIds(ownerId, toDeleteIds)
         }
         insertAll(apiEntries)
         if (toPreserve.isNotEmpty()) {
@@ -112,41 +115,33 @@ interface LibraryDao {
         }
     }
 
-    @Query("DELETE FROM library_entries WHERE mediaId IN (:mediaIds)")
-    suspend fun deleteByMediaIds(mediaIds: List<Int>)
+    @Query("DELETE FROM library_entries WHERE ownerId = :ownerId AND mediaId IN (:mediaIds)")
+    suspend fun deleteByMediaIds(ownerId: Int, mediaIds: List<Int>)
 
     /**
-     * Delete every library entry. Used when switching accounts to drop the previous
-     * account's list before the new account's data is fetched.
+     * Update status and progress for a specific media entry in an account.
      */
-    @Query("DELETE FROM library_entries")
-    suspend fun deleteAll()
+    @Query("UPDATE library_entries SET status = :status, progress = :progress, lastUpdated = :timestamp WHERE ownerId = :ownerId AND mediaId = :mediaId")
+    suspend fun updateStatusAndProgress(ownerId: Int, mediaId: Int, status: LibraryStatus, progress: Int, timestamp: Long = System.currentTimeMillis())
 
     /**
-     * Update status and progress for a specific media entry.
-     * Used when status is changed from DetailsScreen.
+     * Delete a specific entry by mediaId for an account.
      */
-    @Query("UPDATE library_entries SET status = :status, progress = :progress, lastUpdated = :timestamp WHERE mediaId = :mediaId")
-    suspend fun updateStatusAndProgress(mediaId: Int, status: LibraryStatus, progress: Int, timestamp: Long = System.currentTimeMillis())
+    @Query("DELETE FROM library_entries WHERE ownerId = :ownerId AND mediaId = :mediaId")
+    suspend fun deleteByMediaId(ownerId: Int, mediaId: Int)
 
     /**
-     * Delete a specific entry by mediaId.
-     * Used when an entry is removed from the user's list.
-     */
-    @Query("DELETE FROM library_entries WHERE mediaId = :mediaId")
-    suspend fun deleteByMediaId(mediaId: Int)
-
-    /**
-     * Update an entire entry.
+     * Update an entire entry (matched by primary key; the entity carries its ownerId).
      */
     @androidx.room.Update
     suspend fun updateEntry(entry: LibraryEntryEntity)
 
     /**
-     * Update status, progress, and completedAt when media is completed.
+     * Update status, progress, and completedAt when media is completed, in an account.
      */
-    @Query("UPDATE library_entries SET status = :status, progress = :progress, completedAt = :completedAt, lastUpdated = :timestamp WHERE mediaId = :mediaId")
+    @Query("UPDATE library_entries SET status = :status, progress = :progress, completedAt = :completedAt, lastUpdated = :timestamp WHERE ownerId = :ownerId AND mediaId = :mediaId")
     suspend fun updateStatusProgressAndCompletedAt(
+        ownerId: Int,
         mediaId: Int,
         status: LibraryStatus,
         progress: Int,
@@ -155,13 +150,27 @@ interface LibraryDao {
     )
 
     /**
-     * Update status and startedAt when starting to watch/read.
+     * Update status and startedAt when starting to watch/read, in an account.
      */
-    @Query("UPDATE library_entries SET status = :status, startedAt = :startedAt, lastUpdated = :timestamp WHERE mediaId = :mediaId")
+    @Query("UPDATE library_entries SET status = :status, startedAt = :startedAt, lastUpdated = :timestamp WHERE ownerId = :ownerId AND mediaId = :mediaId")
     suspend fun updateStatusAndStartedAt(
+        ownerId: Int,
         mediaId: Int,
         status: LibraryStatus,
         startedAt: Long,
         timestamp: Long = System.currentTimeMillis()
     )
+
+    /**
+     * Re-tag entries from one owner to another. Used to promote the migrated legacy library
+     * (owner 0) to the account's real id once it is resolved.
+     */
+    @Query("UPDATE library_entries SET ownerId = :newOwnerId WHERE ownerId = :oldOwnerId")
+    suspend fun reassignOwner(oldOwnerId: Int, newOwnerId: Int)
+
+    /**
+     * Delete every library entry across all accounts (e.g. encrypted-store reset recovery).
+     */
+    @Query("DELETE FROM library_entries")
+    suspend fun deleteAll()
 }

--- a/app/src/main/java/com/anisync/android/data/local/dao/SavedForumThreadDao.kt
+++ b/app/src/main/java/com/anisync/android/data/local/dao/SavedForumThreadDao.kt
@@ -24,4 +24,8 @@ interface SavedForumThreadDao {
 
     @Query("SELECT EXISTS(SELECT 1 FROM saved_forum_threads WHERE threadId = :threadId)")
     suspend fun exists(threadId: Int): Boolean
+
+    /** Delete every saved thread. Used when switching accounts (bookmarks are per-account). */
+    @Query("DELETE FROM saved_forum_threads")
+    suspend fun deleteAll()
 }

--- a/app/src/main/java/com/anisync/android/data/local/dao/UserProfileDao.kt
+++ b/app/src/main/java/com/anisync/android/data/local/dao/UserProfileDao.kt
@@ -14,17 +14,17 @@ import kotlinx.coroutines.flow.Flow
 interface UserProfileDao {
     
     /**
-     * Observe the cached user profile.
-     * Emits null if not cached.
+     * Observe a specific account's cached profile (the row's primary key is the user id, so this
+     * scopes the own-profile cache per account). Emits null if not cached.
      */
-    @Query("SELECT * FROM user_profile LIMIT 1")
-    fun observe(): Flow<UserProfileEntity?>
+    @Query("SELECT * FROM user_profile WHERE id = :userId LIMIT 1")
+    fun observe(userId: Int): Flow<UserProfileEntity?>
 
     /**
-     * Get the cached user profile (one-time read).
+     * Get a specific account's cached profile (one-time read).
      */
-    @Query("SELECT * FROM user_profile LIMIT 1")
-    suspend fun get(): UserProfileEntity?
+    @Query("SELECT * FROM user_profile WHERE id = :userId LIMIT 1")
+    suspend fun get(userId: Int): UserProfileEntity?
 
     /**
      * Insert or replace user profile.

--- a/app/src/main/java/com/anisync/android/data/local/entity/LibraryEntryEntity.kt
+++ b/app/src/main/java/com/anisync/android/data/local/entity/LibraryEntryEntity.kt
@@ -18,6 +18,8 @@ import com.anisync.android.type.MediaType
 @Entity(
     tableName = "library_entries",
     indices = [
+        Index(value = ["ownerId"]),              // Per-account scoping (multi-account)
+        Index(value = ["ownerId", "mediaType"]),
         Index(value = ["mediaType"]),
         Index(value = ["status"]),
         Index(value = ["mediaType", "status"]),
@@ -30,7 +32,10 @@ import com.anisync.android.type.MediaType
     ]
 )
 data class LibraryEntryEntity(
-    @PrimaryKey val id: Int,                   // MediaList ID
+    @PrimaryKey val id: Int,                   // MediaList ID (globally unique per AniList)
+    /** AniList user id this entry belongs to. Lets multiple accounts' libraries coexist. */
+    @androidx.room.ColumnInfo(defaultValue = "0")
+    val ownerId: Int = 0,
     val mediaId: Int,
     val titleRomaji: String?,
     val titleEnglish: String?,

--- a/app/src/main/java/com/anisync/android/data/repository/PreferencesRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/repository/PreferencesRepositoryImpl.kt
@@ -119,6 +119,10 @@ class PreferencesRepositoryImpl @Inject constructor(
         prefs.edit().putInt(KEY_LAST_SOCIAL_NOTIFIED_ID, id).apply()
     }
 
+    override suspend fun clearAll() = withContext(Dispatchers.IO) {
+        prefs.edit().clear().apply()
+    }
+
     companion object {
         private const val PREFS_NAME = "anisync_prefs"
         private const val KEY_LAST_NOTIFIED_ID = "last_notified_id"

--- a/app/src/main/java/com/anisync/android/data/repository/PreferencesRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/repository/PreferencesRepositoryImpl.kt
@@ -8,6 +8,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
+/**
+ * Notification dedup state in plain SharedPreferences, keyed per account (`<base>_<accountId>`) so
+ * each signed-in account tracks its own high-water marks independently.
+ */
 class PreferencesRepositoryImpl @Inject constructor(
     @ApplicationContext private val context: Context
 ) : PreferencesRepository {
@@ -16,111 +20,124 @@ class PreferencesRepositoryImpl @Inject constructor(
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     }
 
-    override suspend fun getLastNotifiedId(): Int = withContext(Dispatchers.IO) {
-        prefs.getInt(KEY_LAST_NOTIFIED_ID, 0)
+    private fun key(base: String, accountId: Int) = "${base}_$accountId"
+
+    override suspend fun getLastNotifiedId(accountId: Int): Int = withContext(Dispatchers.IO) {
+        prefs.getInt(key(KEY_LAST_NOTIFIED_ID, accountId), 0)
     }
 
-    override suspend fun setLastNotifiedId(id: Int) = withContext(Dispatchers.IO) {
-        prefs.edit().putInt(KEY_LAST_NOTIFIED_ID, id).apply()
+    override suspend fun setLastNotifiedId(accountId: Int, id: Int) = withContext(Dispatchers.IO) {
+        prefs.edit().putInt(key(KEY_LAST_NOTIFIED_ID, accountId), id).apply()
     }
 
-    override suspend fun getNotifiedPlanningMediaIds(): Set<Int> = withContext(Dispatchers.IO) {
-        prefs.getStringSet(KEY_NOTIFIED_PLANNING, emptySet())
+    override suspend fun getNotifiedPlanningMediaIds(accountId: Int): Set<Int> = withContext(Dispatchers.IO) {
+        prefs.getStringSet(key(KEY_NOTIFIED_PLANNING, accountId), emptySet())
             ?.mapNotNull { it.toIntOrNull() }
             ?.toSet() ?: emptySet()
     }
 
-    override suspend fun markPlanningMediaAsNotified(mediaId: Int) = withContext(Dispatchers.IO) {
-        val current = prefs.getStringSet(KEY_NOTIFIED_PLANNING, mutableSetOf())?.toMutableSet() ?: mutableSetOf()
+    override suspend fun markPlanningMediaAsNotified(accountId: Int, mediaId: Int) = withContext(Dispatchers.IO) {
+        val k = key(KEY_NOTIFIED_PLANNING, accountId)
+        val current = prefs.getStringSet(k, mutableSetOf())?.toMutableSet() ?: mutableSetOf()
         current.add(mediaId.toString())
-        prefs.edit().putStringSet(KEY_NOTIFIED_PLANNING, current).apply()
+        prefs.edit().putStringSet(k, current).apply()
     }
 
-    override suspend fun cleanupOrphanedPlanningIds(currentPlanningIds: Set<Int>) = withContext(Dispatchers.IO) {
-        val notifiedIds = prefs.getStringSet(KEY_NOTIFIED_PLANNING, emptySet())
+    override suspend fun cleanupOrphanedPlanningIds(accountId: Int, currentPlanningIds: Set<Int>) = withContext(Dispatchers.IO) {
+        val k = key(KEY_NOTIFIED_PLANNING, accountId)
+        val notifiedIds = prefs.getStringSet(k, emptySet())
             ?.mapNotNull { it.toIntOrNull() }
             ?.toSet() ?: emptySet()
-        
+
         // Keep only IDs that are still in the planning list
         val validIds = notifiedIds.intersect(currentPlanningIds)
-        
+
         if (validIds.size != notifiedIds.size) {
             prefs.edit()
-                .putStringSet(KEY_NOTIFIED_PLANNING, validIds.map { it.toString() }.toSet())
+                .putStringSet(k, validIds.map { it.toString() }.toSet())
                 .apply()
         }
     }
 
     // ---- Upcoming airing notifications ----
 
-    override suspend fun getNotifiedUpcomingAiringIds(): Set<Int> = withContext(Dispatchers.IO) {
-        prefs.getStringSet(KEY_NOTIFIED_UPCOMING, emptySet())
+    override suspend fun getNotifiedUpcomingAiringIds(accountId: Int): Set<Int> = withContext(Dispatchers.IO) {
+        prefs.getStringSet(key(KEY_NOTIFIED_UPCOMING, accountId), emptySet())
             ?.mapNotNull { it.toIntOrNull() }
             ?.toSet() ?: emptySet()
     }
 
-    override suspend fun markUpcomingAiringNotified(airingId: Int) = withContext(Dispatchers.IO) {
-        val current = prefs.getStringSet(KEY_NOTIFIED_UPCOMING, mutableSetOf())?.toMutableSet() ?: mutableSetOf()
+    override suspend fun markUpcomingAiringNotified(accountId: Int, airingId: Int) = withContext(Dispatchers.IO) {
+        val k = key(KEY_NOTIFIED_UPCOMING, accountId)
+        val current = prefs.getStringSet(k, mutableSetOf())?.toMutableSet() ?: mutableSetOf()
         current.add(airingId.toString())
-        prefs.edit().putStringSet(KEY_NOTIFIED_UPCOMING, current).apply()
+        prefs.edit().putStringSet(k, current).apply()
     }
 
-    override suspend fun cleanupOldUpcomingAirings(currentValidIds: Set<Int>) = withContext(Dispatchers.IO) {
-        val notifiedIds = prefs.getStringSet(KEY_NOTIFIED_UPCOMING, emptySet())
+    override suspend fun cleanupOldUpcomingAirings(accountId: Int, currentValidIds: Set<Int>) = withContext(Dispatchers.IO) {
+        val k = key(KEY_NOTIFIED_UPCOMING, accountId)
+        val notifiedIds = prefs.getStringSet(k, emptySet())
             ?.mapNotNull { it.toIntOrNull() }
             ?.toSet() ?: emptySet()
-        
+
         // Keep only IDs that are still valid (upcoming)
         val validIds = notifiedIds.intersect(currentValidIds)
-        
+
         if (validIds.size != notifiedIds.size) {
             prefs.edit()
-                .putStringSet(KEY_NOTIFIED_UPCOMING, validIds.map { it.toString() }.toSet())
+                .putStringSet(k, validIds.map { it.toString() }.toSet())
                 .apply()
         }
     }
 
-    override suspend fun hasNotificationsEverRun(): Boolean = withContext(Dispatchers.IO) {
-        prefs.getBoolean(KEY_HAS_EVER_RUN, false)
+    override suspend fun hasNotificationsEverRun(accountId: Int): Boolean = withContext(Dispatchers.IO) {
+        prefs.getBoolean(key(KEY_HAS_EVER_RUN, accountId), false)
     }
 
-    override suspend fun markNotificationsHaveRun() = withContext(Dispatchers.IO) {
-        prefs.edit().putBoolean(KEY_HAS_EVER_RUN, true).apply()
+    override suspend fun markNotificationsHaveRun(accountId: Int) = withContext(Dispatchers.IO) {
+        prefs.edit().putBoolean(key(KEY_HAS_EVER_RUN, accountId), true).apply()
     }
 
     // ---- Key-based notification tracking for two-tier system ----
 
-    override suspend fun hasNotifiedWithKey(key: String): Boolean = withContext(Dispatchers.IO) {
-        val keys = prefs.getStringSet(KEY_NOTIFICATION_KEYS, emptySet()) ?: emptySet()
-        key in keys
+    override suspend fun hasNotifiedWithKey(accountId: Int, notificationKey: String): Boolean = withContext(Dispatchers.IO) {
+        val keys = prefs.getStringSet(key(KEY_NOTIFICATION_KEYS, accountId), emptySet()) ?: emptySet()
+        notificationKey in keys
     }
 
-    override suspend fun markNotifiedWithKey(key: String) = withContext(Dispatchers.IO) {
-        val current = prefs.getStringSet(KEY_NOTIFICATION_KEYS, mutableSetOf())?.toMutableSet() ?: mutableSetOf()
-        current.add(key)
-        
+    override suspend fun markNotifiedWithKey(accountId: Int, notificationKey: String) = withContext(Dispatchers.IO) {
+        val storeKey = key(KEY_NOTIFICATION_KEYS, accountId)
+        val current = prefs.getStringSet(storeKey, mutableSetOf())?.toMutableSet() ?: mutableSetOf()
+        current.add(notificationKey)
+
         // Clean up old keys to prevent unbounded growth
-        // Keep only keys from the last 7 days worth of airings (assuming ~50 per day max)
         if (current.size > MAX_NOTIFICATION_KEYS) {
             val keysToKeep = current.toList().takeLast(MAX_NOTIFICATION_KEYS).toSet()
-            prefs.edit().putStringSet(KEY_NOTIFICATION_KEYS, keysToKeep).apply()
+            prefs.edit().putStringSet(storeKey, keysToKeep).apply()
         } else {
-            prefs.edit().putStringSet(KEY_NOTIFICATION_KEYS, current).apply()
+            prefs.edit().putStringSet(storeKey, current).apply()
         }
     }
 
     // ---- Social/Forum notification tracking ----
 
-    override suspend fun getLastSocialNotifiedId(): Int = withContext(Dispatchers.IO) {
-        prefs.getInt(KEY_LAST_SOCIAL_NOTIFIED_ID, 0)
+    override suspend fun getLastSocialNotifiedId(accountId: Int): Int = withContext(Dispatchers.IO) {
+        prefs.getInt(key(KEY_LAST_SOCIAL_NOTIFIED_ID, accountId), 0)
     }
 
-    override suspend fun setLastSocialNotifiedId(id: Int) = withContext(Dispatchers.IO) {
-        prefs.edit().putInt(KEY_LAST_SOCIAL_NOTIFIED_ID, id).apply()
+    override suspend fun setLastSocialNotifiedId(accountId: Int, id: Int) = withContext(Dispatchers.IO) {
+        prefs.edit().putInt(key(KEY_LAST_SOCIAL_NOTIFIED_ID, accountId), id).apply()
     }
 
-    override suspend fun clearAll() = withContext(Dispatchers.IO) {
-        prefs.edit().clear().apply()
+    override suspend fun clearForAccount(accountId: Int) = withContext(Dispatchers.IO) {
+        prefs.edit().apply {
+            remove(key(KEY_LAST_NOTIFIED_ID, accountId))
+            remove(key(KEY_NOTIFIED_PLANNING, accountId))
+            remove(key(KEY_NOTIFIED_UPCOMING, accountId))
+            remove(key(KEY_HAS_EVER_RUN, accountId))
+            remove(key(KEY_NOTIFICATION_KEYS, accountId))
+            remove(key(KEY_LAST_SOCIAL_NOTIFIED_ID, accountId))
+        }.apply()
     }
 
     companion object {

--- a/app/src/main/java/com/anisync/android/di/AuthorizationInterceptor.kt
+++ b/app/src/main/java/com/anisync/android/di/AuthorizationInterceptor.kt
@@ -95,13 +95,21 @@ class AuthorizationInterceptor @Inject constructor(
         tokenBucket.acquire()
 
         // ── Step 1: Attach Bearer token ─────────────────────────────────
-        val token = authRepository.getToken()
-        val authorizedRequest = if (token != null) {
-            request.newBuilder()
-                .addHeader("Authorization", "Bearer $token")
-                .build()
-        } else {
+        // A request that already carries an Authorization header is a token-scoped call (e.g. a
+        // background poll of a non-active account via TokenedApolloClientFactory). Leave its header
+        // untouched and don't let its 401s trip the global session-expired flow.
+        val hasOwnAuthHeader = request.headers.any { it.name.equals("Authorization", ignoreCase = true) }
+        val authorizedRequest = if (hasOwnAuthHeader) {
             request
+        } else {
+            val token = authRepository.getToken()
+            if (token != null) {
+                request.newBuilder()
+                    .addHeader("Authorization", "Bearer $token")
+                    .build()
+            } else {
+                request
+            }
         }
 
         // ── Step 2: Proactive throttling ────────────────────────────────
@@ -128,7 +136,7 @@ class AuthorizationInterceptor @Inject constructor(
         // ── Step 5: Handle error status codes ───────────────────────────
         return when (response.statusCode) {
             429 -> handleRateLimited(response, authorizedRequest, chain)
-            401 -> handleUnauthorized(response, authorizedRequest)
+            401 -> handleUnauthorized(response, authorizedRequest, isTokenScoped = hasOwnAuthHeader)
             in 500..599 -> handleServerError(response)
             else -> checkBodyForPermissionErrors(response, authorizedRequest)
         }
@@ -254,11 +262,21 @@ class AuthorizationInterceptor @Inject constructor(
      *
      * The UI layer collects `authRepository.sessionExpired` to show the dialog.
      */
-    private fun handleUnauthorized(response: HttpResponse, request: HttpRequest): HttpResponse {
+    private fun handleUnauthorized(
+        response: HttpResponse,
+        request: HttpRequest,
+        isTokenScoped: Boolean
+    ): HttpResponse {
         val operationName = extractOperationName(request)
         if (operationName != null && operationName in permissionGated401Operations) {
             Log.w(TAG, "401 on $operationName — treating as permission denial, not session expiry.")
             throw ApiError.Forbidden()
+        }
+        if (isTokenScoped) {
+            // Per-account background poll — don't disturb the active session; the caller
+            // (NotificationWorker) marks that specific account expired.
+            Log.w(TAG, "Unauthorized (401) on token-scoped request; leaving active session intact.")
+            throw ApiError.Unauthorized()
         }
         Log.w(TAG, "Unauthorized (401). Token expired or revoked.")
         authRepository.onSessionExpired()

--- a/app/src/main/java/com/anisync/android/di/AuthorizationInterceptor.kt
+++ b/app/src/main/java/com/anisync/android/di/AuthorizationInterceptor.kt
@@ -16,6 +16,7 @@ import okio.Buffer
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * HTTP interceptor for all AniList API requests.
@@ -34,6 +35,7 @@ import javax.inject.Inject
  * - Headers on 429: `Retry-After` (seconds), `X-RateLimit-Reset` (unix timestamp)
  * - Burst limiter also exists (undocumented threshold)
  */
+@Singleton
 class AuthorizationInterceptor @Inject constructor(
     private val authRepository: AuthRepository,
     private val toastManager: ToastManager,

--- a/app/src/main/java/com/anisync/android/domain/ActivityRepository.kt
+++ b/app/src/main/java/com/anisync/android/domain/ActivityRepository.kt
@@ -8,6 +8,9 @@ interface ActivityRepository {
     suspend fun deleteActivity(id: Int): Result<Unit>
     suspend fun deleteReply(id: Int): Result<Unit>
     suspend fun getViewerId(): Int?
+
+    /** Drops the in-memory cached viewer id so the next call re-resolves it (used on account switch). */
+    fun clearViewerCache()
     suspend fun toggleSubscription(activityId: Int, subscribe: Boolean): Result<Unit>
     suspend fun saveTextActivity(text: String, id: Int? = null): Result<Unit>
 

--- a/app/src/main/java/com/anisync/android/domain/NotificationRepository.kt
+++ b/app/src/main/java/com/anisync/android/domain/NotificationRepository.kt
@@ -6,11 +6,12 @@ package com.anisync.android.domain
  */
 interface NotificationRepository {
     /**
-     * Fetch paginated notifications for the current user (background poller).
+     * Fetch paginated notifications (background poller).
      * @param page Page number (1-indexed)
+     * @param token AniList token to poll a specific account; null uses the active account's client.
      * @return List of notifications or error
      */
-    suspend fun getNotifications(page: Int): Result<List<Notification>>
+    suspend fun getNotifications(page: Int, token: String? = null): Result<List<Notification>>
 
     /**
      * Fetch paginated notifications with optional type filtering and pagination metadata.

--- a/app/src/main/java/com/anisync/android/domain/PreferencesRepository.kt
+++ b/app/src/main/java/com/anisync/android/domain/PreferencesRepository.kt
@@ -1,72 +1,74 @@
 package com.anisync.android.domain
 
+/**
+ * Notification dedup / baseline state, scoped per account so each signed-in account keeps its own
+ * high-water marks (the background worker polls every account every cycle).
+ */
 interface PreferencesRepository {
-    suspend fun getLastNotifiedId(): Int
-    suspend fun setLastNotifiedId(id: Int)
-    suspend fun getNotifiedPlanningMediaIds(): Set<Int>
-    suspend fun markPlanningMediaAsNotified(mediaId: Int)
+    suspend fun getLastNotifiedId(accountId: Int): Int
+    suspend fun setLastNotifiedId(accountId: Int, id: Int)
+    suspend fun getNotifiedPlanningMediaIds(accountId: Int): Set<Int>
+    suspend fun markPlanningMediaAsNotified(accountId: Int, mediaId: Int)
     /**
      * Remove IDs from the notified set that are no longer in the user's planning list.
      */
-    suspend fun cleanupOrphanedPlanningIds(currentPlanningIds: Set<Int>)
-    
+    suspend fun cleanupOrphanedPlanningIds(accountId: Int, currentPlanningIds: Set<Int>)
+
     // ---- Upcoming airing notifications ----
-    
+
     /**
      * Get airing IDs that have already been notified about upcoming episodes.
      */
-    suspend fun getNotifiedUpcomingAiringIds(): Set<Int>
-    
+    suspend fun getNotifiedUpcomingAiringIds(accountId: Int): Set<Int>
+
     /**
      * Mark an airing as notified for upcoming episode.
      */
-    suspend fun markUpcomingAiringNotified(airingId: Int)
-    
+    suspend fun markUpcomingAiringNotified(accountId: Int, airingId: Int)
+
     /**
      * Clean up old upcoming airing IDs that are no longer relevant.
      */
-    suspend fun cleanupOldUpcomingAirings(currentValidIds: Set<Int>)
-    
+    suspend fun cleanupOldUpcomingAirings(accountId: Int, currentValidIds: Set<Int>)
+
     /**
-     * Check if the notification worker has ever completed a baseline sync.
+     * Check if the notification worker has ever completed a baseline sync for this account.
      * Used to suppress notifications on the very first run.
      */
-    suspend fun hasNotificationsEverRun(): Boolean
-    
+    suspend fun hasNotificationsEverRun(accountId: Int): Boolean
+
     /**
-     * Mark that the notification worker has completed its first baseline sync.
+     * Mark that the notification worker has completed its first baseline sync for this account.
      */
-    suspend fun markNotificationsHaveRun()
-    
+    suspend fun markNotificationsHaveRun(accountId: Int)
+
     // ---- Key-based notification tracking for two-tier system ----
-    
+
     /**
      * Check if a notification has been sent for a specific key.
      * Used for two-tier notification system (advance_123, imminent_123).
      */
-    suspend fun hasNotifiedWithKey(key: String): Boolean
-    
+    suspend fun hasNotifiedWithKey(accountId: Int, notificationKey: String): Boolean
+
     /**
      * Mark a notification key as sent.
      */
-    suspend fun markNotifiedWithKey(key: String)
+    suspend fun markNotifiedWithKey(accountId: Int, notificationKey: String)
 
     // ---- Social/Forum notification tracking ----
 
     /**
      * Get the highest notification ID that was already processed for social/forum notifications.
      */
-    suspend fun getLastSocialNotifiedId(): Int
+    suspend fun getLastSocialNotifiedId(accountId: Int): Int
 
     /**
      * Set the highest processed social/forum notification ID.
      */
-    suspend fun setLastSocialNotifiedId(id: Int)
+    suspend fun setLastSocialNotifiedId(accountId: Int, id: Int)
 
     /**
-     * Wipe all notification dedup state. Called on account switch so the new account re-establishes
-     * its own baseline (preventing both a backlog flood and the previous account's high-water marks
-     * silently suppressing the new account's notifications).
+     * Wipe all notification dedup state for a single account (used when the account is removed).
      */
-    suspend fun clearAll()
+    suspend fun clearForAccount(accountId: Int)
 }

--- a/app/src/main/java/com/anisync/android/domain/PreferencesRepository.kt
+++ b/app/src/main/java/com/anisync/android/domain/PreferencesRepository.kt
@@ -62,4 +62,11 @@ interface PreferencesRepository {
      * Set the highest processed social/forum notification ID.
      */
     suspend fun setLastSocialNotifiedId(id: Int)
+
+    /**
+     * Wipe all notification dedup state. Called on account switch so the new account re-establishes
+     * its own baseline (preventing both a backlog flood and the previous account's high-water marks
+     * silently suppressing the new account's notifications).
+     */
+    suspend fun clearAll()
 }

--- a/app/src/main/java/com/anisync/android/presentation/MainScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/MainScreen.kt
@@ -90,7 +90,10 @@ private data class BottomNavItem<T : Any>(
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
+fun MainScreen(
+    builtAtEpoch: Int = 0,
+    viewModel: MainScreenViewModel = hiltViewModel()
+) {
     val navController = rememberNavController()
     val context = LocalContext.current
     LaunchedEffect(navController) {
@@ -99,13 +102,16 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
             navController.handleDeepLink(intent)
         }
     }
-    // Account-tagged notification deep links: delivered after any account switch settles, and
-    // retained across the switch rebuild so this (possibly fresh) NavController handles them.
+    // Cross-account notification deep links: delivered after the account switch settles, tagged with
+    // the session epoch of the post-switch MainScreen. Only that instance (matching epoch) handles
+    // it, so the pre-switch MainScreen can't consume it first.
     LaunchedEffect(navController) {
         val activity = context as? com.anisync.android.MainActivity ?: return@LaunchedEffect
-        activity.pendingDeepLink.filterNotNull().collect { intent ->
-            navController.handleDeepLink(intent)
-            activity.consumePendingDeepLink()
+        activity.pendingDeepLink.filterNotNull().collect { pending ->
+            if (pending.epoch == builtAtEpoch) {
+                navController.handleDeepLink(pending.intent)
+                activity.consumePendingDeepLink()
+            }
         }
     }
     val unreadNotificationCount by viewModel.unreadNotificationCount.collectAsStateWithLifecycle()

--- a/app/src/main/java/com/anisync/android/presentation/MainScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/MainScreen.kt
@@ -54,6 +54,7 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.flow.filterNotNull
 import com.anisync.android.R
 import com.anisync.android.data.NavBarStyle
 import com.anisync.android.presentation.components.alert.ProvideToastManager
@@ -96,6 +97,15 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
         val activity = context as? com.anisync.android.MainActivity ?: return@LaunchedEffect
         activity.newIntents.collect { intent ->
             navController.handleDeepLink(intent)
+        }
+    }
+    // Account-tagged notification deep links: delivered after any account switch settles, and
+    // retained across the switch rebuild so this (possibly fresh) NavController handles them.
+    LaunchedEffect(navController) {
+        val activity = context as? com.anisync.android.MainActivity ?: return@LaunchedEffect
+        activity.pendingDeepLink.filterNotNull().collect { intent ->
+            navController.handleDeepLink(intent)
+            activity.consumePendingDeepLink()
         }
     }
     val unreadNotificationCount by viewModel.unreadNotificationCount.collectAsStateWithLifecycle()

--- a/app/src/main/java/com/anisync/android/presentation/MainScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/MainScreen.kt
@@ -107,17 +107,12 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
     // Cold-launch restore: open on the tab the user last visited (Library/Discover/
     // Feed/Forum). Compose Navigation restores its own back stack across process
     // death, so this only governs a genuinely fresh start.
-    val startDestination: Any = remember(viewModel.startTabKey, viewModel.startOnProfile) {
-        if (viewModel.startOnProfile) {
-            // Just switched accounts — open the new account's profile.
-            Profile
-        } else {
-            when (viewModel.startTabKey) {
-                "discover" -> Discover
-                "feed" -> Feed
-                "forum" -> Forum
-                else -> Library
-            }
+    val startDestination: Any = remember(viewModel.startTabKey) {
+        when (viewModel.startTabKey) {
+            "discover" -> Discover
+            "feed" -> Feed
+            "forum" -> Forum
+            else -> Library
         }
     }
 

--- a/app/src/main/java/com/anisync/android/presentation/MainScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/MainScreen.kt
@@ -107,12 +107,17 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
     // Cold-launch restore: open on the tab the user last visited (Library/Discover/
     // Feed/Forum). Compose Navigation restores its own back stack across process
     // death, so this only governs a genuinely fresh start.
-    val startDestination: Any = remember(viewModel.startTabKey) {
-        when (viewModel.startTabKey) {
-            "discover" -> Discover
-            "feed" -> Feed
-            "forum" -> Forum
-            else -> Library
+    val startDestination: Any = remember(viewModel.startTabKey, viewModel.startOnProfile) {
+        if (viewModel.startOnProfile) {
+            // Just switched accounts — open the new account's profile.
+            Profile
+        } else {
+            when (viewModel.startTabKey) {
+                "discover" -> Discover
+                "feed" -> Feed
+                "forum" -> Forum
+                else -> Library
+            }
         }
     }
 

--- a/app/src/main/java/com/anisync/android/presentation/MainScreenViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/MainScreenViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.anisync.android.data.AppSettings
 import com.anisync.android.data.NavBarStyle
 import com.anisync.android.data.NotificationBadgeStore
+import com.anisync.android.data.account.AccountManager
 import com.anisync.android.presentation.components.alert.ToastManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.StateFlow
@@ -20,8 +21,16 @@ import javax.inject.Inject
 class MainScreenViewModel @Inject constructor(
     private val notificationBadgeStore: NotificationBadgeStore,
     private val appSettings: AppSettings,
+    accountManager: AccountManager,
     val toastManager: ToastManager
 ) : ViewModel() {
+
+    /**
+     * After an account switch the MainScreen subtree is rebuilt (session epoch > 0) — land on
+     * Profile so the user sees the account they just switched to. A genuinely fresh process
+     * (epoch 0) instead restores [startTabKey].
+     */
+    val startOnProfile: Boolean = accountManager.sessionEpoch.value > 0
 
     val unreadNotificationCount: StateFlow<Int> = notificationBadgeStore.unreadCount
 

--- a/app/src/main/java/com/anisync/android/presentation/MainScreenViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/MainScreenViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import com.anisync.android.data.AppSettings
 import com.anisync.android.data.NavBarStyle
 import com.anisync.android.data.NotificationBadgeStore
-import com.anisync.android.data.account.AccountManager
 import com.anisync.android.presentation.components.alert.ToastManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.StateFlow
@@ -21,16 +20,8 @@ import javax.inject.Inject
 class MainScreenViewModel @Inject constructor(
     private val notificationBadgeStore: NotificationBadgeStore,
     private val appSettings: AppSettings,
-    accountManager: AccountManager,
     val toastManager: ToastManager
 ) : ViewModel() {
-
-    /**
-     * After an account switch the MainScreen subtree is rebuilt (session epoch > 0) — land on
-     * Profile so the user sees the account they just switched to. A genuinely fresh process
-     * (epoch 0) instead restores [startTabKey].
-     */
-    val startOnProfile: Boolean = accountManager.sessionEpoch.value > 0
 
     val unreadNotificationCount: StateFlow<Int> = notificationBadgeStore.unreadCount
 

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsViewModel.kt
@@ -35,6 +35,7 @@ class MediaDetailsViewModel @Inject constructor(
     private val detailsRepository: DetailsRepository,
     private val libraryRepository: LibraryRepository,
     private val libraryDao: LibraryDao,
+    private val accountStore: com.anisync.android.data.account.AccountStore,
     private val appSettings: AppSettings,
     private val toastManager: com.anisync.android.presentation.components.alert.ToastManager,
     savedStateHandle: SavedStateHandle
@@ -156,7 +157,7 @@ class MediaDetailsViewModel @Inject constructor(
         viewModelScope.launch {
             val details = (uiState.value as? DetailsUiState.Success)?.details ?: return@launch
             
-            val existingEntry = libraryDao.getEntry(mediaId)
+            val existingEntry = libraryDao.getEntry(accountStore.activeAccount.value?.id ?: -1, mediaId)
             val draft = existingEntry?.toDomain() ?: LibraryEntry(
                 id = 0,
                 mediaId = details.id,

--- a/app/src/main/java/com/anisync/android/presentation/login/AniListAuth.kt
+++ b/app/src/main/java/com/anisync/android/presentation/login/AniListAuth.kt
@@ -1,0 +1,12 @@
+package com.anisync.android.presentation.login
+
+/**
+ * AniList OAuth entry point shared by the login screen and the account manager.
+ * Implicit grant — the browser redirects back to `anisync://auth#access_token=...&expires_in=...`,
+ * which [com.anisync.android.MainActivity] handles.
+ */
+object AniListAuth {
+    private const val CLIENT_ID = "32893"
+    const val AUTH_URL =
+        "https://anilist.co/api/v2/oauth/authorize?client_id=$CLIENT_ID&response_type=token"
+}

--- a/app/src/main/java/com/anisync/android/presentation/login/LoginScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/login/LoginScreen.kt
@@ -65,10 +65,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.anisync.android.R
 
-private const val CLIENT_ID = "32893"
-private const val AUTH_URL =
-    "https://anilist.co/api/v2/oauth/authorize?client_id=$CLIENT_ID&response_type=token"
-
 /**
  * The primary login screen for AniSync.
  *
@@ -132,7 +128,7 @@ fun LoginScreen() {
             ) {
                 BottomActionBar(
                     onClick = {
-                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(AUTH_URL))
+                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(AniListAuth.AUTH_URL))
                         context.startActivity(intent)
                     }
                 )

--- a/app/src/main/java/com/anisync/android/presentation/profile/ProfileContent.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/ProfileContent.kt
@@ -91,6 +91,8 @@ fun ProfileContent(
     onCommentClick: (threadId: Int, commentId: Int, threadTitle: String) -> Unit = { _, _, _ -> },
     onActivityClick: (Int) -> Unit = {},
     onLastReplyClick: (activityId: Int, replyId: Int) -> Unit = { _, _ -> },
+    showAccountSwitcher: Boolean = false,
+    onAccountSwitchClick: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -142,7 +144,9 @@ fun ProfileContent(
                             text = "${profile.name}\nhttps://anilist.co/user/${profile.name}"
                         )
                     }
-                }
+                },
+                showAccountSwitcher = showAccountSwitcher,
+                onAccountSwitchClick = onAccountSwitchClick
             )
         }
 

--- a/app/src/main/java/com/anisync/android/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/ProfileScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
+import android.content.Intent
+import android.net.Uri
 import android.os.SystemClock
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -16,10 +18,13 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -28,6 +33,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.anisync.android.R
 import com.anisync.android.presentation.components.ErrorState
 import com.anisync.android.presentation.components.richtext.RichTextInputScreen
+import com.anisync.android.presentation.login.AniListAuth
+import com.anisync.android.presentation.profile.components.AccountSwitcherSheet
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
@@ -51,6 +58,10 @@ fun ProfileScreen(
     viewModel: ProfileViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val accounts by viewModel.accounts.collectAsStateWithLifecycle()
+    val activeAccountId by viewModel.activeAccountId.collectAsStateWithLifecycle()
+    var showAccountSwitcherSheet by remember { mutableStateOf(false) }
 
     // Cooldown-gated ON_RESUME refresh. Notification badge no longer needs a
     // separate refresh — it rides on GetUserProfile via @include directive.
@@ -124,7 +135,9 @@ fun ProfileScreen(
                         onThreadClick = onThreadClick,
                         onCommentClick = onCommentClick,
                         onActivityClick = onActivityClick,
-                        onLastReplyClick = onLastReplyClick
+                        onLastReplyClick = onLastReplyClick,
+                        showAccountSwitcher = isOwnProfile && accounts.size > 1,
+                        onAccountSwitchClick = { showAccountSwitcherSheet = true }
                     )
                 }
 
@@ -159,6 +172,22 @@ fun ProfileScreen(
             onDismiss = {
                 viewModel.onAction(ProfileAction.SetEditProfileDialogVisible(false))
             }
+        )
+    }
+
+    if (showAccountSwitcherSheet) {
+        AccountSwitcherSheet(
+            accounts = accounts,
+            activeAccountId = activeAccountId,
+            onSwitch = { id ->
+                showAccountSwitcherSheet = false
+                viewModel.switchAccount(id)
+            },
+            onAddAccount = {
+                showAccountSwitcherSheet = false
+                context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(AniListAuth.AUTH_URL)))
+            },
+            onDismiss = { showAccountSwitcherSheet = false }
         )
     }
 }

--- a/app/src/main/java/com/anisync/android/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/ProfileViewModel.kt
@@ -62,7 +62,7 @@ class ProfileViewModel @Inject constructor(
     private val detailsRepository: com.anisync.android.domain.DetailsRepository,
     private val statisticsRepository: StatisticsRepository,
     private val activityRepository: ActivityRepository,
-    private val authRepository: com.anisync.android.data.AuthRepository,
+    private val accountManager: com.anisync.android.data.account.AccountManager,
     private val appSettings: AppSettings,
     private val notificationBadgeStore: NotificationBadgeStore,
     private val toastManager: ToastManager,
@@ -110,6 +110,20 @@ class ProfileViewModel @Inject constructor(
 
     // Settings from AppSettings (needed for display in profile)
     val titleLanguage: StateFlow<com.anisync.android.data.TitleLanguage> = appSettings.titleLanguage
+
+    // Multi-account quick-switch (own-profile header).
+    val accounts: StateFlow<List<com.anisync.android.data.account.Account>> = accountManager.accounts
+    val activeAccountId: StateFlow<Int?> = accountManager.activeAccount
+        .map { it?.id }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, accountManager.activeAccount.value?.id)
+
+    /**
+     * Switches the active account. The keyed MainScreen subtree rebuilds on the resulting session
+     * epoch bump, so no explicit screen reload is needed here.
+     */
+    fun switchAccount(id: Int) {
+        accountManager.switch(id)
+    }
 
     private data class ProfileUiLocalState(
         val selectedTab: ProfileTab = ProfileTab.OVERVIEW,
@@ -1385,7 +1399,7 @@ class ProfileViewModel @Inject constructor(
 
     fun logout(onComplete: () -> Unit) {
         viewModelScope.launch {
-            authRepository.logout()
+            accountManager.logoutActive()
             onComplete()
         }
     }

--- a/app/src/main/java/com/anisync/android/presentation/profile/components/AccountSwitcherSheet.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/components/AccountSwitcherSheet.kt
@@ -23,14 +23,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import coil.compose.AsyncImage
 import com.anisync.android.R
 import com.anisync.android.data.account.Account
+import com.anisync.android.presentation.components.UserAvatar
 
 /**
  * Quick account switcher shown from the own-profile header. Lists every signed-in account; tapping a
@@ -116,30 +114,11 @@ private fun SwitcherRow(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        Box(
-            modifier = Modifier
-                .size(40.dp)
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.primaryContainer),
-            contentAlignment = Alignment.Center
-        ) {
-            val avatarUrl = account.avatarUrl
-            if (avatarUrl != null) {
-                AsyncImage(
-                    model = avatarUrl,
-                    contentDescription = null,
-                    modifier = Modifier.size(40.dp).clip(CircleShape),
-                    contentScale = ContentScale.Crop
-                )
-            } else {
-                Text(
-                    text = account.name.firstOrNull()?.uppercase() ?: "?",
-                    fontSize = 18.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-            }
-        }
+        UserAvatar(
+            url = account.avatarUrl,
+            contentDescription = null,
+            size = 40.dp
+        )
 
         Column(modifier = Modifier.weight(1f)) {
             Text(

--- a/app/src/main/java/com/anisync/android/presentation/profile/components/AccountSwitcherSheet.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/components/AccountSwitcherSheet.kt
@@ -1,0 +1,167 @@
+package com.anisync.android.presentation.profile.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.outlined.PersonAddAlt
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.anisync.android.R
+import com.anisync.android.data.account.Account
+
+/**
+ * Quick account switcher shown from the own-profile header. Lists every signed-in account; tapping a
+ * non-active one switches to it. "Add account" launches the OAuth flow.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AccountSwitcherSheet(
+    accounts: List<Account>,
+    activeAccountId: Int?,
+    onSwitch: (Int) -> Unit,
+    onAddAccount: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss, modifier = modifier) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.account_switch),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.padding(start = 4.dp, bottom = 8.dp)
+            )
+
+            accounts.forEach { account ->
+                SwitcherRow(
+                    account = account,
+                    isActive = account.id == activeAccountId,
+                    onClick = { if (account.id != activeAccountId) onSwitch(account.id) }
+                )
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(12.dp))
+                    .clickable(onClick = onAddAccount)
+                    .padding(vertical = 12.dp, horizontal = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.PersonAddAlt,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.account_add),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SwitcherRow(
+    account: Account,
+    isActive: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .padding(vertical = 8.dp, horizontal = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primaryContainer),
+            contentAlignment = Alignment.Center
+        ) {
+            val avatarUrl = account.avatarUrl
+            if (avatarUrl != null) {
+                AsyncImage(
+                    model = avatarUrl,
+                    contentDescription = null,
+                    modifier = Modifier.size(40.dp).clip(CircleShape),
+                    contentScale = ContentScale.Crop
+                )
+            } else {
+                Text(
+                    text = account.name.firstOrNull()?.uppercase() ?: "?",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
+        }
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = account.name.ifBlank { stringResource(R.string.settings_account_unknown) },
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = if (isActive) FontWeight.SemiBold else FontWeight.Normal
+            )
+            if (account.isExpired) {
+                Text(
+                    text = stringResource(R.string.account_expired),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+
+        if (isActive) {
+            Icon(
+                imageVector = Icons.Filled.Check,
+                contentDescription = stringResource(R.string.account_active),
+                tint = MaterialTheme.colorScheme.primary
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/anisync/android/presentation/profile/components/ProfileTopSection.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/components/ProfileTopSection.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material.icons.filled.PersonRemove
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.FilledTonalIconButton
@@ -103,6 +104,8 @@ fun ProfileTopSection(
     unreadNotificationCount: Int = 0,
     topActionIcon: ImageVector = Icons.Default.Settings,
     onTopActionClick: () -> Unit = onSettingsClick,
+    showAccountSwitcher: Boolean = false,
+    onAccountSwitchClick: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
 
@@ -350,6 +353,19 @@ fun ProfileTopSection(
                     .padding(bottom = 12.dp)
             ) {
                 if (isOwnProfile) {
+                    if (showAccountSwitcher) {
+                        FilledTonalIconButton(
+                            onClick = onAccountSwitchClick,
+                            shape = RoundedCornerShape(16.dp),
+                            modifier = Modifier.size(48.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.SwapHoriz,
+                                contentDescription = stringResource(R.string.account_switch),
+                                modifier = Modifier.size(20.dp)
+                            )
+                        }
+                    }
                     FilledTonalIconButton(
                         onClick = onEditProfileClick,
                         shape = RoundedCornerShape(16.dp),

--- a/app/src/main/java/com/anisync/android/presentation/settings/AccountScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AccountScreen.kt
@@ -4,23 +4,36 @@ import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.outlined.PersonAddAlt
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -36,24 +49,32 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.anisync.android.R
+import com.anisync.android.data.account.Account
+import com.anisync.android.presentation.login.AniListAuth
 
 /**
- * Account settings screen.
- * Displays user profile information and logout option.
+ * Account settings screen: lists every signed-in account with add / switch / remove / re-auth,
+ * plus logout for the active account. Switching or removing the active account recreates the
+ * activity so all ViewModels rebuild against the new (reset) account state.
  */
 @Composable
 fun AccountScreen(
     onLogout: () -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: SettingsViewModel = hiltViewModel()
+    viewModel: AccountViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val userProfile = uiState.userProfile
-    var showLogoutDialog by rememberSaveable { mutableStateOf(false) }
+    val accounts by viewModel.accounts.collectAsStateWithLifecycle()
+    val activeAccount by viewModel.activeAccount.collectAsStateWithLifecycle()
 
-    // Logout confirmation dialog
+    var showLogoutDialog by rememberSaveable { mutableStateOf(false) }
+    var accountToRemove by remember { mutableStateOf<Account?>(null) }
+
+    fun launchOAuth() {
+        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(AniListAuth.AUTH_URL)))
+    }
+
     if (showLogoutDialog) {
         AlertDialog(
             onDismissRequest = { showLogoutDialog = false },
@@ -63,7 +84,7 @@ fun AccountScreen(
                 TextButton(
                     onClick = {
                         showLogoutDialog = false
-                        viewModel.logout { onLogout() }
+                        viewModel.logoutActive()
                     }
                 ) {
                     Text(
@@ -80,83 +101,86 @@ fun AccountScreen(
         )
     }
 
+    accountToRemove?.let { target ->
+        AlertDialog(
+            onDismissRequest = { accountToRemove = null },
+            title = { Text(stringResource(R.string.account_remove_dialog_title)) },
+            text = {
+                Text(stringResource(R.string.account_remove_dialog_message, target.name.ifBlank { "?" }))
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        accountToRemove = null
+                        viewModel.remove(target.id)
+                    }
+                ) {
+                    Text(
+                        stringResource(R.string.account_remove),
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { accountToRemove = null }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+
     SettingsScreenScaffold(
         title = stringResource(R.string.settings_account),
         onBackClick = onBackClick,
         modifier = modifier
     ) {
-        // User profile section
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 32.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            // Avatar
-            Box(
-                modifier = Modifier
-                    .size(96.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.primaryContainer),
-                contentAlignment = Alignment.Center
-            ) {
-                val avatarUrl = userProfile?.avatarUrl
-                if (avatarUrl != null) {
-                    AsyncImage(
-                        model = avatarUrl,
-                        contentDescription = stringResource(R.string.content_description_profile_avatar),
-                        modifier = Modifier
-                            .size(96.dp)
-                            .clip(CircleShape),
-                        contentScale = ContentScale.Crop
-                    )
-                } else {
-                    Text(
-                        text = userProfile?.name?.firstOrNull()?.uppercase() ?: "?",
-                        fontSize = 40.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
-                    )
-                }
+        SettingsGroup {
+            accounts.forEach { account ->
+                AccountRow(
+                    account = account,
+                    isActive = account.id == activeAccount?.id,
+                    onSwitch = {
+                        if (account.isExpired) launchOAuth()
+                        else viewModel.switch(account.id)
+                    },
+                    onReauthenticate = ::launchOAuth,
+                    onRemove = { accountToRemove = account }
+                )
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
-
-            // Username
-            Text(
-                text = userProfile?.name ?: stringResource(R.string.settings_account_unknown),
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold
-            )
-
-            // AniList indicator
-            Text(
-                text = stringResource(R.string.settings_account_anilist),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-
-        // Account actions
-        SettingsGroup {
             SettingsItem(
-                title = stringResource(R.string.settings_view_on_anilist),
-                subtitle = stringResource(R.string.settings_view_on_anilist_desc),
-                onClick = {
-                    val username = userProfile?.name
-                    if (username != null) {
-                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://anilist.co/user/$username"))
-                        context.startActivity(intent)
-                    }
-                }
+                title = stringResource(R.string.account_add),
+                subtitle = stringResource(R.string.account_add_desc),
+                icon = Icons.Outlined.PersonAddAlt,
+                onClick = ::launchOAuth
             )
         }
 
-        Spacer(modifier = Modifier.height(32.dp))
+        // Active-account actions
+        val active = activeAccount
+        if (active != null && active.name.isNotBlank()) {
+            Spacer(modifier = Modifier.height(16.dp))
+            SettingsGroup {
+                SettingsItem(
+                    title = stringResource(R.string.settings_view_on_anilist),
+                    subtitle = stringResource(R.string.settings_view_on_anilist_desc),
+                    onClick = {
+                        context.startActivity(
+                            Intent(
+                                Intent.ACTION_VIEW,
+                                Uri.parse("https://anilist.co/user/${active.name}")
+                            )
+                        )
+                    }
+                )
+            }
+        }
 
-        // Logout button
+        Spacer(modifier = Modifier.height(24.dp))
+
         OutlinedButton(
             onClick = { showLogoutDialog = true },
+            enabled = activeAccount != null,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(52.dp),
@@ -170,12 +194,134 @@ fun AccountScreen(
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        // Warning text
         Text(
             text = stringResource(R.string.settings_logout_warning),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(horizontal = 4.dp)
         )
+    }
+}
+
+@Composable
+private fun AccountRow(
+    account: Account,
+    isActive: Boolean,
+    onSwitch: () -> Unit,
+    onReauthenticate: () -> Unit,
+    onRemove: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var menuExpanded by remember { mutableStateOf(false) }
+
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .clickable(enabled = !isActive, onClick = onSwitch)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(12.dp).fillMaxWidth()
+        ) {
+            // Avatar
+            Box(
+                modifier = Modifier
+                    .size(44.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primaryContainer),
+                contentAlignment = Alignment.Center
+            ) {
+                val avatarUrl = account.avatarUrl
+                if (avatarUrl != null) {
+                    AsyncImage(
+                        model = avatarUrl,
+                        contentDescription = null,
+                        modifier = Modifier.size(44.dp).clip(CircleShape),
+                        contentScale = ContentScale.Crop
+                    )
+                } else {
+                    Text(
+                        text = account.name.firstOrNull()?.uppercase() ?: "?",
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
+            }
+
+            Column(
+                modifier = Modifier.weight(1f).padding(horizontal = 12.dp)
+            ) {
+                Text(
+                    text = account.name.ifBlank { stringResource(R.string.settings_account_unknown) },
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                val status = when {
+                    account.isExpired -> stringResource(R.string.account_expired)
+                    isActive -> stringResource(R.string.account_active)
+                    else -> stringResource(R.string.settings_account_anilist)
+                }
+                Text(
+                    text = status,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (account.isExpired) MaterialTheme.colorScheme.error
+                    else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            if (isActive) {
+                Icon(
+                    imageVector = Icons.Filled.Check,
+                    contentDescription = stringResource(R.string.account_active),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            } else {
+                Box {
+                    IconButton(onClick = { menuExpanded = true }) {
+                        Icon(
+                            imageVector = Icons.Filled.MoreVert,
+                            contentDescription = null
+                        )
+                    }
+                    DropdownMenu(
+                        expanded = menuExpanded,
+                        onDismissRequest = { menuExpanded = false }
+                    ) {
+                        if (account.isExpired) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.account_reauthenticate)) },
+                                onClick = {
+                                    menuExpanded = false
+                                    onReauthenticate()
+                                }
+                            )
+                        } else {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.account_switch)) },
+                                onClick = {
+                                    menuExpanded = false
+                                    onSwitch()
+                                }
+                            )
+                        }
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    stringResource(R.string.account_remove),
+                                    color = MaterialTheme.colorScheme.error
+                                )
+                            },
+                            onClick = {
+                                menuExpanded = false
+                                onRemove()
+                            }
+                        )
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/anisync/android/presentation/settings/AccountScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AccountScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -47,9 +46,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil.compose.AsyncImage
 import com.anisync.android.R
 import com.anisync.android.data.account.Account
+import com.anisync.android.presentation.components.UserAvatar
 import com.anisync.android.presentation.login.AniListAuth
 
 /**
@@ -226,30 +225,11 @@ private fun AccountRow(
             modifier = Modifier.padding(12.dp).fillMaxWidth()
         ) {
             // Avatar
-            Box(
-                modifier = Modifier
-                    .size(44.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.primaryContainer),
-                contentAlignment = Alignment.Center
-            ) {
-                val avatarUrl = account.avatarUrl
-                if (avatarUrl != null) {
-                    AsyncImage(
-                        model = avatarUrl,
-                        contentDescription = null,
-                        modifier = Modifier.size(44.dp).clip(CircleShape),
-                        contentScale = ContentScale.Crop
-                    )
-                } else {
-                    Text(
-                        text = account.name.firstOrNull()?.uppercase() ?: "?",
-                        fontSize = 20.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
-                    )
-                }
-            }
+            UserAvatar(
+                url = account.avatarUrl,
+                contentDescription = null,
+                size = 44.dp
+            )
 
             Column(
                 modifier = Modifier.weight(1f).padding(horizontal = 12.dp)

--- a/app/src/main/java/com/anisync/android/presentation/settings/AccountViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AccountViewModel.kt
@@ -1,0 +1,28 @@
+package com.anisync.android.presentation.settings
+
+import androidx.lifecycle.ViewModel
+import com.anisync.android.data.account.Account
+import com.anisync.android.data.account.AccountManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+/**
+ * Drives the account list (add / switch / remove / logout). All mutations are fire-and-forget into
+ * [AccountManager], which runs them on its own scope and rebuilds the UI via the session epoch — so
+ * this ViewModel being disposed by that rebuild can't interrupt the operation.
+ */
+@HiltViewModel
+class AccountViewModel @Inject constructor(
+    private val accountManager: AccountManager,
+) : ViewModel() {
+
+    val accounts: StateFlow<List<Account>> = accountManager.accounts
+    val activeAccount: StateFlow<Account?> = accountManager.activeAccount
+
+    fun switch(id: Int) = accountManager.switch(id)
+
+    fun remove(id: Int) = accountManager.removeAccount(id)
+
+    fun logoutActive() = accountManager.logoutActive()
+}

--- a/app/src/main/java/com/anisync/android/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/SettingsViewModel.kt
@@ -9,10 +9,10 @@ import androidx.lifecycle.viewModelScope
 import com.anisync.android.R
 import com.anisync.android.data.AppLocale
 import com.anisync.android.data.AppSettings
-import com.anisync.android.data.AuthRepository
 import com.anisync.android.data.CoverQuality
 import com.anisync.android.data.NavBarStyle
 import com.anisync.android.data.NotificationPreferences
+import com.anisync.android.data.account.AccountManager
 import com.anisync.android.data.update.UpdateCheckResult
 import com.anisync.android.data.update.UpdateManager
 import com.anisync.android.domain.GetProfileUseCase
@@ -56,7 +56,7 @@ class SettingsViewModel @Inject constructor(
     private val notificationPreferences: NotificationPreferences,
     private val notificationScheduler: NotificationScheduler,
     private val notificationDebugService: NotificationDebugService,
-    private val authRepository: AuthRepository,
+    private val accountManager: AccountManager,
     private val updateManager: UpdateManager,
     getProfileUseCase: GetProfileUseCase,
     private val toastManager: ToastManager,
@@ -431,7 +431,7 @@ class SettingsViewModel @Inject constructor(
 
     fun logout(onComplete: () -> Unit) {
         viewModelScope.launch {
-            authRepository.logout()
+            accountManager.logoutActive()
             onComplete()
         }
     }

--- a/app/src/main/java/com/anisync/android/worker/AiringScheduleWorker.kt
+++ b/app/src/main/java/com/anisync/android/worker/AiringScheduleWorker.kt
@@ -33,6 +33,7 @@ class AiringScheduleWorker @AssistedInject constructor(
     private val apolloClient: ApolloClient,
     private val airingScheduleDao: AiringScheduleDao,
     private val libraryDao: LibraryDao,
+    private val accountStore: com.anisync.android.data.account.AccountStore,
     private val appSettings: AppSettings
 ) : CoroutineWorker(appContext, workerParams) {
 
@@ -97,7 +98,7 @@ class AiringScheduleWorker @AssistedInject constructor(
                     val mId = media.id ?: return@mapNotNull null
 
                     // Check if user is actively watching this anime (only CURRENT status, not PLANNING)
-                    val libraryEntry = libraryDao.getEntry(mId)
+                    val libraryEntry = libraryDao.getEntry(accountStore.activeAccount.value?.id ?: -1, mId)
                     val isWatching = libraryEntry?.status == LibraryStatus.CURRENT
 
                     val streamingSeriesUrl = selectStreamingSeriesUrl(

--- a/app/src/main/java/com/anisync/android/worker/EpisodeUpdateWorker.kt
+++ b/app/src/main/java/com/anisync/android/worker/EpisodeUpdateWorker.kt
@@ -15,6 +15,7 @@ class EpisodeUpdateWorker @AssistedInject constructor(
     @Assisted val appContext: Context,
     @Assisted workerParams: WorkerParameters,
     private val libraryDao: LibraryDao,
+    private val accountStore: com.anisync.android.data.account.AccountStore,
     private val libraryRepository: com.anisync.android.domain.LibraryRepository
 ) : CoroutineWorker(appContext, workerParams) {
 
@@ -24,7 +25,8 @@ class EpisodeUpdateWorker @AssistedInject constructor(
         if (mediaId == -1) return Result.failure()
 
         try {
-            val entry = libraryDao.getEntry(mediaId) ?: return Result.failure()
+            val ownerId = accountStore.activeAccount.value?.id ?: -1
+            val entry = libraryDao.getEntry(ownerId, mediaId) ?: return Result.failure()
             // Update progress
             val newProgress = (entry.progress + amount).coerceAtLeast(0)
             

--- a/app/src/main/java/com/anisync/android/worker/NotificationWorker.kt
+++ b/app/src/main/java/com/anisync/android/worker/NotificationWorker.kt
@@ -50,8 +50,12 @@ class NotificationWorker @AssistedInject constructor(
     private val libraryDao: LibraryDao,
     private val imageLoader: ImageLoader,
     private val authRepository: AuthRepository,
+    private val accountStore: com.anisync.android.data.account.AccountStore,
     private val notificationPreferences: com.anisync.android.data.NotificationPreferences
 ) : CoroutineWorker(appContext, workerParams) {
+
+    /** Active account's id, used to read only this account's library entries. */
+    private fun ownerId(): Int = accountStore.activeAccount.value?.id ?: -1
 
     companion object {
         private const val TAG = "NotificationWorker"
@@ -185,7 +189,7 @@ class NotificationWorker @AssistedInject constructor(
         }
 
         // 2. Mark all current planning items as "already notified"
-        val planningEntries = libraryDao.getByType(MediaType.ANIME)
+        val planningEntries = libraryDao.getByType(ownerId(), MediaType.ANIME)
             .filter { it.status == LibraryStatus.PLANNING }
         val planningMediaIds = planningEntries.map { it.mediaId }
 
@@ -217,7 +221,7 @@ class NotificationWorker @AssistedInject constructor(
         // Get planning list media IDs to exclude Episode 1 notifications for them
         // (those are handled by checkPlanningFirstEpisodes with "Add to Watching" action)
         val planningMediaIds = if (notificationPreferences.planningEnabled.value) {
-            libraryDao.getByType(MediaType.ANIME)
+            libraryDao.getByType(ownerId(), MediaType.ANIME)
                 .filter { it.status == LibraryStatus.PLANNING }
                 .map { it.mediaId }
                 .toSet()
@@ -570,7 +574,7 @@ class NotificationWorker @AssistedInject constructor(
      * - 2 hours before: "Episode 1 is airing in 2 hours"
      */
     private suspend fun checkUpcomingPlanningEpisodes() {
-        val planningEntries = libraryDao.getByType(MediaType.ANIME)
+        val planningEntries = libraryDao.getByType(ownerId(), MediaType.ANIME)
             .filter { it.status == LibraryStatus.PLANNING }
 
         if (planningEntries.isEmpty()) return
@@ -626,7 +630,7 @@ class NotificationWorker @AssistedInject constructor(
      * to prevent duplicate alerts.
      */
     private suspend fun checkPlanningFirstEpisodes() {
-        val planningEntries = libraryDao.getByType(MediaType.ANIME)
+        val planningEntries = libraryDao.getByType(ownerId(), MediaType.ANIME)
             .filter { it.status == LibraryStatus.PLANNING }
 
         val mediaIds = planningEntries.map { it.mediaId }

--- a/app/src/main/java/com/anisync/android/worker/NotificationWorker.kt
+++ b/app/src/main/java/com/anisync/android/worker/NotificationWorker.kt
@@ -17,8 +17,9 @@ import coil.ImageLoader
 import coil.request.ImageRequest
 import coil.request.SuccessResult
 import com.anisync.android.R
-import com.anisync.android.data.AuthRepository
+import com.anisync.android.data.account.AccountStore
 import com.anisync.android.data.local.dao.LibraryDao
+import com.anisync.android.data.util.ApiError
 import com.anisync.android.domain.ActivityLikeNotification
 import com.anisync.android.domain.ActivityMentionNotification
 import com.anisync.android.domain.ActivityMessageNotification
@@ -49,19 +50,22 @@ class NotificationWorker @AssistedInject constructor(
     private val preferencesRepository: PreferencesRepository,
     private val libraryDao: LibraryDao,
     private val imageLoader: ImageLoader,
-    private val authRepository: AuthRepository,
-    private val accountStore: com.anisync.android.data.account.AccountStore,
+    private val accountStore: AccountStore,
     private val notificationPreferences: com.anisync.android.data.NotificationPreferences
 ) : CoroutineWorker(appContext, workerParams) {
 
-    /** Active account's id, used to read only this account's library entries. */
-    private fun ownerId(): Int = accountStore.activeAccount.value?.id ?: -1
+    /** Per-iteration account context threaded through the checks + notification builders. */
+    private data class AcctCtx(
+        val id: Int,
+        val token: String,
+        val name: String,
+        val showLabel: Boolean,
+    )
 
     companion object {
         private const val TAG = "NotificationWorker"
-        private const val MAX_RETRY_ATTEMPTS = 3
         private const val MAX_NOTIFICATION_PAGES = 3
-        
+
         // Two-tier upcoming notification system
         private const val ADVANCE_NOTICE_HOURS = 12 // First notification: "Episode 1 airs tomorrow at X"
         private const val IMMINENT_NOTICE_HOURS = 2  // Second notification: "Episode 1 airs in 2 hours"
@@ -79,183 +83,145 @@ class NotificationWorker @AssistedInject constructor(
     }
 
     override suspend fun doWork(): androidx.work.ListenableWorker.Result {
-        // Skip if user is not authenticated
-        if (authRepository.getToken() == null) {
-            Log.d(TAG, "Skipping notification check - user not authenticated")
+        // Poll every signed-in account that still has a (non-expired) token.
+        val accounts = accountStore.accounts.value.filterNot { it.isExpired }
+        if (accounts.isEmpty()) {
+            Log.d(TAG, "No usable accounts — skipping notification check")
             return androidx.work.ListenableWorker.Result.success()
         }
 
-        return try {
-            val isFirstRun = !preferencesRepository.hasNotificationsEverRun()
+        val activeId = accountStore.activeAccount.value?.id
+        val showLabel = accounts.size > 1
 
-            if (isFirstRun) {
-                // On first run, establish baseline without showing any notifications.
-                // This prevents spamming the user with all historical notifications.
-                performBaselineSync()
-                preferencesRepository.markNotificationsHaveRun()
-                Log.d(TAG, "First run: Baseline sync completed. Future runs will notify.")
-            } else {
-                // Normal run: check and notify based on granular settings
+        val anySocialEnabled = notificationPreferences.threadCommentReplyEnabled.value ||
+            notificationPreferences.threadSubscribedEnabled.value ||
+            notificationPreferences.threadCommentMentionEnabled.value ||
+            notificationPreferences.threadLikeEnabled.value ||
+            notificationPreferences.threadCommentLikeEnabled.value ||
+            notificationPreferences.activityReplyEnabled.value ||
+            notificationPreferences.activityMentionEnabled.value ||
+            notificationPreferences.activityLikeEnabled.value ||
+            notificationPreferences.activityMessageEnabled.value
+
+        for (account in accounts) {
+            val ctx = AcctCtx(account.id, account.token, account.name, showLabel)
+            val isActive = account.id == activeId
+            try {
+                if (!preferencesRepository.hasNotificationsEverRun(ctx.id)) {
+                    // First time we see this account — establish baselines silently.
+                    performBaselineSync(ctx, isActive)
+                    preferencesRepository.markNotificationsHaveRun(ctx.id)
+                    Log.d(TAG, "Baseline sync done for ${ctx.name}")
+                    continue
+                }
+
+                // AniList feed (airing + social) — works for any account via its token.
                 if (notificationPreferences.watchingEnabled.value) {
-                    checkWatchingListNotifications()
-                } else {
-                    Log.d(TAG, "Skipping watching list notifications - disabled by user")
+                    val planningMediaIds = if (isActive && notificationPreferences.planningEnabled.value) {
+                        libraryDao.getByType(ctx.id, MediaType.ANIME)
+                            .filter { it.status == LibraryStatus.PLANNING }
+                            .map { it.mediaId }
+                            .toSet()
+                    } else {
+                        emptySet()
+                    }
+                    checkWatchingListNotifications(ctx, planningMediaIds)
                 }
-                
-                if (notificationPreferences.upcomingEnabled.value) {
-                    checkUpcomingPlanningEpisodes()
-                } else {
-                    Log.d(TAG, "Skipping upcoming notifications - disabled by user")
-                }
-                
-                if (notificationPreferences.planningEnabled.value) {
-                    checkPlanningFirstEpisodes()
-                } else {
-                    Log.d(TAG, "Skipping planning notifications - disabled by user")
-                }
-
-                // Social/Forum notifications — check if ANY forum or activity type is enabled
-                val anySocialEnabled = notificationPreferences.threadCommentReplyEnabled.value ||
-                    notificationPreferences.threadSubscribedEnabled.value ||
-                    notificationPreferences.threadCommentMentionEnabled.value ||
-                    notificationPreferences.threadLikeEnabled.value ||
-                    notificationPreferences.threadCommentLikeEnabled.value ||
-                    notificationPreferences.activityReplyEnabled.value ||
-                    notificationPreferences.activityMentionEnabled.value ||
-                    notificationPreferences.activityLikeEnabled.value ||
-                    notificationPreferences.activityMessageEnabled.value
-
                 if (anySocialEnabled) {
-                    checkSocialNotifications()
-                } else {
-                    Log.d(TAG, "Skipping social notifications - all forum/activity types disabled")
+                    checkSocialNotifications(ctx)
                 }
-            }
 
-            androidx.work.ListenableWorker.Result.success()
-        } catch (e: com.anisync.android.data.util.ApiError.RateLimited) {
-            Log.w(TAG, "Rate limited (wait ${e.retryAfterSeconds}s). Scheduling retry (attempt ${runAttemptCount + 1})")
-            androidx.work.ListenableWorker.Result.retry()
-        } catch (e: com.anisync.android.data.util.ApiError.Unauthorized) {
-            Log.w(TAG, "Unauthorized — session expired, skipping notification check")
-            androidx.work.ListenableWorker.Result.failure()
-        } catch (e: com.anisync.android.data.util.ApiError.ServerError) {
-            Log.e(TAG, "Server error ${e.statusCode} on attempt $runAttemptCount")
-            if (runAttemptCount < MAX_RETRY_ATTEMPTS) {
-                androidx.work.ListenableWorker.Result.retry()
-            } else {
-                androidx.work.ListenableWorker.Result.failure()
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Worker failed on attempt $runAttemptCount", e)
-            
-            val isRecoverable = e is java.net.UnknownHostException ||
-                e is java.net.SocketTimeoutException ||
-                e is java.io.IOException
-            
-            if (isRecoverable && runAttemptCount < MAX_RETRY_ATTEMPTS) {
-                Log.d(TAG, "Scheduling retry (attempt ${runAttemptCount + 1})")
-                androidx.work.ListenableWorker.Result.retry()
-            } else {
-                Log.w(TAG, "Worker failed permanently after $runAttemptCount attempts")
-                androidx.work.ListenableWorker.Result.failure()
+                // Planning / upcoming "Episode 1" alerts depend on the locally-cached library,
+                // so they only run for the active account.
+                if (isActive) {
+                    if (notificationPreferences.upcomingEnabled.value) checkUpcomingPlanningEpisodes(ctx)
+                    if (notificationPreferences.planningEnabled.value) checkPlanningFirstEpisodes(ctx)
+                }
+            } catch (e: ApiError.RateLimited) {
+                // Back off the whole worker; per-account dedup makes the retry idempotent.
+                Log.w(TAG, "Rate limited on ${ctx.name} (wait ${e.retryAfterSeconds}s) — retrying worker")
+                return androidx.work.ListenableWorker.Result.retry()
+            } catch (e: ApiError.Unauthorized) {
+                // This account's token expired/revoked — flag only it; keep polling the rest.
+                Log.w(TAG, "Unauthorized for ${ctx.name} — marking account expired")
+                accountStore.markExpired(ctx.id)
+            } catch (e: Exception) {
+                // One account failing must not abort the others.
+                Log.e(TAG, "Notification check failed for ${ctx.name}", e)
             }
         }
+
+        return androidx.work.ListenableWorker.Result.success()
     }
 
     /**
-     * On first run, fetch the current state and set baselines WITHOUT notifying.
-     * This prevents spamming the user with all historical notifications.
+     * On an account's first run, fetch current state and set baselines WITHOUT notifying, so the
+     * user isn't spammed with that account's historical notifications. Planning/upcoming baseline
+     * runs only for the active account (it uses the locally-cached library).
      */
-    private suspend fun performBaselineSync() {
-        // 1. Set baseline for Watching notifications
-        val repoResult = notificationRepository.getNotifications(1)
+    private suspend fun performBaselineSync(ctx: AcctCtx, isActive: Boolean) {
+        val repoResult = notificationRepository.getNotifications(1, ctx.token)
         if (repoResult is DomainResult.Success) {
             val allNotifications = repoResult.data
             val latestAiringId = allNotifications
                 .filterIsInstance<AiringNotification>()
                 .maxOfOrNull { it.id } ?: 0
-            if (latestAiringId > 0) {
-                preferencesRepository.setLastNotifiedId(latestAiringId)
-                Log.d(TAG, "Baseline: Set lastNotifiedId to $latestAiringId")
-            }
+            if (latestAiringId > 0) preferencesRepository.setLastNotifiedId(ctx.id, latestAiringId)
             val latestSocialId = allNotifications
                 .filter { isSocialNotification(it) }
                 .maxOfOrNull { it.id } ?: 0
-            if (latestSocialId > 0) {
-                preferencesRepository.setLastSocialNotifiedId(latestSocialId)
-                Log.d(TAG, "Baseline: Set lastSocialNotifiedId to $latestSocialId")
-            }
+            if (latestSocialId > 0) preferencesRepository.setLastSocialNotifiedId(ctx.id, latestSocialId)
         }
 
-        // 2. Mark all current planning items as "already notified"
-        val planningEntries = libraryDao.getByType(ownerId(), MediaType.ANIME)
+        if (!isActive) return
+
+        val planningEntries = libraryDao.getByType(ctx.id, MediaType.ANIME)
             .filter { it.status == LibraryStatus.PLANNING }
         val planningMediaIds = planningEntries.map { it.mediaId }
 
-        // Mark all planning items that have already aired Ep1 as notified
         val airedResult = notificationRepository.getFirstEpisodeAirings(planningMediaIds)
         if (airedResult is DomainResult.Success) {
             for (airing in airedResult.data) {
-                preferencesRepository.markPlanningMediaAsNotified(airing.mediaId)
+                preferencesRepository.markPlanningMediaAsNotified(ctx.id, airing.mediaId)
             }
-            Log.d(TAG, "Baseline: Marked ${airedResult.data.size} planning items as already notified")
         }
-
-        // Mark all upcoming items as notified (so we don't alert about already-upcoming shows)
         val upcomingResult = notificationRepository.getUpcomingFirstEpisodes(planningMediaIds, ADVANCE_NOTICE_HOURS)
         if (upcomingResult is DomainResult.Success) {
             for (airing in upcomingResult.data) {
-                preferencesRepository.markUpcomingAiringNotified(airing.id)
+                preferencesRepository.markUpcomingAiringNotified(ctx.id, airing.id)
             }
-            Log.d(TAG, "Baseline: Marked ${upcomingResult.data.size} upcoming episodes as already notified")
         }
     }
 
-    private suspend fun checkWatchingListNotifications() {
+    private suspend fun checkWatchingListNotifications(ctx: AcctCtx, planningMediaIds: Set<Int>) {
         val allNewAiring = mutableListOf<AiringNotification>()
-        val lastNotifiedId = preferencesRepository.getLastNotifiedId()
+        val lastNotifiedId = preferencesRepository.getLastNotifiedId(ctx.id)
         var currentPage = 1
         var hasMore = true
-        
-        // Get planning list media IDs to exclude Episode 1 notifications for them
-        // (those are handled by checkPlanningFirstEpisodes with "Add to Watching" action)
-        val planningMediaIds = if (notificationPreferences.planningEnabled.value) {
-            libraryDao.getByType(ownerId(), MediaType.ANIME)
-                .filter { it.status == LibraryStatus.PLANNING }
-                .map { it.mediaId }
-                .toSet()
-        } else {
-            emptySet()
-        }
 
         while (hasMore && currentPage <= MAX_NOTIFICATION_PAGES) {
-            val repoResult = notificationRepository.getNotifications(currentPage)
-            
+            val repoResult = notificationRepository.getNotifications(currentPage, ctx.token)
+
             when (repoResult) {
                 is DomainResult.Success -> {
                     val notifications = repoResult.data
-                    
+
                     val newOnThisPage = notifications
                         .filterIsInstance<AiringNotification>()
                         .filter { it.id > lastNotifiedId }
                         // Skip Episode 1 for Planning items (handled by checkPlanningFirstEpisodes)
                         .filter { notification ->
-                            val isEpisode1ForPlanning = notification.episode == 1 && 
+                            val isEpisode1ForPlanning = notification.episode == 1 &&
                                 notification.media?.id in planningMediaIds
                             !isEpisode1ForPlanning
                         }
-                    
-                    // Check if we've passed all new airing notifications on this page
+
                     val allAiringOnPage = notifications.filterIsInstance<AiringNotification>()
                     val hasOlderAiring = allAiringOnPage.any { it.id <= lastNotifiedId }
 
                     if (newOnThisPage.isEmpty() && hasOlderAiring) {
-                        // All airing notifications on this page are old
                         hasMore = false
                     } else if (newOnThisPage.isEmpty() && allAiringOnPage.isEmpty()) {
-                        // No airing notifications on this page at all (e.g. only thread notifications)
-                        // Continue to next page to find airing notifications
                         currentPage++
                         if (notifications.size < 20) hasMore = false
                     } else {
@@ -265,22 +231,16 @@ class NotificationWorker @AssistedInject constructor(
                     }
                 }
                 is DomainResult.Error -> {
-                    Log.e(TAG, "Failed to fetch notifications page $currentPage: ${repoResult.message}", repoResult.exception)
+                    Log.e(TAG, "Failed to fetch notifications page $currentPage for ${ctx.name}: ${repoResult.message}", repoResult.exception)
                     hasMore = false
                 }
             }
         }
-        
+
         if (allNewAiring.isNotEmpty()) {
             val sortedAiring = allNewAiring.sortedBy { it.id }
 
-            // Apply user-configured streaming delay. AniList stamps AiringNotification.createdAt
-            // at the official airing moment, so an episode is "due" once
-            // now >= createdAt + delay. Defer anything not yet due to the next worker run.
-            //
-            // To keep dedup correct, never advance lastNotifiedId past a deferred id —
-            // a deferred id with a smaller value than an already-due id forces us to leave
-            // the high-water mark at deferredId-1 so the deferred one is reprocessed next poll.
+            // Apply the user-configured streaming delay (defer episodes not yet "due").
             val delaySeconds = notificationPreferences.streamingDelayMinutes.value * 60L
             val nowSeconds = System.currentTimeMillis() / 1000
             val cutoff = if (delaySeconds > 0L) {
@@ -290,25 +250,16 @@ class NotificationWorker @AssistedInject constructor(
                 Int.MAX_VALUE
             }
             val toEmit = sortedAiring.filter { it.id < cutoff }
-            val deferredCount = sortedAiring.size - toEmit.size
 
             for (notification in toEmit) {
-                showNotification(notification)
+                showNotification(notification, ctx)
             }
-
             if (toEmit.size >= 3) {
-                showSummaryNotification(toEmit)
+                showSummaryNotification(toEmit, ctx)
             }
-
             if (toEmit.isNotEmpty()) {
-                val maxId = toEmit.maxOf { it.id }
-                preferencesRepository.setLastNotifiedId(maxId)
+                preferencesRepository.setLastNotifiedId(ctx.id, toEmit.maxOf { it.id })
             }
-
-            Log.d(
-                TAG,
-                "Processed ${toEmit.size} new airing notifications (deferred $deferredCount due to streaming delay of ${delaySeconds / 60} min)"
-            )
         }
     }
 
@@ -316,14 +267,14 @@ class NotificationWorker @AssistedInject constructor(
      * Check for new social/forum notifications (thread replies, mentions, likes, subscriptions).
      * Each type is gated behind its own preference toggle.
      */
-    private suspend fun checkSocialNotifications() {
-        val lastSocialId = preferencesRepository.getLastSocialNotifiedId()
+    private suspend fun checkSocialNotifications(ctx: AcctCtx) {
+        val lastSocialId = preferencesRepository.getLastSocialNotifiedId(ctx.id)
         val allNewSocial = mutableListOf<Notification>()
         var currentPage = 1
         var hasMore = true
 
         while (hasMore && currentPage <= MAX_NOTIFICATION_PAGES) {
-            val repoResult = notificationRepository.getNotifications(currentPage)
+            val repoResult = notificationRepository.getNotifications(currentPage, ctx.token)
 
             when (repoResult) {
                 is DomainResult.Success -> {
@@ -349,7 +300,7 @@ class NotificationWorker @AssistedInject constructor(
                     }
                 }
                 is DomainResult.Error -> {
-                    Log.e(TAG, "Failed to fetch social notifications page $currentPage: ${repoResult.message}", repoResult.exception)
+                    Log.e(TAG, "Failed to fetch social notifications page $currentPage for ${ctx.name}: ${repoResult.message}", repoResult.exception)
                     hasMore = false
                 }
             }
@@ -359,7 +310,6 @@ class NotificationWorker @AssistedInject constructor(
             val sorted = allNewSocial.sortedBy { it.id }
 
             for (notification in sorted) {
-                // Respect per-type preferences
                 val shouldNotify = when (notification) {
                     is ThreadCommentReplyNotification -> notificationPreferences.threadCommentReplyEnabled.value
                     is ThreadCommentSubscribedNotification -> notificationPreferences.threadSubscribedEnabled.value
@@ -375,13 +325,11 @@ class NotificationWorker @AssistedInject constructor(
                     else -> false
                 }
                 if (shouldNotify) {
-                    showSocialNotification(notification)
+                    showSocialNotification(notification, ctx)
                 }
             }
 
-            val maxId = sorted.maxOf { it.id }
-            preferencesRepository.setLastSocialNotifiedId(maxId)
-            Log.d(TAG, "Processed ${sorted.size} new social notifications")
+            preferencesRepository.setLastSocialNotifiedId(ctx.id, sorted.maxOf { it.id })
         }
     }
 
@@ -402,7 +350,7 @@ class NotificationWorker @AssistedInject constructor(
     /**
      * Display a social/forum notification using the appropriate channel.
      */
-    private suspend fun showSocialNotification(notification: Notification) {
+    private suspend fun showSocialNotification(notification: Notification, ctx: AcctCtx) {
         val data = when (notification) {
             is ThreadCommentReplyNotification -> {
                 val userName = notification.user?.name ?: "Someone"
@@ -516,15 +464,8 @@ class NotificationWorker @AssistedInject constructor(
             data.activityId != null -> "anisync://activity/${data.activityId}"
             data.commentId != null -> "anisync://forum/thread/${data.threadId}?commentId=${data.commentId}"
             data.threadId != null -> "anisync://forum/thread/${data.threadId}"
-            else -> "anisync://details/0"
+            else -> "anisync://notifications"
         }
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(deepLinkUri))
-        val pendingIntent = PendingIntent.getActivity(
-            applicationContext,
-            notificationId,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
 
         val largeIcon: Bitmap? = when (notification) {
             is ThreadCommentReplyNotification -> notification.user?.avatarUrl
@@ -547,15 +488,12 @@ class NotificationWorker @AssistedInject constructor(
             .setContentText(data.content)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
-            .setGroup(GROUP_KEY_SOCIAL)
-            .setContentIntent(pendingIntent)
+            .setGroup(groupKey(GROUP_KEY_SOCIAL, ctx))
+            .setContentIntent(deepLinkIntent(deepLinkUri, ctx, notificationId))
 
-        if (largeIcon != null) {
-            builder.setLargeIcon(largeIcon)
-        }
+        if (largeIcon != null) builder.setLargeIcon(largeIcon)
 
-        val notificationManager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.notify(notificationId, builder.build())
+        post(ctx, notificationId, builder)
     }
 
     private data class SocialNotificationData(
@@ -568,51 +506,40 @@ class NotificationWorker @AssistedInject constructor(
     )
 
     /**
-     * Check for upcoming Episode 1 airings for Planning list items.
-     * Implements a two-tier notification system:
-     * - 12 hours before: "Episode 1 airs tomorrow at 3:00 PM"
-     * - 2 hours before: "Episode 1 is airing in 2 hours"
+     * Check for upcoming Episode 1 airings for Planning list items (active account only).
+     * Two-tier: 12h advance, then 2h imminent.
      */
-    private suspend fun checkUpcomingPlanningEpisodes() {
-        val planningEntries = libraryDao.getByType(ownerId(), MediaType.ANIME)
+    private suspend fun checkUpcomingPlanningEpisodes(ctx: AcctCtx) {
+        val planningEntries = libraryDao.getByType(ctx.id, MediaType.ANIME)
             .filter { it.status == LibraryStatus.PLANNING }
-
         if (planningEntries.isEmpty()) return
 
         val mediaIds = planningEntries.map { it.mediaId }
         val currentTimeSeconds = System.currentTimeMillis() / 1000
-        
-        // Get upcoming Episode 1 airings within next 12 hours
-        val result = notificationRepository.getUpcomingFirstEpisodes(mediaIds, ADVANCE_NOTICE_HOURS)
 
+        val result = notificationRepository.getUpcomingFirstEpisodes(mediaIds, ADVANCE_NOTICE_HOURS)
         if (result is DomainResult.Success) {
             val upcomingAirings = result.data
-            
-            // Clean up old tracking - only keep IDs that are still upcoming
             val currentAiringIds = upcomingAirings.map { it.id }.toSet()
-            preferencesRepository.cleanupOldUpcomingAirings(currentAiringIds)
-            
+            preferencesRepository.cleanupOldUpcomingAirings(ctx.id, currentAiringIds)
+
             for (airing in upcomingAirings) {
                 val hoursUntil = ((airing.airingAt - currentTimeSeconds) / 3600).toInt()
-                
-                // Determine which tier of notification to send
                 when {
                     hoursUntil <= IMMINENT_NOTICE_HOURS -> {
-                        // 2 hours or less: Send imminent notification
                         val imminentKey = "imminent_${airing.id}"
-                        if (!preferencesRepository.hasNotifiedWithKey(imminentKey)) {
-                            showImminentEpisodeNotification(airing, hoursUntil)
-                            preferencesRepository.markNotifiedWithKey(imminentKey)
-                            preferencesRepository.markUpcomingAiringNotified(airing.id)
+                        if (!preferencesRepository.hasNotifiedWithKey(ctx.id, imminentKey)) {
+                            showImminentEpisodeNotification(airing, hoursUntil, ctx)
+                            preferencesRepository.markNotifiedWithKey(ctx.id, imminentKey)
+                            preferencesRepository.markUpcomingAiringNotified(ctx.id, airing.id)
                         }
                     }
                     hoursUntil <= ADVANCE_NOTICE_HOURS -> {
-                        // Between 2-12 hours: Send advance notification (only once)
                         val advanceKey = "advance_${airing.id}"
-                        if (!preferencesRepository.hasNotifiedWithKey(advanceKey)) {
-                            showAdvanceEpisodeNotification(airing)
-                            preferencesRepository.markNotifiedWithKey(advanceKey)
-                            preferencesRepository.markUpcomingAiringNotified(airing.id)
+                        if (!preferencesRepository.hasNotifiedWithKey(ctx.id, advanceKey)) {
+                            showAdvanceEpisodeNotification(airing, ctx)
+                            preferencesRepository.markNotifiedWithKey(ctx.id, advanceKey)
+                            preferencesRepository.markUpcomingAiringNotified(ctx.id, airing.id)
                         }
                     }
                 }
@@ -623,75 +550,42 @@ class NotificationWorker @AssistedInject constructor(
     }
 
     /**
-     * Check for already-aired Episode 1 for Planning list items.
-     * This is a reactive notification - "Episode 1 is now available!"
-     * 
-     * IMPORTANT: Skips media that have already received upcoming notifications
-     * to prevent duplicate alerts.
+     * Check for already-aired Episode 1 for Planning list items (active account only).
      */
-    private suspend fun checkPlanningFirstEpisodes() {
-        val planningEntries = libraryDao.getByType(ownerId(), MediaType.ANIME)
+    private suspend fun checkPlanningFirstEpisodes(ctx: AcctCtx) {
+        val planningEntries = libraryDao.getByType(ctx.id, MediaType.ANIME)
             .filter { it.status == LibraryStatus.PLANNING }
-
-        val mediaIds = planningEntries.map { it.mediaId }
-        
-        // NOTE: We intentionally do NOT call cleanupOrphanedPlanningIds here.
-        // Once an "Episode 1 aired" notification has been sent for a media ID,
-        // that fact should persist permanently. If a user moves an item out of
-        // Planning and then back, they should not receive the notification again.
-        
         if (planningEntries.isEmpty()) return
 
-        val notifiedIds = preferencesRepository.getNotifiedPlanningMediaIds()
+        val mediaIds = planningEntries.map { it.mediaId }
+        val notifiedIds = preferencesRepository.getNotifiedPlanningMediaIds(ctx.id)
         val unnotifiedIds = mediaIds.filter { it !in notifiedIds }
         if (unnotifiedIds.isEmpty()) return
 
-        // Get upcoming airing IDs to cross-reference and avoid duplicates
-        val upcomingNotifiedAiringIds = preferencesRepository.getNotifiedUpcomingAiringIds()
-
+        val upcomingNotifiedAiringIds = preferencesRepository.getNotifiedUpcomingAiringIds(ctx.id)
         val result = notificationRepository.getFirstEpisodeAirings(unnotifiedIds)
 
         if (result is DomainResult.Success) {
             for (airing in result.data) {
-                // Skip if we already sent an upcoming notification for this specific airing
-                // This prevents "Episode 1 is now available" after "Episode 1 airs in 2 hours"
                 if (airing.id in upcomingNotifiedAiringIds) {
-                    Log.d(TAG, "Skipping '${airing.mediaTitle}' - already notified as upcoming")
-                    // Still mark as notified to prevent future checks
-                    preferencesRepository.markPlanningMediaAsNotified(airing.mediaId)
+                    preferencesRepository.markPlanningMediaAsNotified(ctx.id, airing.mediaId)
                     continue
                 }
-                
-                showPlanningFirstEpisodeNotification(airing)
-                preferencesRepository.markPlanningMediaAsNotified(airing.mediaId)
-            }
-            if (result.data.isNotEmpty()) {
-                Log.d(TAG, "Processed ${result.data.size} planning first episode notifications")
+                showPlanningFirstEpisodeNotification(airing, ctx)
+                preferencesRepository.markPlanningMediaAsNotified(ctx.id, airing.mediaId)
             }
         } else if (result is DomainResult.Error) {
             Log.e(TAG, "Failed to fetch planning first episodes: ${result.message}", result.exception)
         }
     }
 
-    private suspend fun showNotification(notification: AiringNotification) {
+    private suspend fun showNotification(notification: AiringNotification, ctx: AcctCtx) {
         val notificationId = AIRING_NOTIFICATION_BASE_ID + notification.id
         val media = notification.media
         val title = media?.title ?: "New Episode"
         val content = "Episode ${notification.episode} has aired!"
 
-        // Body tap opens the in-app inbox rather than the media details page
-        // so the user lands on the same row that fired the system notification.
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("anisync://notifications"))
-        val pendingIntent = PendingIntent.getActivity(
-            applicationContext,
-            notificationId,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-
-        val largeIcon: Bitmap? = media?.coverUrl?.let { url ->
-            loadImage(url)
-        }
+        val largeIcon: Bitmap? = media?.coverUrl?.let { loadImage(it) }
 
         val builder = NotificationCompat.Builder(applicationContext, NotificationChannels.AIRING_CHANNEL_ID)
             .setSmallIcon(getApplicationIcon())
@@ -699,36 +593,28 @@ class NotificationWorker @AssistedInject constructor(
             .setContentText(content)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
-            .setGroup(GROUP_KEY_AIRING)
-            .setContentIntent(pendingIntent)
+            .setGroup(groupKey(GROUP_KEY_AIRING, ctx))
+            // Body tap opens the in-app inbox so the user lands on the row that fired it.
+            .setContentIntent(deepLinkIntent("anisync://notifications", ctx, notificationId))
 
-        if (largeIcon != null) {
-            builder.setLargeIcon(largeIcon)
-        }
+        if (largeIcon != null) builder.setLargeIcon(largeIcon)
 
-        val notificationManager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.notify(notificationId, builder.build())
+        post(ctx, notificationId, builder)
     }
 
-    /**
-     * Show advance notification (12 hours before).
-     * Example: "Episode 1 airs tomorrow at 3:00 PM"
-     */
-    private suspend fun showAdvanceEpisodeNotification(airing: AiringSchedule) {
+    private suspend fun showAdvanceEpisodeNotification(airing: AiringSchedule, ctx: AcctCtx) {
         val notificationId = UPCOMING_ADVANCE_NOTIFICATION_BASE_ID + airing.id
         val title = "📅 Premiere Alert: ${airing.mediaTitle}"
-        
-        // Format the airing time in user's locale
+
         val airingDate = java.util.Date(airing.airingAt * 1000)
         val timeFormat = DateFormat.getTimeFormat(applicationContext)
         val formattedTime = timeFormat.format(airingDate)
-        
-        // Determine if it's today or tomorrow
+
         val calendar = java.util.Calendar.getInstance()
         val currentDay = calendar.get(java.util.Calendar.DAY_OF_YEAR)
         calendar.time = airingDate
         val airingDay = calendar.get(java.util.Calendar.DAY_OF_YEAR)
-        
+
         val dayPrefix = when {
             airingDay == currentDay -> "today"
             airingDay == currentDay + 1 -> "tomorrow"
@@ -737,20 +623,9 @@ class NotificationWorker @AssistedInject constructor(
                 "on ${dateFormat.format(airingDate)}"
             }
         }
-        
         val content = "Episode 1 airs $dayPrefix at $formattedTime"
 
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("anisync://details/${airing.mediaId}"))
-        val pendingIntent = PendingIntent.getActivity(
-            applicationContext,
-            notificationId,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-
-        val largeIcon: Bitmap? = airing.mediaCoverUrl?.let { url ->
-            loadImage(url)
-        }
+        val largeIcon: Bitmap? = airing.mediaCoverUrl?.let { loadImage(it) }
 
         val builder = NotificationCompat.Builder(applicationContext, NotificationChannels.UPCOMING_CHANNEL_ID)
             .setSmallIcon(getApplicationIcon())
@@ -758,76 +633,48 @@ class NotificationWorker @AssistedInject constructor(
             .setContentText(content)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
-            .setGroup(GROUP_KEY_PLANNING)
-            .setContentIntent(pendingIntent)
+            .setGroup(groupKey(GROUP_KEY_PLANNING, ctx))
+            .setContentIntent(deepLinkIntent("anisync://details/${airing.mediaId}", ctx, notificationId))
 
-        if (largeIcon != null) {
-            builder.setLargeIcon(largeIcon)
-        }
+        if (largeIcon != null) builder.setLargeIcon(largeIcon)
 
-        val notificationManager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.notify(notificationId, builder.build())
+        post(ctx, notificationId, builder)
         Log.d(TAG, "Sent advance notification for ${airing.mediaTitle}: $content")
     }
 
-    /**
-     * Show imminent notification (2 hours or less before).
-     * Example: "Episode 1 is airing in 2 hours!"
-     */
-    private suspend fun showImminentEpisodeNotification(airing: AiringSchedule, hoursUntil: Int) {
+    private suspend fun showImminentEpisodeNotification(airing: AiringSchedule, hoursUntil: Int, ctx: AcctCtx) {
         val notificationId = UPCOMING_IMMINENT_NOTIFICATION_BASE_ID + airing.id
         val title = "🔔 Starting Soon: ${airing.mediaTitle}"
-        
+
         val content = when {
             hoursUntil < 1 -> "Episode 1 is airing in less than an hour!"
             hoursUntil == 1 -> "Episode 1 is airing in about an hour!"
             else -> "Episode 1 is airing in $hoursUntil hours!"
         }
 
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("anisync://details/${airing.mediaId}"))
-        val pendingIntent = PendingIntent.getActivity(
-            applicationContext,
-            notificationId,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-
-        val largeIcon: Bitmap? = airing.mediaCoverUrl?.let { url ->
-            loadImage(url)
-        }
+        val largeIcon: Bitmap? = airing.mediaCoverUrl?.let { loadImage(it) }
 
         val builder = NotificationCompat.Builder(applicationContext, NotificationChannels.UPCOMING_CHANNEL_ID)
             .setSmallIcon(getApplicationIcon())
             .setContentTitle(title)
             .setContentText(content)
-            .setPriority(NotificationCompat.PRIORITY_HIGH) // Higher priority for imminent notifications
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setAutoCancel(true)
-            .setGroup(GROUP_KEY_PLANNING)
-            .setContentIntent(pendingIntent)
+            .setGroup(groupKey(GROUP_KEY_PLANNING, ctx))
+            .setContentIntent(deepLinkIntent("anisync://details/${airing.mediaId}", ctx, notificationId))
 
-        if (largeIcon != null) {
-            builder.setLargeIcon(largeIcon)
-        }
+        if (largeIcon != null) builder.setLargeIcon(largeIcon)
 
-        val notificationManager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.notify(notificationId, builder.build())
+        post(ctx, notificationId, builder)
         Log.d(TAG, "Sent imminent notification for ${airing.mediaTitle}: $content")
     }
 
-    private suspend fun showPlanningFirstEpisodeNotification(airing: AiringSchedule) {
+    private suspend fun showPlanningFirstEpisodeNotification(airing: AiringSchedule, ctx: AcctCtx) {
         val notificationId = PLANNING_NOTIFICATION_BASE_ID + airing.mediaId
         val title = "${airing.mediaTitle} has started!"
         val content = "Episode 1 is now available"
 
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("anisync://details/${airing.mediaId}"))
-        val pendingIntent = PendingIntent.getActivity(
-            applicationContext,
-            notificationId,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-
-        // Create "Add to Watching" action button
+        // "Add to Watching" action button
         val addToWatchingIntent = Intent(applicationContext, AddToWatchingReceiver::class.java).apply {
             action = AddToWatchingReceiver.ACTION_ADD_TO_WATCHING
             putExtra(AddToWatchingReceiver.EXTRA_MEDIA_ID, airing.mediaId)
@@ -841,9 +688,7 @@ class NotificationWorker @AssistedInject constructor(
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        val largeIcon: Bitmap? = airing.mediaCoverUrl?.let { url ->
-            loadImage(url)
-        }
+        val largeIcon: Bitmap? = airing.mediaCoverUrl?.let { loadImage(it) }
 
         val builder = NotificationCompat.Builder(applicationContext, NotificationChannels.PLANNING_CHANNEL_ID)
             .setSmallIcon(getApplicationIcon())
@@ -851,26 +696,23 @@ class NotificationWorker @AssistedInject constructor(
             .setContentText(content)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
-            .setGroup(GROUP_KEY_PLANNING)
-            .setContentIntent(pendingIntent)
+            .setGroup(groupKey(GROUP_KEY_PLANNING, ctx))
+            .setContentIntent(deepLinkIntent("anisync://details/${airing.mediaId}", ctx, notificationId))
             .addAction(
-                R.drawable.ic_notification, // Icon for the action
+                R.drawable.ic_notification,
                 "Add to Watching",
                 addToWatchingPendingIntent
             )
 
-        if (largeIcon != null) {
-            builder.setLargeIcon(largeIcon)
-        }
+        if (largeIcon != null) builder.setLargeIcon(largeIcon)
 
-        val notificationManager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.notify(notificationId, builder.build())
+        post(ctx, notificationId, builder)
     }
 
-    private fun showSummaryNotification(notifications: List<AiringNotification>) {
+    private fun showSummaryNotification(notifications: List<AiringNotification>, ctx: AcctCtx) {
         val inboxStyle = NotificationCompat.InboxStyle()
             .setBigContentTitle("${notifications.size} new episodes aired")
-            .setSummaryText("AniSync")
+            .setSummaryText(if (ctx.showLabel) ctx.name else "AniSync")
 
         for (notification in notifications) {
             val title = notification.media?.title ?: "Anime"
@@ -880,13 +722,39 @@ class NotificationWorker @AssistedInject constructor(
         val builder = NotificationCompat.Builder(applicationContext, NotificationChannels.AIRING_CHANNEL_ID)
             .setSmallIcon(getApplicationIcon())
             .setStyle(inboxStyle)
-            .setGroup(GROUP_KEY_AIRING)
+            .setGroup(groupKey(GROUP_KEY_AIRING, ctx))
             .setGroupSummary(true)
             .setAutoCancel(true)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
 
-        val notificationManager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.notify(SUMMARY_ID, builder.build())
+        post(ctx, SUMMARY_ID, builder)
+    }
+
+    // ── Multi-account notification helpers ──────────────────────────────────────────────
+
+    /** Group key salted per account so each account's notifications group under their own summary. */
+    private fun groupKey(base: String, ctx: AcctCtx) = "$base.${ctx.id}"
+
+    /** Deep link tagged with the account so a tap can switch to it first (see MainActivity). */
+    private fun deepLinkIntent(uri: String, ctx: AcctCtx, requestCode: Int): PendingIntent {
+        val withAccount = if (uri.contains('?')) "$uri&account=${ctx.id}" else "$uri?account=${ctx.id}"
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(withAccount))
+        return PendingIntent.getActivity(
+            applicationContext,
+            requestCode,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+
+    /**
+     * Posts under a per-account tag so the same AniList notification id from two accounts can't
+     * overwrite each other in the tray, and labels the account when more than one is signed in.
+     */
+    private fun post(ctx: AcctCtx, id: Int, builder: NotificationCompat.Builder) {
+        if (ctx.showLabel) builder.setSubText(ctx.name)
+        val nm = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        nm.notify("acct_${ctx.id}", id, builder.build())
     }
 
     private suspend fun loadImage(url: String): Bitmap? {
@@ -903,7 +771,7 @@ class NotificationWorker @AssistedInject constructor(
             null
         }
     }
-    
+
     private fun getApplicationIcon(): Int {
         return R.drawable.ic_notification
     }

--- a/app/src/main/java/com/anisync/android/worker/NotificationWorker.kt
+++ b/app/src/main/java/com/anisync/android/worker/NotificationWorker.kt
@@ -488,6 +488,8 @@ class NotificationWorker @AssistedInject constructor(
             .setContentText(data.content)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
+            .setWhen(notification.createdAt.toLong() * 1000L)
+            .setShowWhen(true)
             .setGroup(groupKey(GROUP_KEY_SOCIAL, ctx))
             .setContentIntent(deepLinkIntent(deepLinkUri, ctx, notificationId))
 
@@ -593,6 +595,10 @@ class NotificationWorker @AssistedInject constructor(
             .setContentText(content)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
+            // Stamp with the airing moment (AniList createdAt) so it's consistent across devices
+            // regardless of when each device's worker polled.
+            .setWhen(notification.createdAt.toLong() * 1000L)
+            .setShowWhen(true)
             .setGroup(groupKey(GROUP_KEY_AIRING, ctx))
             // Body tap opens the in-app inbox so the user lands on the row that fired it.
             .setContentIntent(deepLinkIntent("anisync://notifications", ctx, notificationId))
@@ -696,6 +702,8 @@ class NotificationWorker @AssistedInject constructor(
             .setContentText(content)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
+            .setWhen(airing.airingAt * 1000L)
+            .setShowWhen(true)
             .setGroup(groupKey(GROUP_KEY_PLANNING, ctx))
             .setContentIntent(deepLinkIntent("anisync://details/${airing.mediaId}", ctx, notificationId))
             .addAction(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -384,6 +384,18 @@
     <string name="settings_view_on_anilist">View on AniList</string>
     <string name="settings_view_on_anilist_desc">Open your profile on AniList</string>
     <string name="settings_logout_warning">Logging out will remove your session. You can sign in again at any time.</string>
+    <!-- Multiple accounts -->
+    <string name="account_add">Add account</string>
+    <string name="account_add_desc">Sign in to another AniList account</string>
+    <string name="account_active">Active</string>
+    <string name="account_expired">Session expired</string>
+    <string name="account_switch">Switch account</string>
+    <string name="account_remove">Remove account</string>
+    <string name="account_reauthenticate">Re-authenticate</string>
+    <string name="account_sign_in_failed">Couldn\'t sign in. Please try again.</string>
+    <string name="account_remove_dialog_title">Remove account?</string>
+    <string name="account_remove_dialog_message">%1$s will be removed from this device. You can sign in again at any time.</string>
+    <string name="account_switch_to">Switch to %1$s</string>
     <string name="settings_open_source_licenses">Open Source Licenses</string>
     <string name="settings_acknowledgments">Acknowledgments</string>
     <string name="settings_acknowledgments_desc">Thanks to contributors and libraries</string>


### PR DESCRIPTION
Implements multiple-account support requested in #45.

## What's included
- **Accounts**: add / switch / remove multiple AniList accounts. Tokens in EncryptedSharedPreferences (per account); metadata + active id in plain prefs. `AuthRepository` is a thin facade over a new `AccountStore`; `AccountManager` orchestrates add/switch/remove. Legacy single-token logins migrate automatically.
- **Per-account local data**: `library_entries` gains an `ownerId` (DB v18 auto-migration) and `user_profile` is read by user id, so each account's library/profile stays cached and isolated — switching back is instant, no bleed.
- **UI**: Settings → Account becomes an account list (add / switch / remove / re-auth); plus a quick switcher on the profile header. Avatars use the shared `UserAvatar`.
- **Notifications from all accounts**: the worker polls every signed-in account via a per-account token client (`TokenedApolloClientFactory`), with per-account dedup state, per-account tray tags + account-name labelling, and account-aware tap routing (switches to the right account, then opens the item). Airing/social/planning notifications are stamped with the event time.

## Notes
- Notifications use a single global on/off toggle. Per-account notification control (via Android notification channels) was suggested in the issue thread and is a good follow-up — intentionally out of this PR's scope.

## Testing
- `./gradlew assembleStableDebug` + unit tests pass.
- Verified on two devices: add/switch/remove, library+profile isolation, instant switch-back from cache, background notifications from both accounts (separate tray entries, correct labels), and notification tap routing (same- and cross-account). The issue reporter confirmed it works as expected.