### PR TITLE
AniList account options: respect web settings, local-first sync (fixes #53)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -230,6 +230,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,19 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
+    <!--
+      Package visibility (Android 11+): declare that we interact with web browsers so the app can
+      resolve and explicitly target one when opening links externally (see AppLinksUtil.openInBrowser).
+      Without this, queryIntentActivities returns nothing and anilist.co links loop back into the app.
+    -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
+
     <application
         android:name=".AniSyncApplication"
         android:allowBackup="true"

--- a/app/src/main/graphql/Profile.graphql
+++ b/app/src/main/graphql/Profile.graphql
@@ -273,6 +273,7 @@ fragment ActivityFields on ActivityUnion {
         extraLarge
       }
       type
+      isAdult
     }
   }
   ... on TextActivity {

--- a/app/src/main/graphql/UpdateUserOptions.graphql
+++ b/app/src/main/graphql/UpdateUserOptions.graphql
@@ -1,0 +1,43 @@
+mutation UpdateUserOptions(
+  $displayAdultContent: Boolean,
+  $titleLanguage: UserTitleLanguage,
+  $staffNameLanguage: UserStaffNameLanguage,
+  $scoreFormat: ScoreFormat,
+  $airingNotifications: Boolean,
+  $restrictMessagesToFollowing: Boolean,
+  $activityMergeTime: Int,
+  $profileColor: String,
+  $disabledListActivity: [ListActivityOptionInput]
+) {
+  UpdateUser(
+    displayAdultContent: $displayAdultContent,
+    titleLanguage: $titleLanguage,
+    staffNameLanguage: $staffNameLanguage,
+    scoreFormat: $scoreFormat,
+    airingNotifications: $airingNotifications,
+    restrictMessagesToFollowing: $restrictMessagesToFollowing,
+    activityMergeTime: $activityMergeTime,
+    profileColor: $profileColor,
+    disabledListActivity: $disabledListActivity
+  ) {
+    id
+    options {
+      titleLanguage
+      displayAdultContent
+      airingNotifications
+      profileColor
+      timezone
+      activityMergeTime
+      staffNameLanguage
+      restrictMessagesToFollowing
+      disabledListActivity {
+        disabled
+        type
+      }
+    }
+    mediaListOptions {
+      scoreFormat
+      rowOrder
+    }
+  }
+}

--- a/app/src/main/graphql/Viewer.graphql
+++ b/app/src/main/graphql/Viewer.graphql
@@ -6,8 +6,23 @@ query GetViewer {
       large
     }
     unreadNotificationCount
+    options {
+      titleLanguage
+      displayAdultContent
+      airingNotifications
+      profileColor
+      timezone
+      activityMergeTime
+      staffNameLanguage
+      restrictMessagesToFollowing
+      disabledListActivity {
+        disabled
+        type
+      }
+    }
     mediaListOptions {
       scoreFormat
+      rowOrder
     }
   }
 }

--- a/app/src/main/java/com/anisync/android/AniSyncApplication.kt
+++ b/app/src/main/java/com/anisync/android/AniSyncApplication.kt
@@ -32,6 +32,9 @@ class AniSyncApplication : Application(), Configuration.Provider, ImageLoaderFac
     @Inject
     lateinit var imageLoader: ImageLoader
 
+    @Inject
+    lateinit var userOptionsSyncManager: com.anisync.android.data.UserOptionsSyncManager
+
     private val applicationScope = CoroutineScope(
         SupervisorJob() + CoroutineExceptionHandler { _, throwable ->
             Log.e("AniSyncApp", "Unhandled coroutine exception", throwable)
@@ -67,6 +70,10 @@ class AniSyncApplication : Application(), Configuration.Provider, ImageLoaderFac
             }
             Log.d("PerfMetrics", "Background Worker scheduling took $backgroundInitTime ms")
         }
+
+        // Keep AniList account options (adult-content, languages, score format, …) in sync with the
+        // web so the app respects them. Off the cold-start critical path.
+        userOptionsSyncManager.start(applicationScope)
     }
 
     private fun currentProcessName(): String = try {

--- a/app/src/main/java/com/anisync/android/MainActivity.kt
+++ b/app/src/main/java/com/anisync/android/MainActivity.kt
@@ -94,6 +94,9 @@ class MainActivity : AppCompatActivity() {
     @Inject
     lateinit var linkPreviewProvider: LinkPreviewProvider
 
+    @Inject
+    lateinit var userOptionsRepository: com.anisync.android.domain.UserOptionsRepository
+
     private val _newIntents = MutableSharedFlow<Intent>(extraBufferCapacity = 4)
     val newIntents: SharedFlow<Intent> = _newIntents.asSharedFlow()
 
@@ -279,6 +282,14 @@ class MainActivity : AppCompatActivity() {
                             }
 
                             AppUpdateHandler(updateManager = updateManager)
+
+                            // App-wide options sync-conflict prompt (surfaces right after launch,
+                            // not only on the AniList Settings screen).
+                            if (isLoggedIn) {
+                                com.anisync.android.presentation.settings.UserOptionsConflictHandler(
+                                    repository = userOptionsRepository,
+                                )
+                            }
 
                             // Blocking loader while an account add/switch/remove is in flight.
                             val isAccountBusy by accountManager.isBusy.collectAsStateWithLifecycle(

--- a/app/src/main/java/com/anisync/android/data/AppSettings.kt
+++ b/app/src/main/java/com/anisync/android/data/AppSettings.kt
@@ -302,26 +302,12 @@ class AppSettings @Inject constructor(
     )
     val showPrivateEntries: StateFlow<Boolean> = _showPrivateEntries.asStateFlow()
 
-    // Effective "show adult content" flag. Followed by search + the activity feed. By default this
-    // mirrors the AniList account option (UserOptions.displayAdultContent); a user can pin it on this
-    // device via [adultContentOverrideEnabled].
+    // Effective "show adult content" flag, followed by search + the activity feed. Mirrored from the
+    // local-first options state (UserOptions.displayAdultContent); see UserOptionsRepositoryImpl.
     private val _showAdultContent = MutableStateFlow(
         prefs.getBoolean(KEY_SHOW_ADULT_CONTENT, false)
     )
     val showAdultContent: StateFlow<Boolean> = _showAdultContent.asStateFlow()
-
-    // Device-level override switches for the two content prefs that mirror an AniList account option.
-    // OFF (default) = follow the account (pull mirrors the web value); ON = keep the local value and
-    // let account-pull leave it untouched. See UserOptionsRepositoryImpl.mirrorToLocal.
-    private val _adultContentOverrideEnabled = MutableStateFlow(
-        prefs.getBoolean(KEY_ADULT_OVERRIDE_ENABLED, false)
-    )
-    val adultContentOverrideEnabled: StateFlow<Boolean> = _adultContentOverrideEnabled.asStateFlow()
-
-    private val _titleLanguageOverrideEnabled = MutableStateFlow(
-        prefs.getBoolean(KEY_TITLE_LANGUAGE_OVERRIDE_ENABLED, false)
-    )
-    val titleLanguageOverrideEnabled: StateFlow<Boolean> = _titleLanguageOverrideEnabled.asStateFlow()
 
     private val _discoverSearchViewMode = MutableStateFlow(
         DiscoverViewMode.entries.getOrElse(
@@ -708,16 +694,6 @@ class AppSettings @Inject constructor(
         prefs.edit().putBoolean(KEY_SHOW_ADULT_CONTENT, show).apply()
     }
 
-    fun setAdultContentOverrideEnabled(enabled: Boolean) {
-        _adultContentOverrideEnabled.value = enabled
-        prefs.edit().putBoolean(KEY_ADULT_OVERRIDE_ENABLED, enabled).apply()
-    }
-
-    fun setTitleLanguageOverrideEnabled(enabled: Boolean) {
-        _titleLanguageOverrideEnabled.value = enabled
-        prefs.edit().putBoolean(KEY_TITLE_LANGUAGE_OVERRIDE_ENABLED, enabled).apply()
-    }
-
     fun setDiscoverSearchViewMode(mode: DiscoverViewMode) {
         _discoverSearchViewMode.value = mode
         prefs.edit().putInt(KEY_DISCOVER_SEARCH_VIEW_MODE, mode.ordinal).apply()
@@ -973,8 +949,6 @@ companion object {
         private const val KEY_USER_SCORE_FORMAT = "user_score_format"
         private const val KEY_SHOW_PRIVATE_ENTRIES = "show_private_entries"
         private const val KEY_SHOW_ADULT_CONTENT = "show_adult_content"
-        private const val KEY_ADULT_OVERRIDE_ENABLED = "adult_content_override_enabled"
-        private const val KEY_TITLE_LANGUAGE_OVERRIDE_ENABLED = "title_language_override_enabled"
         private const val KEY_STAFF_NAME_LANGUAGE = "staff_name_language"
         private const val KEY_DISCOVER_SEARCH_VIEW_MODE = "discover_search_view_mode"
         private const val KEY_LAST_SELECTED_ANIME_TAB = "last_selected_anime_tab"

--- a/app/src/main/java/com/anisync/android/data/AppSettings.kt
+++ b/app/src/main/java/com/anisync/android/data/AppSettings.kt
@@ -197,6 +197,15 @@ class AppSettings @Inject constructor(
     )
     val titleLanguage: StateFlow<TitleLanguage> = _titleLanguage.asStateFlow()
 
+    // Staff & character name language. Mirrored from the AniList account option
+    // (UserOptions.staffNameLanguage); applied client-side when rendering staff/character names.
+    private val _staffNameLanguage = MutableStateFlow(
+        StaffNameLanguage.entries.getOrElse(
+            prefs.getInt(KEY_STAFF_NAME_LANGUAGE, StaffNameLanguage.ROMAJI_WESTERN.ordinal)
+        ) { StaffNameLanguage.ROMAJI_WESTERN }
+    )
+    val staffNameLanguage: StateFlow<StaffNameLanguage> = _staffNameLanguage.asStateFlow()
+
     // Cover image quality setting
     private val _coverQuality = MutableStateFlow(readCoverQuality())
     val coverQuality: StateFlow<CoverQuality> = _coverQuality.asStateFlow()
@@ -293,12 +302,26 @@ class AppSettings @Inject constructor(
     )
     val showPrivateEntries: StateFlow<Boolean> = _showPrivateEntries.asStateFlow()
 
-    // Whether NSFW tags / adult-only filter are exposed in advanced search.
-    // Off by default; user opts in via the toggle inside the advanced search sheet.
+    // Effective "show adult content" flag. Followed by search + the activity feed. By default this
+    // mirrors the AniList account option (UserOptions.displayAdultContent); a user can pin it on this
+    // device via [adultContentOverrideEnabled].
     private val _showAdultContent = MutableStateFlow(
         prefs.getBoolean(KEY_SHOW_ADULT_CONTENT, false)
     )
     val showAdultContent: StateFlow<Boolean> = _showAdultContent.asStateFlow()
+
+    // Device-level override switches for the two content prefs that mirror an AniList account option.
+    // OFF (default) = follow the account (pull mirrors the web value); ON = keep the local value and
+    // let account-pull leave it untouched. See UserOptionsRepositoryImpl.mirrorToLocal.
+    private val _adultContentOverrideEnabled = MutableStateFlow(
+        prefs.getBoolean(KEY_ADULT_OVERRIDE_ENABLED, false)
+    )
+    val adultContentOverrideEnabled: StateFlow<Boolean> = _adultContentOverrideEnabled.asStateFlow()
+
+    private val _titleLanguageOverrideEnabled = MutableStateFlow(
+        prefs.getBoolean(KEY_TITLE_LANGUAGE_OVERRIDE_ENABLED, false)
+    )
+    val titleLanguageOverrideEnabled: StateFlow<Boolean> = _titleLanguageOverrideEnabled.asStateFlow()
 
     private val _discoverSearchViewMode = MutableStateFlow(
         DiscoverViewMode.entries.getOrElse(
@@ -566,6 +589,14 @@ class AppSettings @Inject constructor(
     }
 
     /**
+     * Set the staff/character name language. Normally mirrored from the AniList account option.
+     */
+    fun setStaffNameLanguage(language: StaffNameLanguage) {
+        _staffNameLanguage.value = language
+        prefs.edit().putInt(KEY_STAFF_NAME_LANGUAGE, language.ordinal).apply()
+    }
+
+    /**
      * Set the preferred media cover image quality.
      */
     fun setCoverQuality(quality: CoverQuality) {
@@ -675,6 +706,16 @@ class AppSettings @Inject constructor(
     fun setShowAdultContent(show: Boolean) {
         _showAdultContent.value = show
         prefs.edit().putBoolean(KEY_SHOW_ADULT_CONTENT, show).apply()
+    }
+
+    fun setAdultContentOverrideEnabled(enabled: Boolean) {
+        _adultContentOverrideEnabled.value = enabled
+        prefs.edit().putBoolean(KEY_ADULT_OVERRIDE_ENABLED, enabled).apply()
+    }
+
+    fun setTitleLanguageOverrideEnabled(enabled: Boolean) {
+        _titleLanguageOverrideEnabled.value = enabled
+        prefs.edit().putBoolean(KEY_TITLE_LANGUAGE_OVERRIDE_ENABLED, enabled).apply()
     }
 
     fun setDiscoverSearchViewMode(mode: DiscoverViewMode) {
@@ -932,6 +973,9 @@ companion object {
         private const val KEY_USER_SCORE_FORMAT = "user_score_format"
         private const val KEY_SHOW_PRIVATE_ENTRIES = "show_private_entries"
         private const val KEY_SHOW_ADULT_CONTENT = "show_adult_content"
+        private const val KEY_ADULT_OVERRIDE_ENABLED = "adult_content_override_enabled"
+        private const val KEY_TITLE_LANGUAGE_OVERRIDE_ENABLED = "title_language_override_enabled"
+        private const val KEY_STAFF_NAME_LANGUAGE = "staff_name_language"
         private const val KEY_DISCOVER_SEARCH_VIEW_MODE = "discover_search_view_mode"
         private const val KEY_LAST_SELECTED_ANIME_TAB = "last_selected_anime_tab"
         private const val KEY_LAST_SELECTED_MANGA_TAB = "last_selected_manga_tab"
@@ -959,6 +1003,17 @@ companion object {
 enum class TitleLanguage {
     ROMAJI,
     ENGLISH,
+    NATIVE
+}
+
+/**
+ * Staff & character name language options. Mirrors AniList's `UserStaffNameLanguage`
+ * ([com.anisync.android.domain.AniListStaffNameLanguage]) but kept as a local enum so the
+ * presentation layer doesn't depend on generated GraphQL types.
+ */
+enum class StaffNameLanguage {
+    ROMAJI_WESTERN,
+    ROMAJI,
     NATIVE
 }
 

--- a/app/src/main/java/com/anisync/android/data/FeedRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/FeedRepositoryImpl.kt
@@ -17,7 +17,8 @@ import com.apollographql.apollo.cache.normalized.fetchPolicy
 import javax.inject.Inject
 
 class FeedRepositoryImpl @Inject constructor(
-    private val apolloClient: ApolloClient
+    private val apolloClient: ApolloClient,
+    private val appSettings: AppSettings,
 ) : FeedRepository {
 
     override suspend fun getFeed(
@@ -57,10 +58,15 @@ class FeedRepositoryImpl @Inject constructor(
             throw Exception(response.errors?.firstOrNull()?.message ?: "Failed to load feed")
         }
 
+        // Respect the viewer's AniList "display adult content" option (mirrored into AppSettings):
+        // hide list activity for 18+ media, matching the website. Text/message activities carry no
+        // media, so mediaIsAdult is false for them and they pass through untouched.
+        val showAdult = appSettings.showAdultContent.value
         val pageData = response.data?.Page
         val items = pageData?.activities
             ?.filterNotNull()
             ?.mapNotNull { it.activityFields.toDomain() }
+            ?.filterAdultActivities(showAdult)
             ?.distinctBy { it.id }
             ?: emptyList()
 

--- a/app/src/main/java/com/anisync/android/data/SearchRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/SearchRepositoryImpl.kt
@@ -29,8 +29,19 @@ import javax.inject.Singleton
 
 @Singleton
 class SearchRepositoryImpl @Inject constructor(
-    private val apolloClient: ApolloClient
+    private val apolloClient: ApolloClient,
+    private val appSettings: AppSettings,
 ) : SearchRepository {
+
+    /**
+     * Resolves the `isAdult` query filter. The per-search [AdultMode] chip takes precedence; when it
+     * is [AdultMode.ANY] (the default) the global "show adult content" preference acts as a floor, so
+     * a user with adult content off never sees 18+ results unless they explicitly ask for them via
+     * the chip. This is the fix for the previously-inert toggle.
+     */
+    private fun resolveAdultFilter(mode: com.anisync.android.domain.AdultMode): Optional<Boolean?> =
+        resolveAdultIsAdult(mode, appSettings.showAdultContent.value)
+            ?.let { Optional.present(it) } ?: Optional.absent()
 
     @Volatile private var cachedGenres: List<String>? = null
     @Volatile private var cachedTags: List<MediaTag>? = null
@@ -90,11 +101,7 @@ class SearchRepositoryImpl @Inject constructor(
                     chapters_lesser = filters.chapters.lesser(),
                     countryOfOrigin = filters.country?.let { Optional.present(it.code) }
                         ?: Optional.absent(),
-                    isAdult = when (filters.adultMode) {
-                        com.anisync.android.domain.AdultMode.ANY -> Optional.absent()
-                        com.anisync.android.domain.AdultMode.HIDE -> Optional.present(false)
-                        com.anisync.android.domain.AdultMode.ONLY -> Optional.present(true)
-                    },
+                    isAdult = resolveAdultFilter(filters.adultMode),
                     countOnly = Optional.present(countOnly)
                 )
             )
@@ -219,11 +226,7 @@ class SearchRepositoryImpl @Inject constructor(
                         chapters_lesser = filters.chapters.lesser(),
                         countryOfOrigin = filters.country?.let { Optional.present(it.code) }
                             ?: Optional.absent(),
-                        isAdult = when (filters.adultMode) {
-                            com.anisync.android.domain.AdultMode.ANY -> Optional.absent()
-                            com.anisync.android.domain.AdultMode.HIDE -> Optional.present(false)
-                            com.anisync.android.domain.AdultMode.ONLY -> Optional.present(true)
-                        }
+                        isAdult = resolveAdultFilter(filters.adultMode)
                     )
                 )
                     .fetchPolicy(FetchPolicy.NetworkFirst)

--- a/app/src/main/java/com/anisync/android/data/UserOptionsMapping.kt
+++ b/app/src/main/java/com/anisync/android/data/UserOptionsMapping.kt
@@ -1,0 +1,43 @@
+package com.anisync.android.data
+
+import com.anisync.android.domain.AdultMode
+import com.anisync.android.domain.AniListStaffNameLanguage
+import com.anisync.android.domain.AniListTitleLanguage
+import com.anisync.android.domain.UserActivity
+
+/**
+ * Pure mapping/resolution helpers shared by the search repository, the options repository, and the
+ * AniList options screen. Kept free of Android/Apollo types so they can be unit-tested directly.
+ */
+
+/**
+ * Resolves the `isAdult` search filter. Returns `null` to leave the filter off (show everything),
+ * `false` to hide 18+, or `true` to show only 18+. The per-search [mode] wins; when it is
+ * [AdultMode.ANY] the global [showAdultContent] preference acts as a floor that hides adult media.
+ */
+fun resolveAdultIsAdult(mode: AdultMode, showAdultContent: Boolean): Boolean? = when (mode) {
+    AdultMode.ANY -> if (showAdultContent) null else false
+    AdultMode.HIDE -> false
+    AdultMode.ONLY -> true
+}
+
+/** Collapses AniList's 6-value title language onto the app's 3-value enum (stylised → base). */
+fun AniListTitleLanguage.toLocalTitleLanguage(): TitleLanguage = when (this) {
+    AniListTitleLanguage.ENGLISH, AniListTitleLanguage.ENGLISH_STYLISED -> TitleLanguage.ENGLISH
+    AniListTitleLanguage.NATIVE, AniListTitleLanguage.NATIVE_STYLISED -> TitleLanguage.NATIVE
+    else -> TitleLanguage.ROMAJI
+}
+
+/** Maps the AniList staff-name language option onto the local enum (1:1). */
+fun AniListStaffNameLanguage.toLocalStaffNameLanguage(): StaffNameLanguage = when (this) {
+    AniListStaffNameLanguage.ROMAJI_WESTERN -> StaffNameLanguage.ROMAJI_WESTERN
+    AniListStaffNameLanguage.ROMAJI -> StaffNameLanguage.ROMAJI
+    AniListStaffNameLanguage.NATIVE -> StaffNameLanguage.NATIVE
+}
+
+/**
+ * Drops activity for 18+ media when adult content is off, matching the AniList website. Text and
+ * message activities carry no media (so [UserActivity.mediaIsAdult] is false) and always pass.
+ */
+fun List<UserActivity>.filterAdultActivities(showAdultContent: Boolean): List<UserActivity> =
+    if (showAdultContent) this else filterNot { it.mediaIsAdult }

--- a/app/src/main/java/com/anisync/android/data/UserOptionsRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/UserOptionsRepositoryImpl.kt
@@ -1,0 +1,251 @@
+package com.anisync.android.data
+
+import com.anisync.android.GetViewerQuery
+import com.anisync.android.UpdateUserOptionsMutation
+import com.anisync.android.data.account.AccountManager
+import com.anisync.android.data.util.safeApiCall
+import com.anisync.android.domain.AniListListActivityStatus
+import com.anisync.android.domain.AniListStaffNameLanguage
+import com.anisync.android.domain.AniListTitleLanguage
+import com.anisync.android.domain.AniListUserOptions
+import com.anisync.android.domain.Result
+import com.anisync.android.domain.ScoreFormat
+import com.anisync.android.domain.UserOptionsPatch
+import com.anisync.android.domain.UserOptionsRepository
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.Optional
+import com.apollographql.apollo.cache.normalized.FetchPolicy
+import com.apollographql.apollo.cache.normalized.fetchPolicy
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+import com.anisync.android.type.MediaListStatus as ApiListStatus
+import com.anisync.android.type.ScoreFormat as ApiScoreFormat
+import com.anisync.android.type.UserStaffNameLanguage as ApiStaffNameLanguage
+import com.anisync.android.type.UserTitleLanguage as ApiTitleLanguage
+
+@Singleton
+class UserOptionsRepositoryImpl @Inject constructor(
+    private val apolloClient: ApolloClient,
+    private val store: UserOptionsStore,
+    private val accountManager: AccountManager,
+    private val appSettings: AppSettings,
+) : UserOptionsRepository {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val _cachedOptions = MutableStateFlow(currentAccountId()?.let { store.read(it) })
+    override val cachedOptions: StateFlow<AniListUserOptions?> = _cachedOptions.asStateFlow()
+
+    init {
+        // On account switch, instantly surface that account's cached options (offline) and re-mirror,
+        // so effective settings reflect the active account without waiting on the network. A fresh
+        // network pull is driven separately by UserOptionsSyncManager.
+        scope.launch {
+            accountManager.activeAccount
+                .map { it?.id }
+                .distinctUntilChanged()
+                .collect { id ->
+                    val cached = id?.let { store.read(it) }
+                    _cachedOptions.value = cached
+                    if (cached != null) mirrorToLocal(cached)
+                }
+        }
+    }
+
+    override suspend fun fetchOptions(): Result<AniListUserOptions> = safeApiCall {
+        val response = apolloClient.query(GetViewerQuery())
+            .fetchPolicy(FetchPolicy.NetworkFirst)
+            .execute()
+        if (response.hasErrors()) {
+            throw Exception(response.errors?.firstOrNull()?.message ?: "Failed to load account options")
+        }
+        val viewer = response.data?.Viewer ?: throw Exception("Not signed in")
+        viewer.toDomain().also { persist(it) }
+    }
+
+    override suspend fun updateOptions(patch: UserOptionsPatch): Result<AniListUserOptions> = safeApiCall {
+        val response = apolloClient.mutation(patch.toMutation()).execute()
+        if (response.hasErrors()) {
+            throw Exception(response.errors?.firstOrNull()?.message ?: "Failed to update account options")
+        }
+        val user = response.data?.UpdateUser ?: throw Exception("Update returned no user")
+        user.toDomain().also { persist(it) }
+    }
+
+    /** Persist to the per-account cache, update the live flow, and mirror behavior-affecting values. */
+    private fun persist(options: AniListUserOptions) {
+        currentAccountId()?.let { store.write(it, options) }
+        _cachedOptions.value = options
+        mirrorToLocal(options)
+    }
+
+    /**
+     * Mirror the options that drive local app behavior into [AppSettings], honoring the device
+     * override switches. Adult content and title language are skipped when their override is ON;
+     * staff-name language and score format always follow the account (no local-only counterpart).
+     */
+    private fun mirrorToLocal(options: AniListUserOptions) {
+        if (!appSettings.adultContentOverrideEnabled.value) {
+            appSettings.setShowAdultContent(options.displayAdultContent)
+        }
+        if (!appSettings.titleLanguageOverrideEnabled.value) {
+            options.titleLanguage?.let { appSettings.setTitleLanguage(it.toLocalTitleLanguage()) }
+        }
+        options.staffNameLanguage?.let { appSettings.setStaffNameLanguage(it.toLocalStaffNameLanguage()) }
+        options.scoreFormat?.let { appSettings.setUserScoreFormat(it) }
+    }
+
+    private fun currentAccountId(): Int? = accountManager.activeAccount.value?.id
+
+    // ── Mapping: generated GraphQL types → domain ────────────────────────────────────────────────
+
+    private fun GetViewerQuery.Viewer.toDomain(): AniListUserOptions = buildOptions(
+        titleLanguage = options?.titleLanguage,
+        displayAdultContent = options?.displayAdultContent,
+        airingNotifications = options?.airingNotifications,
+        profileColor = options?.profileColor,
+        timezone = options?.timezone,
+        activityMergeTime = options?.activityMergeTime,
+        staffNameLanguage = options?.staffNameLanguage,
+        restrictMessagesToFollowing = options?.restrictMessagesToFollowing,
+        disabledListActivity = options?.disabledListActivity?.mapNotNull { it?.type to (it?.disabled ?: false) },
+        scoreFormat = mediaListOptions?.scoreFormat,
+    )
+
+    private fun UpdateUserOptionsMutation.UpdateUser.toDomain(): AniListUserOptions = buildOptions(
+        titleLanguage = options?.titleLanguage,
+        displayAdultContent = options?.displayAdultContent,
+        airingNotifications = options?.airingNotifications,
+        profileColor = options?.profileColor,
+        timezone = options?.timezone,
+        activityMergeTime = options?.activityMergeTime,
+        staffNameLanguage = options?.staffNameLanguage,
+        restrictMessagesToFollowing = options?.restrictMessagesToFollowing,
+        disabledListActivity = options?.disabledListActivity?.mapNotNull { it?.type to (it?.disabled ?: false) },
+        scoreFormat = mediaListOptions?.scoreFormat,
+    )
+
+    private fun buildOptions(
+        titleLanguage: ApiTitleLanguage?,
+        displayAdultContent: Boolean?,
+        airingNotifications: Boolean?,
+        profileColor: String?,
+        timezone: String?,
+        activityMergeTime: Int?,
+        staffNameLanguage: ApiStaffNameLanguage?,
+        restrictMessagesToFollowing: Boolean?,
+        disabledListActivity: List<Pair<ApiListStatus?, Boolean>>?,
+        scoreFormat: ApiScoreFormat?,
+    ): AniListUserOptions = AniListUserOptions(
+        titleLanguage = titleLanguage.toDomain(),
+        displayAdultContent = displayAdultContent ?: false,
+        airingNotifications = airingNotifications ?: true,
+        profileColor = profileColor,
+        timezone = timezone,
+        activityMergeTime = activityMergeTime,
+        staffNameLanguage = staffNameLanguage.toDomain(),
+        restrictMessagesToFollowing = restrictMessagesToFollowing ?: false,
+        disabledListActivity = disabledListActivity
+            ?.mapNotNull { (status, disabled) -> status.toDomain()?.let { it to disabled } }
+            ?.toMap()
+            .orEmpty(),
+        scoreFormat = scoreFormat.toDomain(),
+    )
+
+    private fun UserOptionsPatch.toMutation(): UpdateUserOptionsMutation = UpdateUserOptionsMutation(
+        displayAdultContent = displayAdultContent.toOptional(),
+        titleLanguage = (titleLanguage?.toApi()).toOptional(),
+        staffNameLanguage = (staffNameLanguage?.toApi()).toOptional(),
+        scoreFormat = (scoreFormat?.toApi()).toOptional(),
+        airingNotifications = airingNotifications.toOptional(),
+        restrictMessagesToFollowing = restrictMessagesToFollowing.toOptional(),
+        activityMergeTime = activityMergeTime.toOptional(),
+        profileColor = profileColor.toOptional(),
+        disabledListActivity = disabledListActivity?.map { (status, disabled) ->
+            com.anisync.android.type.ListActivityOptionInput(
+                disabled = Optional.present(disabled),
+                type = Optional.present(status.toApi()),
+            )
+        }.toOptional(),
+    )
+}
+
+private fun <T : Any> T?.toOptional(): Optional<T> =
+    if (this != null) Optional.present(this) else Optional.absent()
+
+private fun ApiTitleLanguage?.toDomain(): AniListTitleLanguage? = when (this) {
+    ApiTitleLanguage.ROMAJI -> AniListTitleLanguage.ROMAJI
+    ApiTitleLanguage.ENGLISH -> AniListTitleLanguage.ENGLISH
+    ApiTitleLanguage.NATIVE -> AniListTitleLanguage.NATIVE
+    ApiTitleLanguage.ROMAJI_STYLISED -> AniListTitleLanguage.ROMAJI_STYLISED
+    ApiTitleLanguage.ENGLISH_STYLISED -> AniListTitleLanguage.ENGLISH_STYLISED
+    ApiTitleLanguage.NATIVE_STYLISED -> AniListTitleLanguage.NATIVE_STYLISED
+    else -> null
+}
+
+private fun AniListTitleLanguage.toApi(): ApiTitleLanguage = when (this) {
+    AniListTitleLanguage.ROMAJI -> ApiTitleLanguage.ROMAJI
+    AniListTitleLanguage.ENGLISH -> ApiTitleLanguage.ENGLISH
+    AniListTitleLanguage.NATIVE -> ApiTitleLanguage.NATIVE
+    AniListTitleLanguage.ROMAJI_STYLISED -> ApiTitleLanguage.ROMAJI_STYLISED
+    AniListTitleLanguage.ENGLISH_STYLISED -> ApiTitleLanguage.ENGLISH_STYLISED
+    AniListTitleLanguage.NATIVE_STYLISED -> ApiTitleLanguage.NATIVE_STYLISED
+}
+
+private fun ApiStaffNameLanguage?.toDomain(): AniListStaffNameLanguage? = when (this) {
+    ApiStaffNameLanguage.ROMAJI_WESTERN -> AniListStaffNameLanguage.ROMAJI_WESTERN
+    ApiStaffNameLanguage.ROMAJI -> AniListStaffNameLanguage.ROMAJI
+    ApiStaffNameLanguage.NATIVE -> AniListStaffNameLanguage.NATIVE
+    else -> null
+}
+
+private fun AniListStaffNameLanguage.toApi(): ApiStaffNameLanguage = when (this) {
+    AniListStaffNameLanguage.ROMAJI_WESTERN -> ApiStaffNameLanguage.ROMAJI_WESTERN
+    AniListStaffNameLanguage.ROMAJI -> ApiStaffNameLanguage.ROMAJI
+    AniListStaffNameLanguage.NATIVE -> ApiStaffNameLanguage.NATIVE
+}
+
+private fun ApiScoreFormat?.toDomain(): ScoreFormat? = when (this) {
+    ApiScoreFormat.POINT_100 -> ScoreFormat.POINT_100
+    ApiScoreFormat.POINT_10_DECIMAL -> ScoreFormat.POINT_10_DECIMAL
+    ApiScoreFormat.POINT_10 -> ScoreFormat.POINT_10
+    ApiScoreFormat.POINT_5 -> ScoreFormat.POINT_5
+    ApiScoreFormat.POINT_3 -> ScoreFormat.POINT_3
+    else -> null
+}
+
+private fun ScoreFormat.toApi(): ApiScoreFormat = when (this) {
+    ScoreFormat.POINT_100 -> ApiScoreFormat.POINT_100
+    ScoreFormat.POINT_10_DECIMAL -> ApiScoreFormat.POINT_10_DECIMAL
+    ScoreFormat.POINT_10 -> ApiScoreFormat.POINT_10
+    ScoreFormat.POINT_5 -> ApiScoreFormat.POINT_5
+    ScoreFormat.POINT_3 -> ApiScoreFormat.POINT_3
+}
+
+private fun ApiListStatus?.toDomain(): AniListListActivityStatus? = when (this) {
+    ApiListStatus.CURRENT -> AniListListActivityStatus.CURRENT
+    ApiListStatus.PLANNING -> AniListListActivityStatus.PLANNING
+    ApiListStatus.COMPLETED -> AniListListActivityStatus.COMPLETED
+    ApiListStatus.DROPPED -> AniListListActivityStatus.DROPPED
+    ApiListStatus.PAUSED -> AniListListActivityStatus.PAUSED
+    ApiListStatus.REPEATING -> AniListListActivityStatus.REPEATING
+    else -> null
+}
+
+private fun AniListListActivityStatus.toApi(): ApiListStatus = when (this) {
+    AniListListActivityStatus.CURRENT -> ApiListStatus.CURRENT
+    AniListListActivityStatus.PLANNING -> ApiListStatus.PLANNING
+    AniListListActivityStatus.COMPLETED -> ApiListStatus.COMPLETED
+    AniListListActivityStatus.DROPPED -> ApiListStatus.DROPPED
+    AniListListActivityStatus.PAUSED -> ApiListStatus.PAUSED
+    AniListListActivityStatus.REPEATING -> ApiListStatus.REPEATING
+}

--- a/app/src/main/java/com/anisync/android/data/UserOptionsRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/UserOptionsRepositoryImpl.kt
@@ -103,18 +103,23 @@ class UserOptionsRepositoryImpl @Inject constructor(
      */
     private fun reconcile(accountId: Int, fresh: AniListUserOptions) {
         val current = _state.value ?: LocalOptionsState()
-        val allFields = UserOptionField.entries.toSet()
-        val changedOnServer = current.serverSnapshot.differingFields(fresh)
-        val conflictFields = current.dirty intersect changedOnServer
-        val cleanFields = allFields - current.dirty
+        val all = UserOptionField.entries.toSet()
+        // Dirty edits still genuinely pending: the local value disagrees with the fresh server value.
+        // A dirty field the server already agrees with isn't pending (and isn't a conflict).
+        val pending = current.dirty intersect current.local.differingFields(fresh)
+        // A conflict is a pending edit where the server also moved since our baseline.
+        val conflictFields = pending intersect current.serverSnapshot.differingFields(fresh)
+        // Everything not pending adopts the server value (clean fields + converged dirty edits).
+        val adopt = all - pending
 
         commit(
             accountId,
             current.copy(
-                local = current.local.takeFields(cleanFields, fresh),
-                // Baseline advances to the server for everything except unresolved conflict fields.
-                serverSnapshot = current.serverSnapshot.takeFields(allFields - conflictFields, fresh),
-                conflict = if (conflictFields.isNotEmpty()) ConflictState(conflictFields, fresh) else current.conflict,
+                local = current.local.takeFields(adopt, fresh),
+                // Baseline advances to the server everywhere except unresolved conflicts.
+                serverSnapshot = current.serverSnapshot.takeFields(all - conflictFields, fresh),
+                dirty = pending,
+                conflict = if (conflictFields.isNotEmpty()) ConflictState(conflictFields, fresh) else null,
             ),
         )
     }

--- a/app/src/main/java/com/anisync/android/data/UserOptionsRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/UserOptionsRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.anisync.android.data
 
+import android.content.Context
 import com.anisync.android.GetViewerQuery
 import com.anisync.android.UpdateUserOptionsMutation
 import com.anisync.android.data.account.AccountManager
@@ -8,23 +9,38 @@ import com.anisync.android.domain.AniListListActivityStatus
 import com.anisync.android.domain.AniListStaffNameLanguage
 import com.anisync.android.domain.AniListTitleLanguage
 import com.anisync.android.domain.AniListUserOptions
+import com.anisync.android.domain.ConflictState
+import com.anisync.android.domain.LocalOptionsState
 import com.anisync.android.domain.Result
 import com.anisync.android.domain.ScoreFormat
+import com.anisync.android.domain.UserOptionField
 import com.anisync.android.domain.UserOptionsPatch
 import com.anisync.android.domain.UserOptionsRepository
+import com.anisync.android.domain.applyPatch
+import com.anisync.android.domain.affectedFields
+import com.anisync.android.domain.differingFields
+import com.anisync.android.domain.patchForFields
+import com.anisync.android.domain.takeFields
+import com.anisync.android.worker.UserOptionsFlushWorker
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Optional
 import com.apollographql.apollo.cache.normalized.FetchPolicy
 import com.apollographql.apollo.cache.normalized.fetchPolicy
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 import com.anisync.android.type.MediaListStatus as ApiListStatus
@@ -38,70 +54,159 @@ class UserOptionsRepositoryImpl @Inject constructor(
     private val store: UserOptionsStore,
     private val accountManager: AccountManager,
     private val appSettings: AppSettings,
+    @ApplicationContext private val context: Context,
 ) : UserOptionsRepository {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val flushMutex = Mutex()
+    private var debounceJob: Job? = null
 
-    private val _cachedOptions = MutableStateFlow(currentAccountId()?.let { store.read(it) })
-    override val cachedOptions: StateFlow<AniListUserOptions?> = _cachedOptions.asStateFlow()
+    private val _state = MutableStateFlow(currentAccountId()?.let { store.read(it) })
+
+    override val cachedOptions: StateFlow<AniListUserOptions?> =
+        _state.map { it?.local }.stateIn(scope, SharingStarted.Eagerly, _state.value?.local)
+
+    override val conflict: StateFlow<ConflictState?> =
+        _state.map { it?.conflict }.stateIn(scope, SharingStarted.Eagerly, _state.value?.conflict)
 
     init {
-        // On account switch, instantly surface that account's cached options (offline) and re-mirror,
-        // so effective settings reflect the active account without waiting on the network. A fresh
-        // network pull is driven separately by UserOptionsSyncManager.
+        // On account switch, load that account's cached state (offline) and re-mirror immediately.
+        // A fresh network pull is driven separately by UserOptionsSyncManager.
         scope.launch {
             accountManager.activeAccount
                 .map { it?.id }
                 .distinctUntilChanged()
                 .collect { id ->
-                    val cached = id?.let { store.read(it) }
-                    _cachedOptions.value = cached
-                    if (cached != null) mirrorToLocal(cached)
+                    val loaded = id?.let { store.read(it) }
+                    _state.value = loaded
+                    loaded?.local?.let { mirror(it) }
                 }
         }
     }
 
-    override suspend fun fetchOptions(): Result<AniListUserOptions> = safeApiCall {
+    override suspend fun pull(): Result<Unit> = safeApiCall {
+        val accountId = currentAccountId() ?: throw Exception("Not signed in")
         val response = apolloClient.query(GetViewerQuery())
             .fetchPolicy(FetchPolicy.NetworkFirst)
             .execute()
         if (response.hasErrors()) {
             throw Exception(response.errors?.firstOrNull()?.message ?: "Failed to load account options")
         }
-        val viewer = response.data?.Viewer ?: throw Exception("Not signed in")
-        viewer.toDomain().also { persist(it) }
-    }
-
-    override suspend fun updateOptions(patch: UserOptionsPatch): Result<AniListUserOptions> = safeApiCall {
-        val response = apolloClient.mutation(patch.toMutation()).execute()
-        if (response.hasErrors()) {
-            throw Exception(response.errors?.firstOrNull()?.message ?: "Failed to update account options")
-        }
-        val user = response.data?.UpdateUser ?: throw Exception("Update returned no user")
-        user.toDomain().also { persist(it) }
-    }
-
-    /** Persist to the per-account cache, update the live flow, and mirror behavior-affecting values. */
-    private fun persist(options: AniListUserOptions) {
-        currentAccountId()?.let { store.write(it, options) }
-        _cachedOptions.value = options
-        mirrorToLocal(options)
+        val fresh = response.data?.Viewer?.toDomain() ?: throw Exception("Not signed in")
+        reconcile(accountId, fresh)
     }
 
     /**
-     * Mirror the options that drive local app behavior into [AppSettings], honoring the device
-     * override switches. Adult content and title language are skipped when their override is ON;
-     * staff-name language and score format always follow the account (no local-only counterpart).
+     * Merge a fresh server snapshot into local state. Clean (non-dirty) fields adopt the server value;
+     * a dirty field whose server value changed since our baseline becomes a conflict (local value is
+     * kept until the user resolves it).
      */
-    private fun mirrorToLocal(options: AniListUserOptions) {
-        if (!appSettings.adultContentOverrideEnabled.value) {
-            appSettings.setShowAdultContent(options.displayAdultContent)
+    private fun reconcile(accountId: Int, fresh: AniListUserOptions) {
+        val current = _state.value ?: LocalOptionsState()
+        val allFields = UserOptionField.entries.toSet()
+        val changedOnServer = current.serverSnapshot.differingFields(fresh)
+        val conflictFields = current.dirty intersect changedOnServer
+        val cleanFields = allFields - current.dirty
+
+        commit(
+            accountId,
+            current.copy(
+                local = current.local.takeFields(cleanFields, fresh),
+                // Baseline advances to the server for everything except unresolved conflict fields.
+                serverSnapshot = current.serverSnapshot.takeFields(allFields - conflictFields, fresh),
+                conflict = if (conflictFields.isNotEmpty()) ConflictState(conflictFields, fresh) else current.conflict,
+            ),
+        )
+    }
+
+    override fun applyEdit(patch: UserOptionsPatch) {
+        val accountId = currentAccountId() ?: return
+        val current = _state.value ?: LocalOptionsState()
+        commit(
+            accountId,
+            current.copy(
+                local = current.local.applyPatch(patch),
+                dirty = current.dirty + patch.affectedFields(),
+            ),
+        )
+        scheduleFlush()
+    }
+
+    override suspend fun flush() {
+        flushMutex.withLock {
+            val accountId = currentAccountId() ?: return
+            if ((_state.value?.dirty).isNullOrEmpty()) return
+
+            // Refresh from the server first so a concurrent web change is detected as a conflict
+            // rather than silently overwritten. Offline → keep the pending edits and retry later.
+            if (pull() is Result.Error) return
+
+            val state = _state.value ?: return
+            val pushFields = state.dirty - (state.conflict?.fields ?: emptySet())
+            if (pushFields.isEmpty()) return
+
+            val patch = state.local.patchForFields(pushFields)
+            val response = apolloClient.mutation(patch.toMutation()).execute()
+            if (response.hasErrors()) return // keep dirty; a later flush retries
+            val updated = response.data?.UpdateUser?.toDomain() ?: return
+
+            commit(
+                accountId,
+                state.copy(
+                    serverSnapshot = state.serverSnapshot.takeFields(pushFields, updated),
+                    dirty = state.dirty - pushFields,
+                ),
+            )
         }
-        if (!appSettings.titleLanguageOverrideEnabled.value) {
-            options.titleLanguage?.let { appSettings.setTitleLanguage(it.toLocalTitleLanguage()) }
+    }
+
+    override fun resolveConflict(keepLocal: Boolean) {
+        val accountId = currentAccountId() ?: return
+        val state = _state.value ?: return
+        val conflict = state.conflict ?: return
+
+        val resolved = if (keepLocal) {
+            // Re-baseline the conflicting fields to the server value so the next flush pushes local.
+            state.copy(
+                serverSnapshot = state.serverSnapshot.takeFields(conflict.fields, conflict.serverValues),
+                conflict = null,
+            )
+        } else {
+            // Adopt the website's values and drop the local edits for those fields.
+            state.copy(
+                local = state.local.takeFields(conflict.fields, conflict.serverValues),
+                serverSnapshot = state.serverSnapshot.takeFields(conflict.fields, conflict.serverValues),
+                dirty = state.dirty - conflict.fields,
+                conflict = null,
+            )
         }
-        options.staffNameLanguage?.let { appSettings.setStaffNameLanguage(it.toLocalStaffNameLanguage()) }
-        options.scoreFormat?.let { appSettings.setUserScoreFormat(it) }
+        commit(accountId, resolved)
+        if (keepLocal) scheduleFlush()
+    }
+
+    /** Persist, publish, and mirror behavior-affecting values into [AppSettings]. */
+    private fun commit(accountId: Int, state: LocalOptionsState) {
+        store.write(accountId, state)
+        _state.value = state
+        mirror(state.local)
+    }
+
+    private fun scheduleFlush() {
+        debounceJob?.cancel()
+        debounceJob = scope.launch {
+            delay(FLUSH_DEBOUNCE_MS)
+            flush()
+        }
+        // Safety net: survives process death and waits for connectivity.
+        UserOptionsFlushWorker.enqueue(context)
+    }
+
+    /** The options that drive local app behavior always follow the local working copy. */
+    private fun mirror(local: AniListUserOptions) {
+        appSettings.setShowAdultContent(local.displayAdultContent)
+        local.titleLanguage?.let { appSettings.setTitleLanguage(it.toLocalTitleLanguage()) }
+        local.staffNameLanguage?.let { appSettings.setStaffNameLanguage(it.toLocalStaffNameLanguage()) }
+        local.scoreFormat?.let { appSettings.setUserScoreFormat(it) }
     }
 
     private fun currentAccountId(): Int? = accountManager.activeAccount.value?.id
@@ -177,6 +282,10 @@ class UserOptionsRepositoryImpl @Inject constructor(
             )
         }.toOptional(),
     )
+
+    private companion object {
+        const val FLUSH_DEBOUNCE_MS = 5_000L
+    }
 }
 
 private fun <T : Any> T?.toOptional(): Optional<T> =

--- a/app/src/main/java/com/anisync/android/data/UserOptionsStore.kt
+++ b/app/src/main/java/com/anisync/android/data/UserOptionsStore.kt
@@ -1,0 +1,43 @@
+package com.anisync.android.data
+
+import android.content.Context
+import com.anisync.android.domain.AniListUserOptions
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Per-account on-device cache of [AniListUserOptions], persisted as JSON in SharedPreferences and
+ * keyed by AniList account id. Mirrors the JSON-blob persistence pattern used for typography
+ * overrides in [AppSettings]; one small blob per account avoids a migration when the option set grows.
+ */
+@Singleton
+class UserOptionsStore @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+    private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    fun read(accountId: Int): AniListUserOptions? {
+        val raw = prefs.getString(key(accountId), null) ?: return null
+        return runCatching { json.decodeFromString<AniListUserOptions>(raw) }.getOrNull()
+    }
+
+    fun write(accountId: Int, options: AniListUserOptions) {
+        prefs.edit().putString(key(accountId), json.encodeToString(options)).apply()
+    }
+
+    fun clear(accountId: Int) {
+        prefs.edit().remove(key(accountId)).apply()
+    }
+
+    private fun key(accountId: Int): String = "options_$accountId"
+
+    companion object {
+        private const val PREFS_NAME = "anisync_user_options"
+    }
+}

--- a/app/src/main/java/com/anisync/android/data/UserOptionsStore.kt
+++ b/app/src/main/java/com/anisync/android/data/UserOptionsStore.kt
@@ -1,16 +1,17 @@
 package com.anisync.android.data
 
 import android.content.Context
-import com.anisync.android.domain.AniListUserOptions
+import com.anisync.android.domain.LocalOptionsState
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Per-account on-device cache of [AniListUserOptions], persisted as JSON in SharedPreferences and
- * keyed by AniList account id. Mirrors the JSON-blob persistence pattern used for typography
- * overrides in [AppSettings]; one small blob per account avoids a migration when the option set grows.
+ * Per-account on-device cache of the local-first sync state ([LocalOptionsState]: server snapshot,
+ * local working copy, dirty fields, pending conflict), persisted as JSON in SharedPreferences keyed
+ * by AniList account id. Mirrors the JSON-blob persistence pattern used for typography overrides in
+ * [AppSettings]; one small blob per account avoids a migration when the option set grows.
  */
 @Singleton
 class UserOptionsStore @Inject constructor(
@@ -22,20 +23,20 @@ class UserOptionsStore @Inject constructor(
         encodeDefaults = true
     }
 
-    fun read(accountId: Int): AniListUserOptions? {
+    fun read(accountId: Int): LocalOptionsState? {
         val raw = prefs.getString(key(accountId), null) ?: return null
-        return runCatching { json.decodeFromString<AniListUserOptions>(raw) }.getOrNull()
+        return runCatching { json.decodeFromString<LocalOptionsState>(raw) }.getOrNull()
     }
 
-    fun write(accountId: Int, options: AniListUserOptions) {
-        prefs.edit().putString(key(accountId), json.encodeToString(options)).apply()
+    fun write(accountId: Int, state: LocalOptionsState) {
+        prefs.edit().putString(key(accountId), json.encodeToString(state)).apply()
     }
 
     fun clear(accountId: Int) {
         prefs.edit().remove(key(accountId)).apply()
     }
 
-    private fun key(accountId: Int): String = "options_$accountId"
+    private fun key(accountId: Int): String = "state_$accountId"
 
     companion object {
         private const val PREFS_NAME = "anisync_user_options"

--- a/app/src/main/java/com/anisync/android/data/UserOptionsSyncManager.kt
+++ b/app/src/main/java/com/anisync/android/data/UserOptionsSyncManager.kt
@@ -1,0 +1,33 @@
+package com.anisync.android.data
+
+import com.anisync.android.data.account.AccountManager
+import com.anisync.android.domain.SyncUserOptionsUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Drives the network pull of AniList account options. Started once from the Application; pulls fresh
+ * options whenever a (non-null) account becomes active — i.e. on cold start with a signed-in account
+ * and after every account add/switch — so the app respects the latest web options (fixes the activity
+ * feed leaking NSFW content blocked on the account).
+ */
+@Singleton
+class UserOptionsSyncManager @Inject constructor(
+    private val accountManager: AccountManager,
+    private val syncUserOptions: SyncUserOptionsUseCase,
+) {
+    fun start(scope: CoroutineScope) {
+        scope.launch {
+            accountManager.activeAccount
+                .map { it?.id }
+                .distinctUntilChanged()
+                .collect { id ->
+                    if (id != null) syncUserOptions()
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/anisync/android/data/UserOptionsSyncManager.kt
+++ b/app/src/main/java/com/anisync/android/data/UserOptionsSyncManager.kt
@@ -2,7 +2,12 @@ package com.anisync.android.data
 
 import com.anisync.android.data.account.AccountManager
 import com.anisync.android.domain.SyncUserOptionsUseCase
+import com.anisync.android.domain.UserOptionsRepository
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.ProcessLifecycleOwner
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -10,15 +15,17 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Drives the network pull of AniList account options. Started once from the Application; pulls fresh
- * options whenever a (non-null) account becomes active — i.e. on cold start with a signed-in account
- * and after every account add/switch — so the app respects the latest web options (fixes the activity
- * feed leaking NSFW content blocked on the account).
+ * Drives the network side of the local-first options sync. Started once from the Application:
+ *  - **Pull** fresh options whenever a (non-null) account becomes active — cold start with a signed-in
+ *    account and after every account add/switch — so the app respects the latest web options.
+ *  - **Flush** any pending local edits when the app goes to the background (a natural "user stopped
+ *    interacting" point), complementing the per-edit debounce and the WorkManager safety net.
  */
 @Singleton
 class UserOptionsSyncManager @Inject constructor(
     private val accountManager: AccountManager,
     private val syncUserOptions: SyncUserOptionsUseCase,
+    private val userOptionsRepository: UserOptionsRepository,
 ) {
     fun start(scope: CoroutineScope) {
         scope.launch {
@@ -28,6 +35,17 @@ class UserOptionsSyncManager @Inject constructor(
                 .collect { id ->
                     if (id != null) syncUserOptions()
                 }
+        }
+
+        // Lifecycle observers must be registered on the main thread.
+        scope.launch(Dispatchers.Main) {
+            ProcessLifecycleOwner.get().lifecycle.addObserver(
+                LifecycleEventObserver { _, event ->
+                    if (event == Lifecycle.Event.ON_STOP) {
+                        scope.launch { userOptionsRepository.flush() }
+                    }
+                }
+            )
         }
     }
 }

--- a/app/src/main/java/com/anisync/android/data/mapper/ActivityMapper.kt
+++ b/app/src/main/java/com/anisync/android/data/mapper/ActivityMapper.kt
@@ -16,6 +16,7 @@ internal fun ActivityFields.toDomain(): UserActivity? {
             mediaTitle = l.media?.title?.userPreferred ?: "Unknown",
             mediaCoverUrl = l.media?.coverImage?.medium,
             mediaCover = com.anisync.android.domain.CoverImage.of(l.media?.coverImage?.medium, l.media?.coverImage?.large, l.media?.coverImage?.extraLarge),
+            mediaIsAdult = l.media?.isAdult == true,
             timestamp = (l.createdAt?.toLong() ?: 0L) * 1000L,
             mediaScore = null,
             userId = l.user?.id,

--- a/app/src/main/java/com/anisync/android/di/RepositoryModule.kt
+++ b/app/src/main/java/com/anisync/android/di/RepositoryModule.kt
@@ -12,6 +12,7 @@ import com.anisync.android.data.NotificationRepositoryImpl
 import com.anisync.android.data.ProfileRepositoryImpl
 import com.anisync.android.data.SearchRepositoryImpl
 import com.anisync.android.data.StatisticsRepositoryImpl
+import com.anisync.android.data.UserOptionsRepositoryImpl
 import com.anisync.android.data.repository.PreferencesRepositoryImpl
 import com.anisync.android.domain.ActivityRepository
 import com.anisync.android.domain.CalendarRepository
@@ -26,6 +27,7 @@ import com.anisync.android.domain.PreferencesRepository
 import com.anisync.android.domain.ProfileRepository
 import com.anisync.android.domain.SearchRepository
 import com.anisync.android.domain.StatisticsRepository
+import com.anisync.android.domain.UserOptionsRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -99,4 +101,9 @@ abstract class RepositoryModule {
     abstract fun bindCalendarRepository(
         impl: CalendarRepositoryImpl
     ): CalendarRepository
+
+    @Binds
+    abstract fun bindUserOptionsRepository(
+        impl: UserOptionsRepositoryImpl
+    ): UserOptionsRepository
 }

--- a/app/src/main/java/com/anisync/android/domain/AniListUserOptions.kt
+++ b/app/src/main/java/com/anisync/android/domain/AniListUserOptions.kt
@@ -1,0 +1,76 @@
+package com.anisync.android.domain
+
+import androidx.compose.runtime.Immutable
+import kotlinx.serialization.Serializable
+
+/**
+ * A device-cached snapshot of a user's AniList account options (the `UserOptions` object plus the
+ * score format from `MediaListOptions`). AniList is the source of truth; this mirrors the last-known
+ * values per account so the app can respect them offline and resolve "effective" settings without a
+ * round-trip. See [UserOptionsRepository] for the sync mechanic.
+ */
+@Immutable
+@Serializable
+data class AniListUserOptions(
+    val titleLanguage: AniListTitleLanguage? = null,
+    val displayAdultContent: Boolean = false,
+    val airingNotifications: Boolean = true,
+    /** AniList profile highlight color name (blue/purple/pink/orange/red/green/gray), or null. */
+    val profileColor: String? = null,
+    val timezone: String? = null,
+    /** Minutes before separate activities merge. 0 = Never, >= 20160 (2 weeks) = Always. */
+    val activityMergeTime: Int? = null,
+    val staffNameLanguage: AniListStaffNameLanguage? = null,
+    val restrictMessagesToFollowing: Boolean = false,
+    /**
+     * Per list-status flag: `true` means list updates of that status are **disabled** from creating
+     * activity on AniList. Statuses absent from the map are enabled (the AniList default).
+     */
+    val disabledListActivity: Map<AniListListActivityStatus, Boolean> = emptyMap(),
+    val scoreFormat: ScoreFormat? = null,
+)
+
+/** Mirrors AniList's `UserTitleLanguage` (6 values, including the creator-stylised variants). */
+@Serializable
+enum class AniListTitleLanguage {
+    ROMAJI,
+    ENGLISH,
+    NATIVE,
+    ROMAJI_STYLISED,
+    ENGLISH_STYLISED,
+    NATIVE_STYLISED,
+}
+
+/** Mirrors AniList's `UserStaffNameLanguage`. */
+@Serializable
+enum class AniListStaffNameLanguage {
+    ROMAJI_WESTERN,
+    ROMAJI,
+    NATIVE,
+}
+
+/** The `MediaListStatus` values that can drive auto-created list activity. */
+@Serializable
+enum class AniListListActivityStatus {
+    CURRENT,
+    PLANNING,
+    COMPLETED,
+    DROPPED,
+    PAUSED,
+    REPEATING,
+}
+
+/**
+ * A partial edit pushed to AniList via `UpdateUser`. Null fields are left unchanged on the server.
+ */
+data class UserOptionsPatch(
+    val displayAdultContent: Boolean? = null,
+    val titleLanguage: AniListTitleLanguage? = null,
+    val staffNameLanguage: AniListStaffNameLanguage? = null,
+    val scoreFormat: ScoreFormat? = null,
+    val airingNotifications: Boolean? = null,
+    val restrictMessagesToFollowing: Boolean? = null,
+    val activityMergeTime: Int? = null,
+    val profileColor: String? = null,
+    val disabledListActivity: Map<AniListListActivityStatus, Boolean>? = null,
+)

--- a/app/src/main/java/com/anisync/android/domain/SyncUserOptionsUseCase.kt
+++ b/app/src/main/java/com/anisync/android/domain/SyncUserOptionsUseCase.kt
@@ -1,0 +1,13 @@
+package com.anisync.android.domain
+
+import javax.inject.Inject
+
+/**
+ * Pulls the active account's AniList options and mirrors them into local settings. Safe to call on
+ * app start and on account switch; it no-ops (returns an error result) when signed out.
+ */
+class SyncUserOptionsUseCase @Inject constructor(
+    private val repository: UserOptionsRepository,
+) {
+    suspend operator fun invoke(): Result<AniListUserOptions> = repository.fetchOptions()
+}

--- a/app/src/main/java/com/anisync/android/domain/SyncUserOptionsUseCase.kt
+++ b/app/src/main/java/com/anisync/android/domain/SyncUserOptionsUseCase.kt
@@ -9,5 +9,5 @@ import javax.inject.Inject
 class SyncUserOptionsUseCase @Inject constructor(
     private val repository: UserOptionsRepository,
 ) {
-    suspend operator fun invoke(): Result<AniListUserOptions> = repository.fetchOptions()
+    suspend operator fun invoke(): Result<Unit> = repository.pull()
 }

--- a/app/src/main/java/com/anisync/android/domain/UserOptionField.kt
+++ b/app/src/main/java/com/anisync/android/domain/UserOptionField.kt
@@ -1,0 +1,105 @@
+package com.anisync.android.domain
+
+import kotlinx.serialization.Serializable
+
+/**
+ * The individually-editable AniList account options. Used to track which fields the user changed
+ * locally ("dirty") and to detect per-field conflicts against the server during sync.
+ */
+@Serializable
+enum class UserOptionField {
+    DISPLAY_ADULT_CONTENT,
+    TITLE_LANGUAGE,
+    STAFF_NAME_LANGUAGE,
+    SCORE_FORMAT,
+    AIRING_NOTIFICATIONS,
+    RESTRICT_MESSAGES_TO_FOLLOWING,
+    ACTIVITY_MERGE_TIME,
+    PROFILE_COLOR,
+    DISABLED_LIST_ACTIVITY,
+}
+
+/**
+ * Per-account local-first sync state, persisted between launches.
+ *
+ * - [serverSnapshot]: the option values last known to match the AniList server (the conflict baseline).
+ * - [local]: the working copy the app reads and the UI shows (may be ahead of the server).
+ * - [dirty]: fields edited locally that still need pushing.
+ * - [conflict]: a detected divergence awaiting the user's choice (null when none).
+ */
+@Serializable
+data class LocalOptionsState(
+    val serverSnapshot: AniListUserOptions = AniListUserOptions(),
+    val local: AniListUserOptions = AniListUserOptions(),
+    val dirty: Set<UserOptionField> = emptySet(),
+    val conflict: ConflictState? = null,
+)
+
+/** A field-level conflict: [fields] changed both locally and on the server; [serverValues] is fresh. */
+@Serializable
+data class ConflictState(
+    val fields: Set<UserOptionField>,
+    val serverValues: AniListUserOptions,
+)
+
+/** Fields whose values differ between two snapshots. */
+fun AniListUserOptions.differingFields(other: AniListUserOptions): Set<UserOptionField> =
+    UserOptionField.entries.filterTo(mutableSetOf()) { !valueEquals(other, it) }
+
+private fun AniListUserOptions.valueEquals(other: AniListUserOptions, field: UserOptionField): Boolean =
+    when (field) {
+        UserOptionField.DISPLAY_ADULT_CONTENT -> displayAdultContent == other.displayAdultContent
+        UserOptionField.TITLE_LANGUAGE -> titleLanguage == other.titleLanguage
+        UserOptionField.STAFF_NAME_LANGUAGE -> staffNameLanguage == other.staffNameLanguage
+        UserOptionField.SCORE_FORMAT -> scoreFormat == other.scoreFormat
+        UserOptionField.AIRING_NOTIFICATIONS -> airingNotifications == other.airingNotifications
+        UserOptionField.RESTRICT_MESSAGES_TO_FOLLOWING ->
+            restrictMessagesToFollowing == other.restrictMessagesToFollowing
+        UserOptionField.ACTIVITY_MERGE_TIME -> activityMergeTime == other.activityMergeTime
+        UserOptionField.PROFILE_COLOR -> profileColor == other.profileColor
+        UserOptionField.DISABLED_LIST_ACTIVITY -> disabledListActivity == other.disabledListActivity
+    }
+
+/** The fields a patch sets (its non-null members). */
+fun UserOptionsPatch.affectedFields(): Set<UserOptionField> = buildSet {
+    if (displayAdultContent != null) add(UserOptionField.DISPLAY_ADULT_CONTENT)
+    if (titleLanguage != null) add(UserOptionField.TITLE_LANGUAGE)
+    if (staffNameLanguage != null) add(UserOptionField.STAFF_NAME_LANGUAGE)
+    if (scoreFormat != null) add(UserOptionField.SCORE_FORMAT)
+    if (airingNotifications != null) add(UserOptionField.AIRING_NOTIFICATIONS)
+    if (restrictMessagesToFollowing != null) add(UserOptionField.RESTRICT_MESSAGES_TO_FOLLOWING)
+    if (activityMergeTime != null) add(UserOptionField.ACTIVITY_MERGE_TIME)
+    if (profileColor != null) add(UserOptionField.PROFILE_COLOR)
+    if (disabledListActivity != null) add(UserOptionField.DISABLED_LIST_ACTIVITY)
+}
+
+/** Returns a copy with the patch's non-null fields applied. */
+fun AniListUserOptions.applyPatch(patch: UserOptionsPatch): AniListUserOptions = copy(
+    displayAdultContent = patch.displayAdultContent ?: displayAdultContent,
+    titleLanguage = patch.titleLanguage ?: titleLanguage,
+    staffNameLanguage = patch.staffNameLanguage ?: staffNameLanguage,
+    scoreFormat = patch.scoreFormat ?: scoreFormat,
+    airingNotifications = patch.airingNotifications ?: airingNotifications,
+    restrictMessagesToFollowing = patch.restrictMessagesToFollowing ?: restrictMessagesToFollowing,
+    activityMergeTime = patch.activityMergeTime ?: activityMergeTime,
+    profileColor = patch.profileColor ?: profileColor,
+    disabledListActivity = patch.disabledListActivity ?: disabledListActivity,
+)
+
+/** Builds a patch carrying this snapshot's values for exactly [fields] (for pushing dirty fields). */
+fun AniListUserOptions.patchForFields(fields: Set<UserOptionField>): UserOptionsPatch = UserOptionsPatch(
+    displayAdultContent = displayAdultContent.takeIf { UserOptionField.DISPLAY_ADULT_CONTENT in fields },
+    titleLanguage = titleLanguage.takeIf { UserOptionField.TITLE_LANGUAGE in fields },
+    staffNameLanguage = staffNameLanguage.takeIf { UserOptionField.STAFF_NAME_LANGUAGE in fields },
+    scoreFormat = scoreFormat.takeIf { UserOptionField.SCORE_FORMAT in fields },
+    airingNotifications = airingNotifications.takeIf { UserOptionField.AIRING_NOTIFICATIONS in fields },
+    restrictMessagesToFollowing =
+        restrictMessagesToFollowing.takeIf { UserOptionField.RESTRICT_MESSAGES_TO_FOLLOWING in fields },
+    activityMergeTime = activityMergeTime.takeIf { UserOptionField.ACTIVITY_MERGE_TIME in fields },
+    profileColor = profileColor.takeIf { UserOptionField.PROFILE_COLOR in fields },
+    disabledListActivity = disabledListActivity.takeIf { UserOptionField.DISABLED_LIST_ACTIVITY in fields },
+)
+
+/** Returns a copy with [fields] taken from [from], other fields unchanged. */
+fun AniListUserOptions.takeFields(fields: Set<UserOptionField>, from: AniListUserOptions): AniListUserOptions =
+    applyPatch(from.patchForFields(fields))

--- a/app/src/main/java/com/anisync/android/domain/UserOptionsRepository.kt
+++ b/app/src/main/java/com/anisync/android/domain/UserOptionsRepository.kt
@@ -3,18 +3,31 @@ package com.anisync.android.domain
 import kotlinx.coroutines.flow.StateFlow
 
 /**
- * Reads and writes the active account's AniList options, treating AniList as the source of truth.
+ * Local-first store of the active account's AniList options.
  *
- * - [cachedOptions] is the last-known snapshot for the **active** account (reloaded on account switch).
- * - [fetchOptions] pulls fresh values from AniList, persists them per account, and mirrors the ones
- *   that map to local app behavior into [com.anisync.android.data.AppSettings] (honoring the device
- *   override flags).
- * - [updateOptions] pushes a partial edit via `UpdateUser` and refreshes the cache from the response.
+ * Edits apply to [cachedOptions] immediately (optimistic) and are coalesced into a pending patch that
+ * is flushed to AniList in the background. [pull] reconciles with the server; when a field changed both
+ * locally and on the website a [conflict] is surfaced for the user to resolve via [resolveConflict].
  */
 interface UserOptionsRepository {
+    /** The local working copy for the active account (what the UI shows). Null when signed out. */
     val cachedOptions: StateFlow<AniListUserOptions?>
 
-    suspend fun fetchOptions(): Result<AniListUserOptions>
+    /** A pending conflict awaiting the user's choice, or null. */
+    val conflict: StateFlow<ConflictState?>
 
-    suspend fun updateOptions(patch: UserOptionsPatch): Result<AniListUserOptions>
+    /** Pull from AniList and reconcile: clean fields take the server value; a dirty field whose server
+     *  value also changed becomes a [conflict]. */
+    suspend fun pull(): Result<Unit>
+
+    /** Apply an edit to the local copy immediately, mirror it, and schedule a background flush. */
+    fun applyEdit(patch: UserOptionsPatch)
+
+    /** Push pending local edits to AniList in one request. Guarded, coalesced, and a no-op when there
+     *  is nothing safe to push. */
+    suspend fun flush()
+
+    /** Resolve the current conflict. [keepLocal] = push the device's values over the website;
+     *  otherwise discard the local edits and adopt the website's values. */
+    fun resolveConflict(keepLocal: Boolean)
 }

--- a/app/src/main/java/com/anisync/android/domain/UserOptionsRepository.kt
+++ b/app/src/main/java/com/anisync/android/domain/UserOptionsRepository.kt
@@ -1,0 +1,20 @@
+package com.anisync.android.domain
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Reads and writes the active account's AniList options, treating AniList as the source of truth.
+ *
+ * - [cachedOptions] is the last-known snapshot for the **active** account (reloaded on account switch).
+ * - [fetchOptions] pulls fresh values from AniList, persists them per account, and mirrors the ones
+ *   that map to local app behavior into [com.anisync.android.data.AppSettings] (honoring the device
+ *   override flags).
+ * - [updateOptions] pushes a partial edit via `UpdateUser` and refreshes the cache from the response.
+ */
+interface UserOptionsRepository {
+    val cachedOptions: StateFlow<AniListUserOptions?>
+
+    suspend fun fetchOptions(): Result<AniListUserOptions>
+
+    suspend fun updateOptions(patch: UserOptionsPatch): Result<AniListUserOptions>
+}

--- a/app/src/main/java/com/anisync/android/domain/UserProfile.kt
+++ b/app/src/main/java/com/anisync/android/domain/UserProfile.kt
@@ -71,6 +71,9 @@ data class UserActivity(
     val mediaTitle: String = "",
     val mediaCoverUrl: String? = null,
     val mediaCover: CoverImage? = null,
+    /** AniList 18+ flag for the activity's media. Used to hide adult ListActivity from the feed
+     *  when the viewer's account has displayAdultContent off (matches the website). */
+    val mediaIsAdult: Boolean = false,
     val timestamp: Long,
     val mediaScore: Int? = null,
     val text: String? = null,

--- a/app/src/main/java/com/anisync/android/presentation/navigation/NavHost.kt
+++ b/app/src/main/java/com/anisync/android/presentation/navigation/NavHost.kt
@@ -52,12 +52,11 @@ import com.anisync.android.presentation.review.RecentReviewsScreen
 import com.anisync.android.presentation.review.ReviewDetailScreen
 import com.anisync.android.presentation.review.WriteReviewScreen
 import com.anisync.android.presentation.settings.AboutScreen
-import com.anisync.android.presentation.settings.AccountScreen
 import com.anisync.android.presentation.settings.AcknowledgmentsScreen
 import com.anisync.android.presentation.settings.DeveloperToolsScreen
 import com.anisync.android.presentation.settings.FontSettingsScreen
 import com.anisync.android.presentation.settings.LinksScreen
-import com.anisync.android.presentation.settings.AniListOptionsScreen
+import com.anisync.android.presentation.settings.AniListSettingsScreen
 import com.anisync.android.presentation.settings.LookAndFeelScreen
 import com.anisync.android.presentation.settings.MediaUploadSettingsScreen
 import com.anisync.android.presentation.settings.NotificationsScreen
@@ -1139,7 +1138,6 @@ fun AniSyncNavHost(
                     onNavigateToAniList = { navController.navigate(SettingsAniList) },
                     onNavigateToNotifications = { navController.navigate(SettingsNotifications) },
                     onNavigateToStorage = { navController.navigate(SettingsStorage) },
-                    onNavigateToAccount = { navController.navigate(SettingsAccount) },
                     onNavigateToAbout = { navController.navigate(SettingsAbout) },
                     onNavigateToSponsors = { navController.navigate(SettingsSponsors) },
                     onNavigateToUpdates = { navController.navigate(SettingsUpdates) },
@@ -1161,14 +1159,19 @@ fun AniSyncNavHost(
                 )
             }
 
-            // AniList Account options (synced with the user's AniList account)
+            // AniList settings (account management + AniList account options)
             composable<SettingsAniList>(
                 enterTransition = { sharedAxisZEnter() },
                 exitTransition = { sharedAxisZExit() },
                 popEnterTransition = { sharedAxisZPopEnter() },
                 popExitTransition = { sharedAxisZPopExit() }
             ) {
-                AniListOptionsScreen(
+                AniListSettingsScreen(
+                    onLogout = {
+                        navController.navigate(Login) {
+                            popUpTo(0) { inclusive = true }
+                        }
+                    },
                     onBackClick = { navController.popBackStack() }
                 )
             }
@@ -1193,23 +1196,6 @@ fun AniSyncNavHost(
                 popExitTransition = { sharedAxisZPopExit() }
             ) {
                 StorageScreen(
-                    onBackClick = { navController.popBackStack() }
-                )
-            }
-
-            // Account Settings
-            composable<SettingsAccount>(
-                enterTransition = { sharedAxisZEnter() },
-                exitTransition = { sharedAxisZExit() },
-                popEnterTransition = { sharedAxisZPopEnter() },
-                popExitTransition = { sharedAxisZPopExit() }
-            ) {
-                AccountScreen(
-                    onLogout = {
-                        navController.navigate(Login) {
-                            popUpTo(0) { inclusive = true }
-                        }
-                    },
                     onBackClick = { navController.popBackStack() }
                 )
             }

--- a/app/src/main/java/com/anisync/android/presentation/navigation/NavHost.kt
+++ b/app/src/main/java/com/anisync/android/presentation/navigation/NavHost.kt
@@ -57,6 +57,7 @@ import com.anisync.android.presentation.settings.AcknowledgmentsScreen
 import com.anisync.android.presentation.settings.DeveloperToolsScreen
 import com.anisync.android.presentation.settings.FontSettingsScreen
 import com.anisync.android.presentation.settings.LinksScreen
+import com.anisync.android.presentation.settings.AniListOptionsScreen
 import com.anisync.android.presentation.settings.LookAndFeelScreen
 import com.anisync.android.presentation.settings.MediaUploadSettingsScreen
 import com.anisync.android.presentation.settings.NotificationsScreen
@@ -1135,6 +1136,7 @@ fun AniSyncNavHost(
             ) {
                 SettingsScreen(
                     onNavigateToLookAndFeel = { navController.navigate(SettingsLookAndFeel) },
+                    onNavigateToAniList = { navController.navigate(SettingsAniList) },
                     onNavigateToNotifications = { navController.navigate(SettingsNotifications) },
                     onNavigateToStorage = { navController.navigate(SettingsStorage) },
                     onNavigateToAccount = { navController.navigate(SettingsAccount) },
@@ -1155,6 +1157,18 @@ fun AniSyncNavHost(
                 popExitTransition = { sharedAxisZPopExit() }
             ) {
                 LookAndFeelScreen(
+                    onBackClick = { navController.popBackStack() }
+                )
+            }
+
+            // AniList Account options (synced with the user's AniList account)
+            composable<SettingsAniList>(
+                enterTransition = { sharedAxisZEnter() },
+                exitTransition = { sharedAxisZExit() },
+                popEnterTransition = { sharedAxisZPopEnter() },
+                popExitTransition = { sharedAxisZPopExit() }
+            ) {
+                AniListOptionsScreen(
                     onBackClick = { navController.popBackStack() }
                 )
             }

--- a/app/src/main/java/com/anisync/android/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/navigation/Screen.kt
@@ -269,6 +269,13 @@ object Settings
 object SettingsLookAndFeel
 
 /**
+ * AniList account options (adult content, languages, score format, activity, profile color)
+ * that sync with the user's AniList account.
+ */
+@Serializable
+object SettingsAniList
+
+/**
  * Notification settings with master toggle and granular controls.
  */
 @Serializable

--- a/app/src/main/java/com/anisync/android/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/navigation/Screen.kt
@@ -269,8 +269,8 @@ object Settings
 object SettingsLookAndFeel
 
 /**
- * AniList account options (adult content, languages, score format, activity, profile color)
- * that sync with the user's AniList account.
+ * AniList settings: account management (add / switch / remove / logout) merged with the AniList
+ * account options (adult content, languages, score format, activity, profile color).
  */
 @Serializable
 object SettingsAniList
@@ -286,12 +286,6 @@ object SettingsNotifications
  */
 @Serializable
 object SettingsStorage
-
-/**
- * Account settings (user info, logout).
- */
-@Serializable
-object SettingsAccount
 
 /**
  * About app (version, licenses, acknowledgments).

--- a/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsScreen.kt
@@ -66,15 +66,8 @@ internal fun AniListOptionsContent(
         SwitchSettingsItem(
             title = "Show adult content (18+)",
             subtitle = "Include 18+ anime and manga in search, the activity feed, and lists",
-            checked = uiState.effectiveShowAdult,
+            checked = options?.displayAdultContent == true,
             onCheckedChange = { onAction(AniListOptionsAction.SetAdultContent(it)) },
-            enabled = !uiState.isSaving,
-        )
-        SwitchSettingsItem(
-            title = "Override on this device",
-            subtitle = "Ignore the account setting and use the value above only on this device",
-            checked = uiState.adultOverrideEnabled,
-            onCheckedChange = { onAction(AniListOptionsAction.SetAdultOverrideEnabled(it)) },
         )
 
         var showTitleSheet by remember { mutableStateOf(false) }
@@ -82,7 +75,6 @@ internal fun AniListOptionsContent(
             title = "Title language",
             currentValue = options?.titleLanguage?.toBaseLanguage().label(),
             onClick = { showTitleSheet = true },
-            enabled = !uiState.isSaving,
         )
         if (showTitleSheet) {
             OptionPickerSheet(
@@ -92,7 +84,7 @@ internal fun AniListOptionsContent(
                 label = { it.label() },
                 subtitle = { it.example() },
                 onSelect = {
-                    onAction(AniListOptionsAction.SetTitleLanguageAccount(it))
+                    onAction(AniListOptionsAction.SetTitleLanguage(it))
                     showTitleSheet = false
                 },
                 onDismiss = { showTitleSheet = false },
@@ -104,7 +96,6 @@ internal fun AniListOptionsContent(
             title = "Staff & character names",
             currentValue = options?.staffNameLanguage.label(),
             onClick = { showStaffSheet = true },
-            enabled = !uiState.isSaving,
         )
         if (showStaffSheet) {
             OptionPickerSheet(
@@ -127,7 +118,6 @@ internal fun AniListOptionsContent(
             title = "Scoring system",
             currentValue = options?.scoreFormat.label(),
             onClick = { showScoreSheet = true },
-            enabled = !uiState.isSaving,
         )
         if (showScoreSheet) {
             OptionPickerSheet(
@@ -152,13 +142,11 @@ internal fun AniListOptionsContent(
             subtitle = "Get notified when shows you're watching air",
             checked = options?.airingNotifications == true,
             onCheckedChange = { onAction(AniListOptionsAction.SetAiringNotifications(it)) },
-            enabled = !uiState.isSaving,
         )
         SwitchSettingsItem(
             title = "Only receive messages from people I follow",
             checked = options?.restrictMessagesToFollowing == true,
             onCheckedChange = { onAction(AniListOptionsAction.SetRestrictMessagesToFollowing(it)) },
-            enabled = !uiState.isSaving,
         )
 
         var showMergeSheet by remember { mutableStateOf(false) }
@@ -166,7 +154,6 @@ internal fun AniListOptionsContent(
             title = "Merge consecutive activity",
             currentValue = activityMergeLabel(options?.activityMergeTime),
             onClick = { showMergeSheet = true },
-            enabled = !uiState.isSaving,
         )
         if (showMergeSheet) {
             OptionPickerSheet(
@@ -195,8 +182,7 @@ internal fun AniListOptionsContent(
                 onCheckedChange = { create ->
                     onAction(AniListOptionsAction.SetListActivityDisabled(status, disabled = !create))
                 },
-                enabled = !uiState.isSaving,
-            )
+                )
         }
     }
 
@@ -208,7 +194,6 @@ internal fun AniListOptionsContent(
             title = "Profile color",
             currentValue = options?.profileColor?.replaceFirstChar { it.uppercase() } ?: "Default",
             onClick = { showColorSheet = true },
-            enabled = !uiState.isSaving,
         )
         if (showColorSheet) {
             ProfileColorSheet(

--- a/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsScreen.kt
@@ -50,42 +50,13 @@ import com.anisync.android.domain.AniListTitleLanguage
 import com.anisync.android.domain.ScoreFormat
 
 /**
- * AniList Account options — the settings that live on the user's AniList account (UserOptions +
- * score format). Everything here is the account's value and edits push to AniList via UpdateUser,
- * except the two device-override controls for adult content and title language.
+ * The AniList account-options sections (content & titles, social & activity, profile). Hosted by
+ * [AniListSettingsScreen]; renders the cached account values and routes edits to the view model.
+ * Everything here is the account's value and edits push to AniList via UpdateUser, except the two
+ * device-override controls for adult content and title language.
  */
 @Composable
-fun AniListOptionsScreen(
-    onBackClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    viewModel: AniListOptionsViewModel = hiltViewModel(),
-) {
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-
-    SettingsScreenScaffold(
-        title = "AniList Account",
-        onBackClick = onBackClick,
-        modifier = modifier,
-    ) {
-        when {
-            !uiState.isSignedIn -> NoticeCard(
-                "Sign in to an AniList account to view and edit these options."
-            )
-
-            uiState.isLoading && uiState.options == null -> Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(200.dp),
-                contentAlignment = Alignment.Center,
-            ) { CircularProgressIndicator() }
-
-            else -> AniListOptionsContent(uiState, viewModel::onAction)
-        }
-    }
-}
-
-@Composable
-private fun AniListOptionsContent(
+internal fun AniListOptionsContent(
     uiState: AniListOptionsUiState,
     onAction: (AniListOptionsAction) -> Unit,
 ) {
@@ -300,7 +271,7 @@ private fun SectionHeader(text: String) {
 }
 
 @Composable
-private fun SectionLabel(text: String) {
+internal fun SectionLabel(text: String) {
     Text(
         text = text,
         style = MaterialTheme.typography.titleSmall,
@@ -308,19 +279,6 @@ private fun SectionLabel(text: String) {
         color = MaterialTheme.colorScheme.primary,
         modifier = Modifier.padding(start = 8.dp, top = 12.dp, bottom = 2.dp),
     )
-}
-
-@Composable
-private fun NoticeCard(text: String) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(16.dp))
-            .background(MaterialTheme.colorScheme.surfaceContainer)
-            .padding(20.dp),
-    ) {
-        Text(text = text, style = MaterialTheme.typography.bodyLarge)
-    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsScreen.kt
@@ -80,48 +80,24 @@ internal fun AniListOptionsContent(
         var showTitleSheet by remember { mutableStateOf(false) }
         SelectionSettingsItem(
             title = "Title language",
-            currentValue = if (uiState.titleLanguageOverrideEnabled) {
-                uiState.localTitleLanguage.label()
-            } else {
-                options?.titleLanguage.label()
-            },
+            currentValue = options?.titleLanguage?.toBaseLanguage().label(),
             onClick = { showTitleSheet = true },
             enabled = !uiState.isSaving,
         )
         if (showTitleSheet) {
-            if (uiState.titleLanguageOverrideEnabled) {
-                OptionPickerSheet(
-                    title = "Title language",
-                    options = TitleLanguage.entries,
-                    selected = uiState.localTitleLanguage,
-                    label = { it.label() },
-                    subtitle = { it.example() },
-                    onSelect = {
-                        onAction(AniListOptionsAction.SetLocalTitleLanguage(it))
-                        showTitleSheet = false
-                    },
-                    onDismiss = { showTitleSheet = false },
-                )
-            } else {
-                OptionPickerSheet(
-                    title = "Title language",
-                    options = AniListTitleLanguage.entries,
-                    selected = options?.titleLanguage,
-                    label = { it.label() },
-                    subtitle = { it.example() },
-                    onSelect = {
-                        onAction(AniListOptionsAction.SetTitleLanguageAccount(it))
-                        showTitleSheet = false
-                    },
-                    onDismiss = { showTitleSheet = false },
-                )
-            }
+            OptionPickerSheet(
+                title = "Title language",
+                options = TITLE_LANGUAGE_OPTIONS,
+                selected = options?.titleLanguage?.toBaseLanguage(),
+                label = { it.label() },
+                subtitle = { it.example() },
+                onSelect = {
+                    onAction(AniListOptionsAction.SetTitleLanguageAccount(it))
+                    showTitleSheet = false
+                },
+                onDismiss = { showTitleSheet = false },
+            )
         }
-        SwitchSettingsItem(
-            title = "Override title language on this device",
-            checked = uiState.titleLanguageOverrideEnabled,
-            onCheckedChange = { onAction(AniListOptionsAction.SetTitleLanguageOverrideEnabled(it)) },
-        )
 
         var showStaffSheet by remember { mutableStateOf(false) }
         SelectionSettingsItem(
@@ -456,6 +432,23 @@ private fun AniListListActivityStatus.label(): String = when (this) {
     AniListListActivityStatus.DROPPED -> "Dropped"
     AniListListActivityStatus.PAUSED -> "Paused"
     AniListListActivityStatus.REPEATING -> "Rewatching / Rereading"
+}
+
+/**
+ * Title languages offered in the picker. The creator-stylised variants are intentionally excluded —
+ * AniList's own site no longer surfaces them and they render identically to the base option here.
+ */
+private val TITLE_LANGUAGE_OPTIONS = listOf(
+    AniListTitleLanguage.ROMAJI,
+    AniListTitleLanguage.ENGLISH,
+    AniListTitleLanguage.NATIVE,
+)
+
+/** Collapse a (possibly stylised) account title language onto its base for selection/display. */
+private fun AniListTitleLanguage.toBaseLanguage(): AniListTitleLanguage = when (this) {
+    AniListTitleLanguage.ROMAJI, AniListTitleLanguage.ROMAJI_STYLISED -> AniListTitleLanguage.ROMAJI
+    AniListTitleLanguage.ENGLISH, AniListTitleLanguage.ENGLISH_STYLISED -> AniListTitleLanguage.ENGLISH
+    AniListTitleLanguage.NATIVE, AniListTitleLanguage.NATIVE_STYLISED -> AniListTitleLanguage.NATIVE
 }
 
 private val ACTIVITY_MERGE_PRESETS = listOf(0, 30, 60, 120, 360, 720, 1440, 20160)

--- a/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -302,7 +304,7 @@ private fun <T> OptionPickerSheet(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 private fun ProfileColorSheet(
     selected: String?,
@@ -323,12 +325,16 @@ private fun ProfileColorSheet(
                 modifier = Modifier.padding(vertical = 8.dp),
             )
             Spacer(Modifier.height(16.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
                 PROFILE_COLORS.forEach { (name, color) ->
                     val isSelected = name == selected
                     Box(
                         modifier = Modifier
-                            .size(44.dp)
+                            .size(48.dp)
                             .clip(CircleShape)
                             .background(color)
                             .then(
@@ -356,7 +362,7 @@ private fun TitleLanguage.label(): String = when (this) {
     TitleLanguage.NATIVE -> "Native"
 }
 
-private fun AniListTitleLanguage?.label(): String = when (this) {
+internal fun AniListTitleLanguage?.label(): String = when (this) {
     AniListTitleLanguage.ROMAJI -> "Romaji"
     AniListTitleLanguage.ENGLISH -> "English"
     AniListTitleLanguage.NATIVE -> "Native"
@@ -366,7 +372,7 @@ private fun AniListTitleLanguage?.label(): String = when (this) {
     null -> "Romaji"
 }
 
-private fun AniListStaffNameLanguage?.label(): String = when (this) {
+internal fun AniListStaffNameLanguage?.label(): String = when (this) {
     AniListStaffNameLanguage.ROMAJI_WESTERN -> "Romaji, Western order"
     AniListStaffNameLanguage.ROMAJI -> "Romaji"
     AniListStaffNameLanguage.NATIVE -> "Native"
@@ -401,7 +407,7 @@ private fun AniListStaffNameLanguage?.example(): String = when (this) {
     null -> "Hajime Isayama"
 }
 
-private fun ScoreFormat?.label(): String = when (this) {
+internal fun ScoreFormat?.label(): String = when (this) {
     ScoreFormat.POINT_100 -> "100 Point (5/100)"
     ScoreFormat.POINT_10_DECIMAL -> "10 Point Decimal (5.5/10)"
     ScoreFormat.POINT_10 -> "10 Point (5/10)"
@@ -430,7 +436,7 @@ private val TITLE_LANGUAGE_OPTIONS = listOf(
 )
 
 /** Collapse a (possibly stylised) account title language onto its base for selection/display. */
-private fun AniListTitleLanguage.toBaseLanguage(): AniListTitleLanguage = when (this) {
+internal fun AniListTitleLanguage.toBaseLanguage(): AniListTitleLanguage = when (this) {
     AniListTitleLanguage.ROMAJI, AniListTitleLanguage.ROMAJI_STYLISED -> AniListTitleLanguage.ROMAJI
     AniListTitleLanguage.ENGLISH, AniListTitleLanguage.ENGLISH_STYLISED -> AniListTitleLanguage.ENGLISH
     AniListTitleLanguage.NATIVE, AniListTitleLanguage.NATIVE_STYLISED -> AniListTitleLanguage.NATIVE
@@ -438,7 +444,7 @@ private fun AniListTitleLanguage.toBaseLanguage(): AniListTitleLanguage = when (
 
 private val ACTIVITY_MERGE_PRESETS = listOf(0, 30, 60, 120, 360, 720, 1440, 20160)
 
-private fun activityMergeLabel(minutes: Int?): String = when {
+internal fun activityMergeLabel(minutes: Int?): String = when {
     minutes == null -> "Default"
     minutes <= 0 -> "Never"
     minutes >= 20160 -> "Always"

--- a/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsScreen.kt
@@ -20,9 +20,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material3.BottomSheetDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -40,8 +38,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.anisync.android.data.StaffNameLanguage
 import com.anisync.android.data.TitleLanguage
 import com.anisync.android.domain.AniListListActivityStatus
@@ -69,8 +65,7 @@ internal fun AniListOptionsContent(
     SettingsGroup {
         SwitchSettingsItem(
             title = "Show adult content (18+)",
-            subtitle = if (uiState.adultOverrideEnabled) "Overridden on this device"
-            else "Synced with your AniList account",
+            subtitle = "Include 18+ anime and manga in search, the activity feed, and lists",
             checked = uiState.effectiveShowAdult,
             onCheckedChange = { onAction(AniListOptionsAction.SetAdultContent(it)) },
             enabled = !uiState.isSaving,
@@ -100,6 +95,7 @@ internal fun AniListOptionsContent(
                     options = TitleLanguage.entries,
                     selected = uiState.localTitleLanguage,
                     label = { it.label() },
+                    subtitle = { it.example() },
                     onSelect = {
                         onAction(AniListOptionsAction.SetLocalTitleLanguage(it))
                         showTitleSheet = false
@@ -112,6 +108,7 @@ internal fun AniListOptionsContent(
                     options = AniListTitleLanguage.entries,
                     selected = options?.titleLanguage,
                     label = { it.label() },
+                    subtitle = { it.example() },
                     onSelect = {
                         onAction(AniListOptionsAction.SetTitleLanguageAccount(it))
                         showTitleSheet = false
@@ -139,12 +136,14 @@ internal fun AniListOptionsContent(
                 options = AniListStaffNameLanguage.entries,
                 selected = options?.staffNameLanguage,
                 label = { it.label() },
+                subtitle = { it.example() },
                 onSelect = {
                     onAction(AniListOptionsAction.SetStaffNameLanguage(it))
                     showStaffSheet = false
                 },
                 onDismiss = { showStaffSheet = false },
             )
+
         }
 
         var showScoreSheet by remember { mutableStateOf(false) }
@@ -246,16 +245,6 @@ internal fun AniListOptionsContent(
             )
         }
     }
-
-    Spacer(Modifier.height(8.dp))
-    SettingsGroup {
-        SettingsItem(
-            title = "Refresh from AniList",
-            icon = Icons.Outlined.Refresh,
-            onClick = { onAction(AniListOptionsAction.Refresh) },
-            enabled = !uiState.isLoading && !uiState.isSaving,
-        )
-    }
 }
 
 // ── Small building blocks ────────────────────────────────────────────────────────────────────────
@@ -290,6 +279,7 @@ private fun <T> OptionPickerSheet(
     label: (T) -> String,
     onSelect: (T) -> Unit,
     onDismiss: () -> Unit,
+    subtitle: (T) -> String? = { null },
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(
@@ -308,6 +298,7 @@ private fun <T> OptionPickerSheet(
             LazyColumn(contentPadding = PaddingValues(horizontal = 16.dp)) {
                 items(options) { option ->
                     val isSelected = option == selected
+                    val sub = subtitle(option)
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -320,13 +311,22 @@ private fun <T> OptionPickerSheet(
                             .padding(vertical = 16.dp, horizontal = 20.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Text(
-                            text = label(option),
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = if (isSelected) MaterialTheme.colorScheme.onSecondaryContainer
-                            else MaterialTheme.colorScheme.onSurface,
-                            modifier = Modifier.weight(1f),
-                        )
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = label(option),
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = if (isSelected) MaterialTheme.colorScheme.onSecondaryContainer
+                                else MaterialTheme.colorScheme.onSurface,
+                            )
+                            if (sub != null) {
+                                Text(
+                                    text = sub,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = if (isSelected) MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.8f)
+                                    else MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
                         if (isSelected) {
                             Icon(
                                 imageVector = Icons.Default.Check,
@@ -416,6 +416,28 @@ private fun StaffNameLanguage.label(): String = when (this) {
     StaffNameLanguage.ROMAJI_WESTERN -> "Romaji, Western order"
     StaffNameLanguage.ROMAJI -> "Romaji"
     StaffNameLanguage.NATIVE -> "Native"
+}
+
+// Worked examples shown under each language option so the choice is concrete.
+
+private fun TitleLanguage.example(): String = when (this) {
+    TitleLanguage.ROMAJI -> "Shingeki no Kyojin"
+    TitleLanguage.ENGLISH -> "Attack on Titan"
+    TitleLanguage.NATIVE -> "進撃の巨人"
+}
+
+private fun AniListTitleLanguage?.example(): String = when (this) {
+    AniListTitleLanguage.ROMAJI, AniListTitleLanguage.ROMAJI_STYLISED -> "Shingeki no Kyojin"
+    AniListTitleLanguage.ENGLISH, AniListTitleLanguage.ENGLISH_STYLISED -> "Attack on Titan"
+    AniListTitleLanguage.NATIVE, AniListTitleLanguage.NATIVE_STYLISED -> "進撃の巨人"
+    null -> "Shingeki no Kyojin"
+}
+
+private fun AniListStaffNameLanguage?.example(): String = when (this) {
+    AniListStaffNameLanguage.ROMAJI_WESTERN -> "Hajime Isayama"
+    AniListStaffNameLanguage.ROMAJI -> "Isayama Hajime"
+    AniListStaffNameLanguage.NATIVE -> "諫山 創"
+    null -> "Hajime Isayama"
 }
 
 private fun ScoreFormat?.label(): String = when (this) {

--- a/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsScreen.kt
@@ -1,0 +1,500 @@
+package com.anisync.android.presentation.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.anisync.android.data.StaffNameLanguage
+import com.anisync.android.data.TitleLanguage
+import com.anisync.android.domain.AniListListActivityStatus
+import com.anisync.android.domain.AniListStaffNameLanguage
+import com.anisync.android.domain.AniListTitleLanguage
+import com.anisync.android.domain.ScoreFormat
+
+/**
+ * AniList Account options — the settings that live on the user's AniList account (UserOptions +
+ * score format). Everything here is the account's value and edits push to AniList via UpdateUser,
+ * except the two device-override controls for adult content and title language.
+ */
+@Composable
+fun AniListOptionsScreen(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: AniListOptionsViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    SettingsScreenScaffold(
+        title = "AniList Account",
+        onBackClick = onBackClick,
+        modifier = modifier,
+    ) {
+        when {
+            !uiState.isSignedIn -> NoticeCard(
+                "Sign in to an AniList account to view and edit these options."
+            )
+
+            uiState.isLoading && uiState.options == null -> Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(200.dp),
+                contentAlignment = Alignment.Center,
+            ) { CircularProgressIndicator() }
+
+            else -> AniListOptionsContent(uiState, viewModel::onAction)
+        }
+    }
+}
+
+@Composable
+private fun AniListOptionsContent(
+    uiState: AniListOptionsUiState,
+    onAction: (AniListOptionsAction) -> Unit,
+) {
+    val options = uiState.options
+
+    SectionHeader("These settings are stored on your AniList account and sync with the website.")
+
+    // ── Content & titles ─────────────────────────────────────────────────────────────────────────
+    SectionLabel("Content & titles")
+    SettingsGroup {
+        SwitchSettingsItem(
+            title = "Show adult content (18+)",
+            subtitle = if (uiState.adultOverrideEnabled) "Overridden on this device"
+            else "Synced with your AniList account",
+            checked = uiState.effectiveShowAdult,
+            onCheckedChange = { onAction(AniListOptionsAction.SetAdultContent(it)) },
+            enabled = !uiState.isSaving,
+        )
+        SwitchSettingsItem(
+            title = "Override on this device",
+            subtitle = "Ignore the account setting and use the value above only on this device",
+            checked = uiState.adultOverrideEnabled,
+            onCheckedChange = { onAction(AniListOptionsAction.SetAdultOverrideEnabled(it)) },
+        )
+
+        var showTitleSheet by remember { mutableStateOf(false) }
+        SelectionSettingsItem(
+            title = "Title language",
+            currentValue = if (uiState.titleLanguageOverrideEnabled) {
+                uiState.localTitleLanguage.label()
+            } else {
+                options?.titleLanguage.label()
+            },
+            onClick = { showTitleSheet = true },
+            enabled = !uiState.isSaving,
+        )
+        if (showTitleSheet) {
+            if (uiState.titleLanguageOverrideEnabled) {
+                OptionPickerSheet(
+                    title = "Title language",
+                    options = TitleLanguage.entries,
+                    selected = uiState.localTitleLanguage,
+                    label = { it.label() },
+                    onSelect = {
+                        onAction(AniListOptionsAction.SetLocalTitleLanguage(it))
+                        showTitleSheet = false
+                    },
+                    onDismiss = { showTitleSheet = false },
+                )
+            } else {
+                OptionPickerSheet(
+                    title = "Title language",
+                    options = AniListTitleLanguage.entries,
+                    selected = options?.titleLanguage,
+                    label = { it.label() },
+                    onSelect = {
+                        onAction(AniListOptionsAction.SetTitleLanguageAccount(it))
+                        showTitleSheet = false
+                    },
+                    onDismiss = { showTitleSheet = false },
+                )
+            }
+        }
+        SwitchSettingsItem(
+            title = "Override title language on this device",
+            checked = uiState.titleLanguageOverrideEnabled,
+            onCheckedChange = { onAction(AniListOptionsAction.SetTitleLanguageOverrideEnabled(it)) },
+        )
+
+        var showStaffSheet by remember { mutableStateOf(false) }
+        SelectionSettingsItem(
+            title = "Staff & character names",
+            currentValue = options?.staffNameLanguage.label(),
+            onClick = { showStaffSheet = true },
+            enabled = !uiState.isSaving,
+        )
+        if (showStaffSheet) {
+            OptionPickerSheet(
+                title = "Staff & character names",
+                options = AniListStaffNameLanguage.entries,
+                selected = options?.staffNameLanguage,
+                label = { it.label() },
+                onSelect = {
+                    onAction(AniListOptionsAction.SetStaffNameLanguage(it))
+                    showStaffSheet = false
+                },
+                onDismiss = { showStaffSheet = false },
+            )
+        }
+
+        var showScoreSheet by remember { mutableStateOf(false) }
+        SelectionSettingsItem(
+            title = "Scoring system",
+            currentValue = options?.scoreFormat.label(),
+            onClick = { showScoreSheet = true },
+            enabled = !uiState.isSaving,
+        )
+        if (showScoreSheet) {
+            OptionPickerSheet(
+                title = "Scoring system",
+                options = ScoreFormat.entries,
+                selected = options?.scoreFormat,
+                label = { it.label() },
+                onSelect = {
+                    onAction(AniListOptionsAction.SetScoreFormat(it))
+                    showScoreSheet = false
+                },
+                onDismiss = { showScoreSheet = false },
+            )
+        }
+    }
+
+    // ── Social & activity ────────────────────────────────────────────────────────────────────────
+    SectionLabel("Social & activity")
+    SettingsGroup {
+        SwitchSettingsItem(
+            title = "Airing notifications",
+            subtitle = "Get notified when shows you're watching air",
+            checked = options?.airingNotifications == true,
+            onCheckedChange = { onAction(AniListOptionsAction.SetAiringNotifications(it)) },
+            enabled = !uiState.isSaving,
+        )
+        SwitchSettingsItem(
+            title = "Only receive messages from people I follow",
+            checked = options?.restrictMessagesToFollowing == true,
+            onCheckedChange = { onAction(AniListOptionsAction.SetRestrictMessagesToFollowing(it)) },
+            enabled = !uiState.isSaving,
+        )
+
+        var showMergeSheet by remember { mutableStateOf(false) }
+        SelectionSettingsItem(
+            title = "Merge consecutive activity",
+            currentValue = activityMergeLabel(options?.activityMergeTime),
+            onClick = { showMergeSheet = true },
+            enabled = !uiState.isSaving,
+        )
+        if (showMergeSheet) {
+            OptionPickerSheet(
+                title = "Merge consecutive activity",
+                options = ACTIVITY_MERGE_PRESETS,
+                selected = ACTIVITY_MERGE_PRESETS.minByOrNull {
+                    kotlin.math.abs(it - (options?.activityMergeTime ?: 0))
+                },
+                label = { activityMergeLabel(it) },
+                onSelect = {
+                    onAction(AniListOptionsAction.SetActivityMergeTime(it))
+                    showMergeSheet = false
+                },
+                onDismiss = { showMergeSheet = false },
+            )
+        }
+    }
+
+    SectionLabel("Create list activity for")
+    SettingsGroup {
+        AniListListActivityStatus.entries.forEach { status ->
+            val disabled = options?.disabledListActivity?.get(status) == true
+            SwitchSettingsItem(
+                title = status.label(),
+                checked = !disabled, // "create activity" = NOT disabled
+                onCheckedChange = { create ->
+                    onAction(AniListOptionsAction.SetListActivityDisabled(status, disabled = !create))
+                },
+                enabled = !uiState.isSaving,
+            )
+        }
+    }
+
+    // ── Profile ──────────────────────────────────────────────────────────────────────────────────
+    SectionLabel("Profile")
+    SettingsGroup {
+        var showColorSheet by remember { mutableStateOf(false) }
+        SelectionSettingsItem(
+            title = "Profile color",
+            currentValue = options?.profileColor?.replaceFirstChar { it.uppercase() } ?: "Default",
+            onClick = { showColorSheet = true },
+            enabled = !uiState.isSaving,
+        )
+        if (showColorSheet) {
+            ProfileColorSheet(
+                selected = options?.profileColor,
+                onSelect = {
+                    onAction(AniListOptionsAction.SetProfileColor(it))
+                    showColorSheet = false
+                },
+                onDismiss = { showColorSheet = false },
+            )
+        }
+    }
+
+    Spacer(Modifier.height(8.dp))
+    SettingsGroup {
+        SettingsItem(
+            title = "Refresh from AniList",
+            icon = Icons.Outlined.Refresh,
+            onClick = { onAction(AniListOptionsAction.Refresh) },
+            enabled = !uiState.isLoading && !uiState.isSaving,
+        )
+    }
+}
+
+// ── Small building blocks ────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun SectionHeader(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+    )
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleSmall,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(start = 8.dp, top = 12.dp, bottom = 2.dp),
+    )
+}
+
+@Composable
+private fun NoticeCard(text: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainer)
+            .padding(20.dp),
+    ) {
+        Text(text = text, style = MaterialTheme.typography.bodyLarge)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun <T> OptionPickerSheet(
+    title: String,
+    options: List<T>,
+    selected: T?,
+    label: (T) -> String,
+    onSelect: (T) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        dragHandle = { BottomSheetDefaults.DragHandle() },
+    ) {
+        Column(modifier = Modifier.fillMaxWidth().padding(bottom = 32.dp)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+            )
+            Spacer(Modifier.height(8.dp))
+            LazyColumn(contentPadding = PaddingValues(horizontal = 16.dp)) {
+                items(options) { option ->
+                    val isSelected = option == selected
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(16.dp))
+                            .clickable { onSelect(option) }
+                            .background(
+                                if (isSelected) MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f)
+                                else Color.Transparent
+                            )
+                            .padding(vertical = 16.dp, horizontal = 20.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = label(option),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = if (isSelected) MaterialTheme.colorScheme.onSecondaryContainer
+                            else MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.weight(1f),
+                        )
+                        if (isSelected) {
+                            Icon(
+                                imageVector = Icons.Default.Check,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ProfileColorSheet(
+    selected: String?,
+    onSelect: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        dragHandle = { BottomSheetDefaults.DragHandle() },
+    ) {
+        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp).padding(bottom = 40.dp)) {
+            Text(
+                text = "Profile color",
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.padding(vertical = 8.dp),
+            )
+            Spacer(Modifier.height(16.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                PROFILE_COLORS.forEach { (name, color) ->
+                    val isSelected = name == selected
+                    Box(
+                        modifier = Modifier
+                            .size(44.dp)
+                            .clip(CircleShape)
+                            .background(color)
+                            .then(
+                                if (isSelected) Modifier.border(3.dp, MaterialTheme.colorScheme.onSurface, CircleShape)
+                                else Modifier
+                            )
+                            .clickable { onSelect(name) },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        if (isSelected) {
+                            Icon(Icons.Default.Check, contentDescription = null, tint = Color.White)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Labels ───────────────────────────────────────────────────────────────────────────────────────
+
+private fun TitleLanguage.label(): String = when (this) {
+    TitleLanguage.ROMAJI -> "Romaji"
+    TitleLanguage.ENGLISH -> "English"
+    TitleLanguage.NATIVE -> "Native"
+}
+
+private fun AniListTitleLanguage?.label(): String = when (this) {
+    AniListTitleLanguage.ROMAJI -> "Romaji"
+    AniListTitleLanguage.ENGLISH -> "English"
+    AniListTitleLanguage.NATIVE -> "Native"
+    AniListTitleLanguage.ROMAJI_STYLISED -> "Romaji (stylised)"
+    AniListTitleLanguage.ENGLISH_STYLISED -> "English (stylised)"
+    AniListTitleLanguage.NATIVE_STYLISED -> "Native (stylised)"
+    null -> "Romaji"
+}
+
+private fun AniListStaffNameLanguage?.label(): String = when (this) {
+    AniListStaffNameLanguage.ROMAJI_WESTERN -> "Romaji, Western order"
+    AniListStaffNameLanguage.ROMAJI -> "Romaji"
+    AniListStaffNameLanguage.NATIVE -> "Native"
+    null -> "Romaji, Western order"
+}
+
+private fun StaffNameLanguage.label(): String = when (this) {
+    StaffNameLanguage.ROMAJI_WESTERN -> "Romaji, Western order"
+    StaffNameLanguage.ROMAJI -> "Romaji"
+    StaffNameLanguage.NATIVE -> "Native"
+}
+
+private fun ScoreFormat?.label(): String = when (this) {
+    ScoreFormat.POINT_100 -> "100 Point (5/100)"
+    ScoreFormat.POINT_10_DECIMAL -> "10 Point Decimal (5.5/10)"
+    ScoreFormat.POINT_10 -> "10 Point (5/10)"
+    ScoreFormat.POINT_5 -> "5 Star (3/5)"
+    ScoreFormat.POINT_3 -> "3 Point Smiley :)"
+    null -> "10 Point Decimal (5.5/10)"
+}
+
+private fun AniListListActivityStatus.label(): String = when (this) {
+    AniListListActivityStatus.CURRENT -> "Watching / Reading"
+    AniListListActivityStatus.PLANNING -> "Planning"
+    AniListListActivityStatus.COMPLETED -> "Completed"
+    AniListListActivityStatus.DROPPED -> "Dropped"
+    AniListListActivityStatus.PAUSED -> "Paused"
+    AniListListActivityStatus.REPEATING -> "Rewatching / Rereading"
+}
+
+private val ACTIVITY_MERGE_PRESETS = listOf(0, 30, 60, 120, 360, 720, 1440, 20160)
+
+private fun activityMergeLabel(minutes: Int?): String = when {
+    minutes == null -> "Default"
+    minutes <= 0 -> "Never"
+    minutes >= 20160 -> "Always"
+    minutes < 60 -> "$minutes minutes"
+    minutes < 1440 -> "${minutes / 60} hour${if (minutes >= 120) "s" else ""}"
+    else -> "${minutes / 1440} day${if (minutes >= 2880) "s" else ""}"
+}
+
+private val PROFILE_COLORS: List<Pair<String, Color>> = listOf(
+    "blue" to Color(0xFF3DB4F2),
+    "purple" to Color(0xFFC063FF),
+    "pink" to Color(0xFFFC9DD6),
+    "orange" to Color(0xFFEF881A),
+    "red" to Color(0xFFE13333),
+    "green" to Color(0xFF4CCB48),
+    "gray" to Color(0xFF677B94),
+)

--- a/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsUiState.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsUiState.kt
@@ -1,0 +1,58 @@
+package com.anisync.android.presentation.settings
+
+import com.anisync.android.data.StaffNameLanguage
+import com.anisync.android.data.TitleLanguage
+import com.anisync.android.domain.AniListListActivityStatus
+import com.anisync.android.domain.AniListStaffNameLanguage
+import com.anisync.android.domain.AniListTitleLanguage
+import com.anisync.android.domain.AniListUserOptions
+import com.anisync.android.domain.ScoreFormat
+
+/**
+ * State for the AniList Account options screen. [options] is the cached account snapshot (source of
+ * truth for everything that pushes to AniList); the `local*` fields back the two device-override
+ * controls (adult content, title language) which only take effect when their override flag is on.
+ */
+data class AniListOptionsUiState(
+    val isLoading: Boolean = true,
+    val isSaving: Boolean = false,
+    val isSignedIn: Boolean = true,
+    val error: String? = null,
+    val options: AniListUserOptions? = null,
+
+    // Device override switches + their local values.
+    val adultOverrideEnabled: Boolean = false,
+    val localShowAdultContent: Boolean = false,
+    val titleLanguageOverrideEnabled: Boolean = false,
+    val localTitleLanguage: TitleLanguage = TitleLanguage.ROMAJI,
+    val localStaffNameLanguage: StaffNameLanguage = StaffNameLanguage.ROMAJI_WESTERN,
+) {
+    /** Effective adult-content value shown by the primary switch (override value or account value). */
+    val effectiveShowAdult: Boolean
+        get() = if (adultOverrideEnabled) localShowAdultContent else options?.displayAdultContent == true
+}
+
+sealed interface AniListOptionsAction {
+    data object Refresh : AniListOptionsAction
+
+    // Content & titles
+    data class SetAdultContent(val enabled: Boolean) : AniListOptionsAction
+    data class SetAdultOverrideEnabled(val enabled: Boolean) : AniListOptionsAction
+    data class SetTitleLanguageAccount(val language: AniListTitleLanguage) : AniListOptionsAction
+    data class SetTitleLanguageOverrideEnabled(val enabled: Boolean) : AniListOptionsAction
+    data class SetLocalTitleLanguage(val language: TitleLanguage) : AniListOptionsAction
+    data class SetStaffNameLanguage(val language: AniListStaffNameLanguage) : AniListOptionsAction
+    data class SetScoreFormat(val format: ScoreFormat) : AniListOptionsAction
+
+    // Social & activity
+    data class SetAiringNotifications(val enabled: Boolean) : AniListOptionsAction
+    data class SetRestrictMessagesToFollowing(val enabled: Boolean) : AniListOptionsAction
+    data class SetActivityMergeTime(val minutes: Int) : AniListOptionsAction
+    data class SetListActivityDisabled(
+        val status: AniListListActivityStatus,
+        val disabled: Boolean,
+    ) : AniListOptionsAction
+
+    // Profile
+    data class SetProfileColor(val color: String) : AniListOptionsAction
+}

--- a/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsUiState.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsUiState.kt
@@ -1,46 +1,31 @@
 package com.anisync.android.presentation.settings
 
-import com.anisync.android.data.StaffNameLanguage
-import com.anisync.android.data.TitleLanguage
 import com.anisync.android.domain.AniListListActivityStatus
 import com.anisync.android.domain.AniListStaffNameLanguage
 import com.anisync.android.domain.AniListTitleLanguage
 import com.anisync.android.domain.AniListUserOptions
+import com.anisync.android.domain.ConflictState
 import com.anisync.android.domain.ScoreFormat
 
 /**
- * State for the AniList Account options screen. [options] is the cached account snapshot (source of
- * truth for everything that pushes to AniList); the `local*` fields back the two device-override
- * controls (adult content, title language) which only take effect when their override flag is on.
+ * State for the AniList Account options screen. [options] is the local working copy (edits apply to
+ * it instantly and sync in the background). [conflict] is non-null when the same option changed both
+ * on this device and on the website and the user must choose a direction.
  */
 data class AniListOptionsUiState(
     val isLoading: Boolean = true,
-    val isSaving: Boolean = false,
     val isSignedIn: Boolean = true,
     val error: String? = null,
     val options: AniListUserOptions? = null,
-
-    // Device override switches + their local values.
-    val adultOverrideEnabled: Boolean = false,
-    val localShowAdultContent: Boolean = false,
-    val titleLanguageOverrideEnabled: Boolean = false,
-    val localTitleLanguage: TitleLanguage = TitleLanguage.ROMAJI,
-    val localStaffNameLanguage: StaffNameLanguage = StaffNameLanguage.ROMAJI_WESTERN,
-) {
-    /** Effective adult-content value shown by the primary switch (override value or account value). */
-    val effectiveShowAdult: Boolean
-        get() = if (adultOverrideEnabled) localShowAdultContent else options?.displayAdultContent == true
-}
+    val conflict: ConflictState? = null,
+)
 
 sealed interface AniListOptionsAction {
     data object Refresh : AniListOptionsAction
 
     // Content & titles
     data class SetAdultContent(val enabled: Boolean) : AniListOptionsAction
-    data class SetAdultOverrideEnabled(val enabled: Boolean) : AniListOptionsAction
-    data class SetTitleLanguageAccount(val language: AniListTitleLanguage) : AniListOptionsAction
-    data class SetTitleLanguageOverrideEnabled(val enabled: Boolean) : AniListOptionsAction
-    data class SetLocalTitleLanguage(val language: TitleLanguage) : AniListOptionsAction
+    data class SetTitleLanguage(val language: AniListTitleLanguage) : AniListOptionsAction
     data class SetStaffNameLanguage(val language: AniListStaffNameLanguage) : AniListOptionsAction
     data class SetScoreFormat(val format: ScoreFormat) : AniListOptionsAction
 
@@ -55,4 +40,7 @@ sealed interface AniListOptionsAction {
 
     // Profile
     data class SetProfileColor(val color: String) : AniListOptionsAction
+
+    /** Resolve a sync conflict: keepLocal pushes this device's values, else adopts the website's. */
+    data class ResolveConflict(val keepLocal: Boolean) : AniListOptionsAction
 }

--- a/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsViewModel.kt
@@ -1,0 +1,166 @@
+package com.anisync.android.presentation.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.anisync.android.data.AppSettings
+import com.anisync.android.data.TitleLanguage
+import com.anisync.android.data.account.AccountManager
+import com.anisync.android.data.toLocalTitleLanguage
+import com.anisync.android.domain.AniListTitleLanguage
+import com.anisync.android.domain.AniListUserOptions
+import com.anisync.android.domain.Result
+import com.anisync.android.domain.SyncUserOptionsUseCase
+import com.anisync.android.domain.UserOptionsPatch
+import com.anisync.android.domain.UserOptionsRepository
+import com.anisync.android.presentation.components.alert.ToastManager
+import com.anisync.android.presentation.components.alert.ToastType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AniListOptionsViewModel @Inject constructor(
+    private val repository: UserOptionsRepository,
+    private val syncUserOptions: SyncUserOptionsUseCase,
+    private val appSettings: AppSettings,
+    private val accountManager: AccountManager,
+    private val toastManager: ToastManager,
+) : ViewModel() {
+
+    private val _loading = MutableStateFlow(true)
+    private val _saving = MutableStateFlow(false)
+    private val _error = MutableStateFlow<String?>(null)
+
+    private data class ContentState(
+        val options: AniListUserOptions?,
+        val adultOverride: Boolean,
+        val showAdult: Boolean,
+        val titleOverride: Boolean,
+        val titleLanguage: TitleLanguage,
+    )
+
+    val uiState: StateFlow<AniListOptionsUiState> = combine(
+        combine(
+            repository.cachedOptions,
+            appSettings.adultContentOverrideEnabled,
+            appSettings.showAdultContent,
+            appSettings.titleLanguageOverrideEnabled,
+            appSettings.titleLanguage,
+        ) { options, adultOverride, showAdult, titleOverride, titleLanguage ->
+            ContentState(options, adultOverride, showAdult, titleOverride, titleLanguage)
+        },
+        appSettings.staffNameLanguage,
+        accountManager.activeAccount,
+        _loading,
+        combine(_saving, _error) { saving, error -> saving to error },
+    ) { content, staffLanguage, account, loading, savingError ->
+        AniListOptionsUiState(
+            isLoading = loading,
+            isSaving = savingError.first,
+            isSignedIn = account != null,
+            error = savingError.second,
+            options = content.options,
+            adultOverrideEnabled = content.adultOverride,
+            localShowAdultContent = content.showAdult,
+            titleLanguageOverrideEnabled = content.titleOverride,
+            localTitleLanguage = content.titleLanguage,
+            localStaffNameLanguage = staffLanguage,
+        )
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AniListOptionsUiState())
+
+    init {
+        refresh()
+    }
+
+    fun onAction(action: AniListOptionsAction) {
+        when (action) {
+            AniListOptionsAction.Refresh -> refresh()
+
+            is AniListOptionsAction.SetAdultContent ->
+                if (appSettings.adultContentOverrideEnabled.value) {
+                    appSettings.setShowAdultContent(action.enabled)
+                } else {
+                    push(UserOptionsPatch(displayAdultContent = action.enabled))
+                }
+
+            is AniListOptionsAction.SetAdultOverrideEnabled -> {
+                appSettings.setAdultContentOverrideEnabled(action.enabled)
+                // Handing control back to AniList: snap the local value to the account value now.
+                if (!action.enabled) {
+                    repository.cachedOptions.value?.let { appSettings.setShowAdultContent(it.displayAdultContent) }
+                }
+            }
+
+            is AniListOptionsAction.SetTitleLanguageAccount ->
+                push(UserOptionsPatch(titleLanguage = action.language))
+
+            is AniListOptionsAction.SetTitleLanguageOverrideEnabled -> {
+                appSettings.setTitleLanguageOverrideEnabled(action.enabled)
+                if (!action.enabled) {
+                    repository.cachedOptions.value?.titleLanguage?.let {
+                        appSettings.setTitleLanguage(it.toLocalTitleLanguage())
+                    }
+                }
+            }
+
+            is AniListOptionsAction.SetLocalTitleLanguage ->
+                appSettings.setTitleLanguage(action.language)
+
+            is AniListOptionsAction.SetStaffNameLanguage ->
+                push(UserOptionsPatch(staffNameLanguage = action.language))
+
+            is AniListOptionsAction.SetScoreFormat ->
+                push(UserOptionsPatch(scoreFormat = action.format))
+
+            is AniListOptionsAction.SetAiringNotifications ->
+                push(UserOptionsPatch(airingNotifications = action.enabled))
+
+            is AniListOptionsAction.SetRestrictMessagesToFollowing ->
+                push(UserOptionsPatch(restrictMessagesToFollowing = action.enabled))
+
+            is AniListOptionsAction.SetActivityMergeTime ->
+                push(UserOptionsPatch(activityMergeTime = action.minutes))
+
+            is AniListOptionsAction.SetListActivityDisabled -> {
+                val current = repository.cachedOptions.value?.disabledListActivity.orEmpty()
+                push(UserOptionsPatch(disabledListActivity = current + (action.status to action.disabled)))
+            }
+
+            is AniListOptionsAction.SetProfileColor ->
+                push(UserOptionsPatch(profileColor = action.color))
+        }
+    }
+
+    private fun refresh() {
+        viewModelScope.launch {
+            if (accountManager.activeAccount.value == null) {
+                _loading.value = false
+                return@launch
+            }
+            _loading.value = true
+            _error.value = null
+            when (val result = syncUserOptions()) {
+                is Result.Error -> _error.value = result.message
+                is Result.Success -> Unit
+            }
+            _loading.value = false
+        }
+    }
+
+    /** Pushes a partial edit to AniList. The repository updates the cache + mirror on success. */
+    private fun push(patch: UserOptionsPatch) {
+        viewModelScope.launch {
+            _saving.value = true
+            when (val result = repository.updateOptions(patch)) {
+                is Result.Success -> toastManager.showToast(ToastType.SUCCESS, message = "Saved to AniList")
+                is Result.Error -> toastManager.showResultError(result)
+            }
+            _saving.value = false
+        }
+    }
+}

--- a/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsViewModel.kt
@@ -2,18 +2,12 @@ package com.anisync.android.presentation.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.anisync.android.data.AppSettings
-import com.anisync.android.data.TitleLanguage
 import com.anisync.android.data.account.AccountManager
-import com.anisync.android.data.toLocalTitleLanguage
-import com.anisync.android.domain.AniListTitleLanguage
-import com.anisync.android.domain.AniListUserOptions
 import com.anisync.android.domain.Result
 import com.anisync.android.domain.SyncUserOptionsUseCase
 import com.anisync.android.domain.UserOptionsPatch
 import com.anisync.android.domain.UserOptionsRepository
 import com.anisync.android.presentation.components.alert.ToastManager
-import com.anisync.android.presentation.components.alert.ToastType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -27,49 +21,26 @@ import javax.inject.Inject
 class AniListOptionsViewModel @Inject constructor(
     private val repository: UserOptionsRepository,
     private val syncUserOptions: SyncUserOptionsUseCase,
-    private val appSettings: AppSettings,
     private val accountManager: AccountManager,
     private val toastManager: ToastManager,
 ) : ViewModel() {
 
     private val _loading = MutableStateFlow(true)
-    private val _saving = MutableStateFlow(false)
     private val _error = MutableStateFlow<String?>(null)
 
-    private data class ContentState(
-        val options: AniListUserOptions?,
-        val adultOverride: Boolean,
-        val showAdult: Boolean,
-        val titleOverride: Boolean,
-        val titleLanguage: TitleLanguage,
-    )
-
     val uiState: StateFlow<AniListOptionsUiState> = combine(
-        combine(
-            repository.cachedOptions,
-            appSettings.adultContentOverrideEnabled,
-            appSettings.showAdultContent,
-            appSettings.titleLanguageOverrideEnabled,
-            appSettings.titleLanguage,
-        ) { options, adultOverride, showAdult, titleOverride, titleLanguage ->
-            ContentState(options, adultOverride, showAdult, titleOverride, titleLanguage)
-        },
-        appSettings.staffNameLanguage,
+        repository.cachedOptions,
+        repository.conflict,
         accountManager.activeAccount,
         _loading,
-        combine(_saving, _error) { saving, error -> saving to error },
-    ) { content, staffLanguage, account, loading, savingError ->
+        _error,
+    ) { options, conflict, account, loading, error ->
         AniListOptionsUiState(
             isLoading = loading,
-            isSaving = savingError.first,
             isSignedIn = account != null,
-            error = savingError.second,
-            options = content.options,
-            adultOverrideEnabled = content.adultOverride,
-            localShowAdultContent = content.showAdult,
-            titleLanguageOverrideEnabled = content.titleOverride,
-            localTitleLanguage = content.titleLanguage,
-            localStaffNameLanguage = staffLanguage,
+            error = error,
+            options = options,
+            conflict = conflict,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AniListOptionsUiState())
 
@@ -82,57 +53,37 @@ class AniListOptionsViewModel @Inject constructor(
             AniListOptionsAction.Refresh -> refresh()
 
             is AniListOptionsAction.SetAdultContent ->
-                if (appSettings.adultContentOverrideEnabled.value) {
-                    appSettings.setShowAdultContent(action.enabled)
-                } else {
-                    push(UserOptionsPatch(displayAdultContent = action.enabled))
-                }
+                repository.applyEdit(UserOptionsPatch(displayAdultContent = action.enabled))
 
-            is AniListOptionsAction.SetAdultOverrideEnabled -> {
-                appSettings.setAdultContentOverrideEnabled(action.enabled)
-                // Handing control back to AniList: snap the local value to the account value now.
-                if (!action.enabled) {
-                    repository.cachedOptions.value?.let { appSettings.setShowAdultContent(it.displayAdultContent) }
-                }
-            }
-
-            is AniListOptionsAction.SetTitleLanguageAccount ->
-                push(UserOptionsPatch(titleLanguage = action.language))
-
-            is AniListOptionsAction.SetTitleLanguageOverrideEnabled -> {
-                appSettings.setTitleLanguageOverrideEnabled(action.enabled)
-                if (!action.enabled) {
-                    repository.cachedOptions.value?.titleLanguage?.let {
-                        appSettings.setTitleLanguage(it.toLocalTitleLanguage())
-                    }
-                }
-            }
-
-            is AniListOptionsAction.SetLocalTitleLanguage ->
-                appSettings.setTitleLanguage(action.language)
+            is AniListOptionsAction.SetTitleLanguage ->
+                repository.applyEdit(UserOptionsPatch(titleLanguage = action.language))
 
             is AniListOptionsAction.SetStaffNameLanguage ->
-                push(UserOptionsPatch(staffNameLanguage = action.language))
+                repository.applyEdit(UserOptionsPatch(staffNameLanguage = action.language))
 
             is AniListOptionsAction.SetScoreFormat ->
-                push(UserOptionsPatch(scoreFormat = action.format))
+                repository.applyEdit(UserOptionsPatch(scoreFormat = action.format))
 
             is AniListOptionsAction.SetAiringNotifications ->
-                push(UserOptionsPatch(airingNotifications = action.enabled))
+                repository.applyEdit(UserOptionsPatch(airingNotifications = action.enabled))
 
             is AniListOptionsAction.SetRestrictMessagesToFollowing ->
-                push(UserOptionsPatch(restrictMessagesToFollowing = action.enabled))
+                repository.applyEdit(UserOptionsPatch(restrictMessagesToFollowing = action.enabled))
 
             is AniListOptionsAction.SetActivityMergeTime ->
-                push(UserOptionsPatch(activityMergeTime = action.minutes))
+                repository.applyEdit(UserOptionsPatch(activityMergeTime = action.minutes))
 
             is AniListOptionsAction.SetListActivityDisabled -> {
                 val current = repository.cachedOptions.value?.disabledListActivity.orEmpty()
-                push(UserOptionsPatch(disabledListActivity = current + (action.status to action.disabled)))
+                repository.applyEdit(
+                    UserOptionsPatch(disabledListActivity = current + (action.status to action.disabled)),
+                )
             }
 
             is AniListOptionsAction.SetProfileColor ->
-                push(UserOptionsPatch(profileColor = action.color))
+                repository.applyEdit(UserOptionsPatch(profileColor = action.color))
+
+            is AniListOptionsAction.ResolveConflict -> repository.resolveConflict(action.keepLocal)
         }
     }
 
@@ -143,24 +94,14 @@ class AniListOptionsViewModel @Inject constructor(
                 return@launch
             }
             _loading.value = true
-            _error.value = null
             when (val result = syncUserOptions()) {
-                is Result.Error -> _error.value = result.message
-                is Result.Success -> Unit
+                is Result.Error -> {
+                    _error.value = result.message
+                    toastManager.showResultError(result)
+                }
+                is Result.Success -> _error.value = null
             }
             _loading.value = false
-        }
-    }
-
-    /** Pushes a partial edit to AniList. The repository updates the cache + mirror on success. */
-    private fun push(patch: UserOptionsPatch) {
-        viewModelScope.launch {
-            _saving.value = true
-            when (val result = repository.updateOptions(patch)) {
-                is Result.Success -> toastManager.showToast(ToastType.SUCCESS, message = "Saved to AniList")
-                is Result.Error -> toastManager.showResultError(result)
-            }
-            _saving.value = false
         }
     }
 }

--- a/app/src/main/java/com/anisync/android/presentation/settings/AniListSettingsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AniListSettingsScreen.kt
@@ -43,7 +43,6 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.anisync.android.R
 import com.anisync.android.data.account.Account
-import com.anisync.android.domain.UserOptionField
 import com.anisync.android.presentation.components.UserAvatar
 import com.anisync.android.presentation.login.AniListAuth
 import com.anisync.android.util.AppLinksUtil
@@ -127,40 +126,6 @@ fun AniListSettingsScreen(
         )
     }
 
-    optionsState.conflict?.let { conflict ->
-        AlertDialog(
-            // No outside-dismiss: the user must pick a direction to clear the conflict.
-            onDismissRequest = {},
-            title = { Text(stringResource(R.string.options_conflict_title)) },
-            text = {
-                Text(
-                    stringResource(
-                        R.string.options_conflict_message,
-                        conflict.fields.joinToString(", ") { it.displayName() },
-                    )
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        optionsViewModel.onAction(AniListOptionsAction.ResolveConflict(keepLocal = true))
-                    }
-                ) {
-                    Text(stringResource(R.string.options_conflict_keep_local))
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = {
-                        optionsViewModel.onAction(AniListOptionsAction.ResolveConflict(keepLocal = false))
-                    }
-                ) {
-                    Text(stringResource(R.string.options_conflict_use_website))
-                }
-            }
-        )
-    }
-
     SettingsScreenScaffold(
         title = stringResource(R.string.settings_anilist_account),
         onBackClick = onBackClick,
@@ -181,7 +146,8 @@ fun AniListSettingsScreen(
                 IconButton(onClick = { showLogoutDialog = true }) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.Logout,
-                        contentDescription = stringResource(R.string.control_log_out)
+                        contentDescription = stringResource(R.string.control_log_out),
+                        tint = MaterialTheme.colorScheme.error
                     )
                 }
             }
@@ -335,15 +301,3 @@ private fun AccountRow(
     }
 }
 
-/** Human-readable label for a conflicting option field, shown in the sync-conflict dialog. */
-private fun UserOptionField.displayName(): String = when (this) {
-    UserOptionField.DISPLAY_ADULT_CONTENT -> "Adult content"
-    UserOptionField.TITLE_LANGUAGE -> "Title language"
-    UserOptionField.STAFF_NAME_LANGUAGE -> "Staff & character names"
-    UserOptionField.SCORE_FORMAT -> "Scoring system"
-    UserOptionField.AIRING_NOTIFICATIONS -> "Airing notifications"
-    UserOptionField.RESTRICT_MESSAGES_TO_FOLLOWING -> "Message restriction"
-    UserOptionField.ACTIVITY_MERGE_TIME -> "Activity merge time"
-    UserOptionField.PROFILE_COLOR -> "Profile color"
-    UserOptionField.DISABLED_LIST_ACTIVITY -> "List activity"
-}

--- a/app/src/main/java/com/anisync/android/presentation/settings/AniListSettingsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AniListSettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.PersonAddAlt
@@ -130,7 +131,27 @@ fun AniListSettingsScreen(
     SettingsScreenScaffold(
         title = stringResource(R.string.settings_anilist_account),
         onBackClick = onBackClick,
-        modifier = modifier
+        modifier = modifier,
+        actions = {
+            val active = activeAccount
+            if (active != null && active.name.isNotBlank()) {
+                IconButton(
+                    onClick = {
+                        context.startActivity(
+                            Intent(
+                                Intent.ACTION_VIEW,
+                                Uri.parse("https://anilist.co/user/${active.name}")
+                            )
+                        )
+                    }
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                        contentDescription = stringResource(R.string.settings_view_on_anilist)
+                    )
+                }
+            }
+        }
     ) {
         // ── Accounts ─────────────────────────────────────────────────────────────────────────────
         SectionLabel(stringResource(R.string.settings_account))
@@ -167,26 +188,6 @@ fun AniListSettingsScreen(
                 ) { CircularProgressIndicator() }
             } else {
                 AniListOptionsContent(optionsState, optionsViewModel::onAction)
-            }
-        }
-
-        // ── Active-account actions ────────────────────────────────────────────────────────────────
-        val active = activeAccount
-        if (active != null && active.name.isNotBlank()) {
-            Spacer(modifier = Modifier.height(16.dp))
-            SettingsGroup {
-                SettingsItem(
-                    title = stringResource(R.string.settings_view_on_anilist),
-                    subtitle = stringResource(R.string.settings_view_on_anilist_desc),
-                    onClick = {
-                        context.startActivity(
-                            Intent(
-                                Intent.ACTION_VIEW,
-                                Uri.parse("https://anilist.co/user/${active.name}")
-                            )
-                        )
-                    }
-                )
             }
         }
 

--- a/app/src/main/java/com/anisync/android/presentation/settings/AniListSettingsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AniListSettingsScreen.kt
@@ -43,6 +43,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.anisync.android.R
 import com.anisync.android.data.account.Account
+import com.anisync.android.domain.UserOptionField
 import com.anisync.android.presentation.components.UserAvatar
 import com.anisync.android.presentation.login.AniListAuth
 import com.anisync.android.util.AppLinksUtil
@@ -121,6 +122,40 @@ fun AniListSettingsScreen(
             dismissButton = {
                 TextButton(onClick = { accountToRemove = null }) {
                     Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+
+    optionsState.conflict?.let { conflict ->
+        AlertDialog(
+            // No outside-dismiss: the user must pick a direction to clear the conflict.
+            onDismissRequest = {},
+            title = { Text(stringResource(R.string.options_conflict_title)) },
+            text = {
+                Text(
+                    stringResource(
+                        R.string.options_conflict_message,
+                        conflict.fields.joinToString(", ") { it.displayName() },
+                    )
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        optionsViewModel.onAction(AniListOptionsAction.ResolveConflict(keepLocal = true))
+                    }
+                ) {
+                    Text(stringResource(R.string.options_conflict_keep_local))
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        optionsViewModel.onAction(AniListOptionsAction.ResolveConflict(keepLocal = false))
+                    }
+                ) {
+                    Text(stringResource(R.string.options_conflict_use_website))
                 }
             }
         )
@@ -298,4 +333,17 @@ private fun AccountRow(
             }
         }
     }
+}
+
+/** Human-readable label for a conflicting option field, shown in the sync-conflict dialog. */
+private fun UserOptionField.displayName(): String = when (this) {
+    UserOptionField.DISPLAY_ADULT_CONTENT -> "Adult content"
+    UserOptionField.TITLE_LANGUAGE -> "Title language"
+    UserOptionField.STAFF_NAME_LANGUAGE -> "Staff & character names"
+    UserOptionField.SCORE_FORMAT -> "Scoring system"
+    UserOptionField.AIRING_NOTIFICATIONS -> "Airing notifications"
+    UserOptionField.RESTRICT_MESSAGES_TO_FOLLOWING -> "Message restriction"
+    UserOptionField.ACTIVITY_MERGE_TIME -> "Activity merge time"
+    UserOptionField.PROFILE_COLOR -> "Profile color"
+    UserOptionField.DISABLED_LIST_ACTIVITY -> "List activity"
 }

--- a/app/src/main/java/com/anisync/android/presentation/settings/AniListSettingsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AniListSettingsScreen.kt
@@ -2,30 +2,27 @@ package com.anisync.android.presentation.settings
 
 import android.content.Intent
 import android.net.Uri
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.PersonAddAlt
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -48,6 +45,7 @@ import com.anisync.android.R
 import com.anisync.android.data.account.Account
 import com.anisync.android.presentation.components.UserAvatar
 import com.anisync.android.presentation.login.AniListAuth
+import com.anisync.android.util.AppLinksUtil
 
 /**
  * AniList settings: one screen merging account management (add / switch / remove / logout) with the
@@ -137,17 +135,18 @@ fun AniListSettingsScreen(
             if (active != null && active.name.isNotBlank()) {
                 IconButton(
                     onClick = {
-                        context.startActivity(
-                            Intent(
-                                Intent.ACTION_VIEW,
-                                Uri.parse("https://anilist.co/user/${active.name}")
-                            )
-                        )
+                        AppLinksUtil.openInBrowser(context, "https://anilist.co/user/${active.name}")
                     }
                 ) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.OpenInNew,
-                        contentDescription = stringResource(R.string.settings_view_on_anilist)
+                        contentDescription = stringResource(R.string.settings_open_in_web)
+                    )
+                }
+                IconButton(onClick = { showLogoutDialog = true }) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.Logout,
+                        contentDescription = stringResource(R.string.control_log_out)
                     )
                 }
             }
@@ -191,30 +190,6 @@ fun AniListSettingsScreen(
             }
         }
 
-        Spacer(modifier = Modifier.height(24.dp))
-
-        OutlinedButton(
-            onClick = { showLogoutDialog = true },
-            enabled = activeAccount != null,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(52.dp),
-            colors = ButtonDefaults.outlinedButtonColors(
-                contentColor = MaterialTheme.colorScheme.error
-            ),
-            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline)
-        ) {
-            Text(stringResource(R.string.control_log_out))
-        }
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Text(
-            text = stringResource(R.string.settings_logout_warning),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(horizontal = 4.dp)
-        )
     }
 }
 

--- a/app/src/main/java/com/anisync/android/presentation/settings/AniListSettingsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AniListSettingsScreen.kt
@@ -3,7 +3,6 @@ package com.anisync.android.presentation.settings
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,8 +11,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -21,6 +18,7 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.PersonAddAlt
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -43,7 +41,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.anisync.android.R
@@ -52,20 +49,22 @@ import com.anisync.android.presentation.components.UserAvatar
 import com.anisync.android.presentation.login.AniListAuth
 
 /**
- * Account settings screen: lists every signed-in account with add / switch / remove / re-auth,
- * plus logout for the active account. Switching or removing the active account recreates the
- * activity so all ViewModels rebuild against the new (reset) account state.
+ * AniList settings: one screen merging account management (add / switch / remove / logout) with the
+ * AniList account options (adult content, languages, score format, activity, profile color). The
+ * accounts section drives identity; the options below it reflect and edit the active account.
  */
 @Composable
-fun AccountScreen(
+fun AniListSettingsScreen(
     onLogout: () -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: AccountViewModel = hiltViewModel()
+    accountViewModel: AccountViewModel = hiltViewModel(),
+    optionsViewModel: AniListOptionsViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
-    val accounts by viewModel.accounts.collectAsStateWithLifecycle()
-    val activeAccount by viewModel.activeAccount.collectAsStateWithLifecycle()
+    val accounts by accountViewModel.accounts.collectAsStateWithLifecycle()
+    val activeAccount by accountViewModel.activeAccount.collectAsStateWithLifecycle()
+    val optionsState by optionsViewModel.uiState.collectAsStateWithLifecycle()
 
     var showLogoutDialog by rememberSaveable { mutableStateOf(false) }
     var accountToRemove by remember { mutableStateOf<Account?>(null) }
@@ -83,7 +82,7 @@ fun AccountScreen(
                 TextButton(
                     onClick = {
                         showLogoutDialog = false
-                        viewModel.logoutActive()
+                        accountViewModel.logoutActive()
                     }
                 ) {
                     Text(
@@ -111,7 +110,7 @@ fun AccountScreen(
                 TextButton(
                     onClick = {
                         accountToRemove = null
-                        viewModel.remove(target.id)
+                        accountViewModel.remove(target.id)
                     }
                 ) {
                     Text(
@@ -129,10 +128,12 @@ fun AccountScreen(
     }
 
     SettingsScreenScaffold(
-        title = stringResource(R.string.settings_account),
+        title = stringResource(R.string.settings_anilist_account),
         onBackClick = onBackClick,
         modifier = modifier
     ) {
+        // ── Accounts ─────────────────────────────────────────────────────────────────────────────
+        SectionLabel(stringResource(R.string.settings_account))
         SettingsGroup {
             accounts.forEach { account ->
                 AccountRow(
@@ -140,7 +141,7 @@ fun AccountScreen(
                     isActive = account.id == activeAccount?.id,
                     onSwitch = {
                         if (account.isExpired) launchOAuth()
-                        else viewModel.switch(account.id)
+                        else accountViewModel.switch(account.id)
                     },
                     onReauthenticate = ::launchOAuth,
                     onRemove = { accountToRemove = account }
@@ -155,7 +156,21 @@ fun AccountScreen(
             )
         }
 
-        // Active-account actions
+        // ── AniList account options (active account) ───────────────────────────────────────────────
+        if (activeAccount != null) {
+            if (optionsState.isLoading && optionsState.options == null) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(160.dp),
+                    contentAlignment = Alignment.Center,
+                ) { CircularProgressIndicator() }
+            } else {
+                AniListOptionsContent(optionsState, optionsViewModel::onAction)
+            }
+        }
+
+        // ── Active-account actions ────────────────────────────────────────────────────────────────
         val active = activeAccount
         if (active != null && active.name.isNotBlank()) {
             Spacer(modifier = Modifier.height(16.dp))
@@ -202,6 +217,10 @@ fun AccountScreen(
     }
 }
 
+/**
+ * One signed-in account: tap to switch, overflow for switch / re-auth / remove. Active account shows
+ * a check and can't be removed via the row (logout handles it).
+ */
 @Composable
 private fun AccountRow(
     account: Account,
@@ -224,7 +243,6 @@ private fun AccountRow(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.padding(12.dp).fillMaxWidth()
         ) {
-            // Avatar
             UserAvatar(
                 url = account.avatarUrl,
                 contentDescription = null,

--- a/app/src/main/java/com/anisync/android/presentation/settings/LookAndFeelScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/LookAndFeelScreen.kt
@@ -116,7 +116,6 @@ fun LookAndFeelScreen(
     val titleLanguage = uiState.titleLanguage
     val preferredStreamingService = uiState.preferredStreamingService
     val hapticEnabled = uiState.hapticEnabled
-    val showAdultContent = uiState.showAdultContent
     val appLocale = uiState.appLocale
     val coverQuality = uiState.coverQuality
     val navBarStyle = uiState.navBarStyle
@@ -429,13 +428,8 @@ fun LookAndFeelScreen(
                 checked = hapticEnabled,
                 onCheckedChange = { viewModel.onAction(SettingsAction.SetHapticEnabled(it)) }
             )
-            SettingsDivider()
-            SwitchSettingsItem(
-                icon = Icons.Default.Visibility,
-                title = "Show adult content",
-                checked = showAdultContent,
-                onCheckedChange = { viewModel.onAction(SettingsAction.SetShowAdultContent(it)) }
-            )
+            // "Show adult content" now lives under Settings ▸ AniList Account, where it follows the
+            // AniList account option by default and can be overridden per device.
         }
     }
 }

--- a/app/src/main/java/com/anisync/android/presentation/settings/LookAndFeelScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/LookAndFeelScreen.kt
@@ -113,7 +113,6 @@ fun LookAndFeelScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val themeMode = uiState.themeMode
-    val titleLanguage = uiState.titleLanguage
     val preferredStreamingService = uiState.preferredStreamingService
     val hapticEnabled = uiState.hapticEnabled
     val appLocale = uiState.appLocale
@@ -131,7 +130,6 @@ fun LookAndFeelScreen(
 
     var showColorPicker by rememberSaveable { mutableStateOf(false) }
     var showThemeModeDialog by rememberSaveable { mutableStateOf(false) }
-    var showTitleLanguageSheet by rememberSaveable { mutableStateOf(false) }
     var showAppLanguageSheet by rememberSaveable { mutableStateOf(false) }
     var showStreamingServiceSheet by rememberSaveable { mutableStateOf(false) }
     var showCoverQualitySheet by rememberSaveable { mutableStateOf(false) }
@@ -188,16 +186,6 @@ fun LookAndFeelScreen(
         )
     }
 
-    if (showTitleLanguageSheet) {
-        TitleLanguageSelectionSheet(
-            currentLanguage = titleLanguage,
-            onLanguageSelected = {
-                viewModel.onAction(SettingsAction.SetTitleLanguage(it))
-                showTitleLanguageSheet = false
-            },
-            onDismiss = { showTitleLanguageSheet = false }
-        )
-    }
 
     if (showStreamingServiceSheet) {
         StreamingServiceSelectionSheet(
@@ -373,13 +361,6 @@ fun LookAndFeelScreen(
                 title = stringResource(R.string.settings_app_language),
                 currentValue = appLocale.displayName,
                 onClick = { showAppLanguageSheet = true }
-            )
-            SettingsDivider()
-            SelectionSettingsItem(
-                icon = Icons.Default.Language,
-                title = stringResource(R.string.settings_title_language),
-                currentValue = getTitleLanguageLabel(titleLanguage),
-                onClick = { showTitleLanguageSheet = true }
             )
             SettingsDivider()
             SelectionSettingsItem(

--- a/app/src/main/java/com/anisync/android/presentation/settings/SettingsComponents.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/SettingsComponents.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -46,6 +47,7 @@ fun SettingsScreenScaffold(
     title: String,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
+    actions: @Composable RowScope.() -> Unit = {},
     content: @Composable () -> Unit
 ) {
     val lazyListState = rememberLazyListState()
@@ -55,7 +57,8 @@ fun SettingsScreenScaffold(
         onBackClick = onBackClick,
         modifier = modifier,
         scrollableState = lazyListState,
-        enableEnterAnimation = true
+        enableEnterAnimation = true,
+        actions = actions
     ) { topContentPadding ->
         LazyColumn(
             state = lazyListState,

--- a/app/src/main/java/com/anisync/android/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/SettingsScreen.kt
@@ -75,7 +75,6 @@ fun SettingsScreen(
     onNavigateToAniList: () -> Unit,
     onNavigateToNotifications: () -> Unit,
     onNavigateToStorage: () -> Unit,
-    onNavigateToAccount: () -> Unit,
     onNavigateToAbout: () -> Unit,
     onNavigateToSponsors: () -> Unit,
     onNavigateToUpdates: () -> Unit,
@@ -178,13 +177,6 @@ fun SettingsScreen(
                 subtitle = stringResource(R.string.settings_media_upload_desc),
                 icon = Icons.Outlined.CloudUpload,
                 onClick = onNavigateToMediaUpload
-            ),
-            CategoryData(
-                key = "account",
-                title = stringResource(R.string.settings_account),
-                subtitle = stringResource(R.string.settings_account_desc),
-                icon = Icons.Outlined.AccountCircle,
-                onClick = onNavigateToAccount
             ),
             CategoryData(
                 key = "links",

--- a/app/src/main/java/com/anisync/android/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/SettingsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.Palette
 import androidx.compose.material.icons.outlined.Storage
+import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material.icons.outlined.Update
 import androidx.compose.material.icons.rounded.Link
 import androidx.compose.material.icons.rounded.VolunteerActivism
@@ -71,6 +72,7 @@ private data class CategoryData(
 @Composable
 fun SettingsScreen(
     onNavigateToLookAndFeel: () -> Unit,
+    onNavigateToAniList: () -> Unit,
     onNavigateToNotifications: () -> Unit,
     onNavigateToStorage: () -> Unit,
     onNavigateToAccount: () -> Unit,
@@ -148,6 +150,13 @@ fun SettingsScreen(
                 subtitle = stringResource(R.string.settings_look_and_feel_desc),
                 icon = Icons.Outlined.Palette,
                 onClick = onNavigateToLookAndFeel
+            ),
+            CategoryData(
+                key = "anilist",
+                title = stringResource(R.string.settings_anilist_account),
+                subtitle = stringResource(R.string.settings_anilist_account_desc),
+                icon = Icons.Outlined.Tune,
+                onClick = onNavigateToAniList
             ),
             CategoryData(
                 key = "notifications",
@@ -337,6 +346,7 @@ private fun getCategoryColors(key: String, isDark: Boolean): Pair<Color, Color> 
     return if (isDark) {
         when (key) {
             "lookandfeel" -> Color(0xFF7D5260) to Color(0xFFFFD8E4)
+            "anilist" -> Color(0xFF2E4B5F) to Color(0xFFB8E6FF)
             "notifications" -> Color(0xFF3E4C63) to Color(0xFFD7E3FF)
             "storage" -> Color(0xFF3B4869) to Color(0xFFD9E2FF)
             "media_upload" -> Color(0xFF004F58) to Color(0xFF88FAFF)
@@ -350,6 +360,7 @@ private fun getCategoryColors(key: String, isDark: Boolean): Pair<Color, Color> 
     } else {
         when (key) {
             "lookandfeel" -> Color(0xFFFFD8E4) to Color(0xFF631835)
+            "anilist" -> Color(0xFFB8E6FF) to Color(0xFF0E3346)
             "notifications" -> Color(0xFFD7E3FF) to Color(0xFF253347)
             "storage" -> Color(0xFFD9E2FF) to Color(0xFF27304E)
             "media_upload" -> Color(0xFFCCE8EA) to Color(0xFF004F58)

--- a/app/src/main/java/com/anisync/android/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/SettingsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.Palette
 import androidx.compose.material.icons.outlined.Storage
+import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material.icons.outlined.Update
 import androidx.compose.material.icons.rounded.Link
@@ -51,12 +52,17 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.ui.platform.LocalContext
 import com.anisync.android.BuildConfig
 import com.anisync.android.R
+import com.anisync.android.util.launchUrl
 import com.anisync.android.data.ThemeMode
 import com.anisync.android.presentation.components.AppLinksPromptDialog
 import com.anisync.android.presentation.util.LocalAppSettings
 import com.anisync.android.ui.theme.decorativeAvatarShape
+
+/** AniSync's Weblate project — community translation. Opened from the Settings top bar. */
+private const val WEBLATE_URL = "https://hosted.weblate.org/engage/anisync/"
 
 private data class CategoryData(
     val key: String,
@@ -103,7 +109,22 @@ fun SettingsScreen(
     SettingsScreenScaffold(
         title = stringResource(R.string.settings),
         onBackClick = onBackClick,
-        modifier = modifier
+        modifier = modifier,
+        actions = {
+            val context = LocalContext.current
+            IconButton(onClick = onNavigateToSponsors) {
+                Icon(
+                    imageVector = Icons.Rounded.VolunteerActivism,
+                    contentDescription = stringResource(R.string.settings_sponsors)
+                )
+            }
+            IconButton(onClick = { context.launchUrl(WEBLATE_URL) }) {
+                Icon(
+                    imageVector = Icons.Outlined.Translate,
+                    contentDescription = stringResource(R.string.translate)
+                )
+            }
+        }
     ) {
         val isDark = isSystemInDarkTheme() || uiState.themeMode == ThemeMode.DARK
 

--- a/app/src/main/java/com/anisync/android/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/SettingsViewModel.kt
@@ -215,7 +215,12 @@ class SettingsViewModel @Inject constructor(
     fun onAction(action: SettingsAction) {
         when (action) {
             is SettingsAction.SetThemeMode -> appSettings.setThemeMode(action.mode)
-            is SettingsAction.SetTitleLanguage -> appSettings.setTitleLanguage(action.language)
+            is SettingsAction.SetTitleLanguage -> {
+                // A manual pick here is a deliberate device choice, so flip on the local override —
+                // otherwise the next AniList options sync would mirror the account value back over it.
+                appSettings.setTitleLanguage(action.language)
+                appSettings.setTitleLanguageOverrideEnabled(true)
+            }
             is SettingsAction.SetCoverQuality -> appSettings.setCoverQuality(action.quality)
             is SettingsAction.SetHapticEnabled -> appSettings.setHapticEnabled(action.enabled)
             is SettingsAction.SetNavBarStyle -> appSettings.setNavBarStyle(action.style)

--- a/app/src/main/java/com/anisync/android/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/SettingsViewModel.kt
@@ -215,12 +215,7 @@ class SettingsViewModel @Inject constructor(
     fun onAction(action: SettingsAction) {
         when (action) {
             is SettingsAction.SetThemeMode -> appSettings.setThemeMode(action.mode)
-            is SettingsAction.SetTitleLanguage -> {
-                // A manual pick here is a deliberate device choice, so flip on the local override —
-                // otherwise the next AniList options sync would mirror the account value back over it.
-                appSettings.setTitleLanguage(action.language)
-                appSettings.setTitleLanguageOverrideEnabled(true)
-            }
+            is SettingsAction.SetTitleLanguage -> appSettings.setTitleLanguage(action.language)
             is SettingsAction.SetCoverQuality -> appSettings.setCoverQuality(action.quality)
             is SettingsAction.SetHapticEnabled -> appSettings.setHapticEnabled(action.enabled)
             is SettingsAction.SetNavBarStyle -> appSettings.setNavBarStyle(action.style)

--- a/app/src/main/java/com/anisync/android/presentation/settings/UserOptionsConflictDialog.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/UserOptionsConflictDialog.kt
@@ -1,0 +1,110 @@
+package com.anisync.android.presentation.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.anisync.android.R
+import androidx.compose.ui.res.stringResource
+import com.anisync.android.domain.AniListUserOptions
+import com.anisync.android.domain.ConflictState
+import com.anisync.android.domain.UserOptionField
+import com.anisync.android.domain.UserOptionsRepository
+
+/**
+ * App-wide host for the options sync-conflict prompt. Hosted once at the app root (see MainActivity)
+ * so a conflict detected by the cold-start pull surfaces right after launch, not only when the user
+ * happens to open AniList Settings.
+ */
+@Composable
+fun UserOptionsConflictHandler(repository: UserOptionsRepository) {
+    val conflict by repository.conflict.collectAsStateWithLifecycle()
+    val local by repository.cachedOptions.collectAsStateWithLifecycle()
+    conflict?.let {
+        UserOptionsConflictDialog(
+            conflict = it,
+            local = local,
+            onResolve = repository::resolveConflict,
+        )
+    }
+}
+
+@Composable
+private fun UserOptionsConflictDialog(
+    conflict: ConflictState,
+    local: AniListUserOptions?,
+    onResolve: (keepLocal: Boolean) -> Unit,
+) {
+    AlertDialog(
+        // No outside-dismiss: the user must pick a direction to clear the conflict.
+        onDismissRequest = {},
+        title = { Text(stringResource(R.string.options_conflict_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(stringResource(R.string.options_conflict_intro))
+                conflict.fields.forEach { field ->
+                    Column {
+                        Text(
+                            text = field.displayName(),
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Text(
+                            text = stringResource(
+                                R.string.options_conflict_field_values,
+                                local?.conflictValueLabel(field) ?: "—",
+                                conflict.serverValues.conflictValueLabel(field),
+                            ),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                Text(stringResource(R.string.options_conflict_question))
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onResolve(true) }) {
+                Text(stringResource(R.string.options_conflict_keep_local))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = { onResolve(false) }) {
+                Text(stringResource(R.string.options_conflict_use_website))
+            }
+        },
+    )
+}
+
+/** Human-readable label for a conflicting option field. */
+private fun UserOptionField.displayName(): String = when (this) {
+    UserOptionField.DISPLAY_ADULT_CONTENT -> "Adult content"
+    UserOptionField.TITLE_LANGUAGE -> "Title language"
+    UserOptionField.STAFF_NAME_LANGUAGE -> "Staff & character names"
+    UserOptionField.SCORE_FORMAT -> "Scoring system"
+    UserOptionField.AIRING_NOTIFICATIONS -> "Airing notifications"
+    UserOptionField.RESTRICT_MESSAGES_TO_FOLLOWING -> "Message restriction"
+    UserOptionField.ACTIVITY_MERGE_TIME -> "Activity merge time"
+    UserOptionField.PROFILE_COLOR -> "Profile color"
+    UserOptionField.DISABLED_LIST_ACTIVITY -> "List activity"
+}
+
+/** Human-readable value of a single field, for spelling out each side of a conflict. */
+private fun AniListUserOptions.conflictValueLabel(field: UserOptionField): String = when (field) {
+    UserOptionField.DISPLAY_ADULT_CONTENT -> if (displayAdultContent) "On" else "Off"
+    UserOptionField.TITLE_LANGUAGE -> titleLanguage?.toBaseLanguage().label()
+    UserOptionField.STAFF_NAME_LANGUAGE -> staffNameLanguage.label()
+    UserOptionField.SCORE_FORMAT -> scoreFormat.label()
+    UserOptionField.AIRING_NOTIFICATIONS -> if (airingNotifications) "On" else "Off"
+    UserOptionField.RESTRICT_MESSAGES_TO_FOLLOWING -> if (restrictMessagesToFollowing) "On" else "Off"
+    UserOptionField.ACTIVITY_MERGE_TIME -> activityMergeLabel(activityMergeTime)
+    UserOptionField.PROFILE_COLOR -> profileColor?.replaceFirstChar { it.uppercase() } ?: "Default"
+    UserOptionField.DISABLED_LIST_ACTIVITY -> "Custom"
+}

--- a/app/src/main/java/com/anisync/android/util/AppLinksUtil.kt
+++ b/app/src/main/java/com/anisync/android/util/AppLinksUtil.kt
@@ -1,6 +1,7 @@
 package com.anisync.android.util
 
 import android.content.ActivityNotFoundException
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -14,6 +15,55 @@ import androidx.core.net.toUri
 object AppLinksUtil {
 
     private const val DOMAIN_ANILIST = "anilist.co"
+
+    /**
+     * Opens [url] in a web browser, never in AniSync. anilist.co is a verified app link, so a plain
+     * ACTION_VIEW is routed straight to AniSync (stable or debug) and skips any chooser — which is
+     * why excluding components doesn't help. Instead we locate an installed browser via a neutral
+     * host AniSync does not handle, then target that package explicitly; an explicit package
+     * overrides app-link verification routing. Falls back to a chooser that excludes AniSync.
+     */
+    fun openInBrowser(context: Context, url: String) {
+        val uri = url.toUri()
+        val pm = context.packageManager
+
+        val probe = Intent(Intent.ACTION_VIEW, "https://www.example.com".toUri())
+            .addCategory(Intent.CATEGORY_BROWSABLE)
+        val browserPackage = pm.queryIntentActivities(probe, PackageManager.MATCH_DEFAULT_ONLY)
+            .map { it.activityInfo.packageName }
+            .firstOrNull { !it.startsWith("com.anisync.android") }
+
+        val view = Intent(Intent.ACTION_VIEW, uri)
+            .addCategory(Intent.CATEGORY_BROWSABLE)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+        try {
+            if (browserPackage != null) {
+                context.startActivity(view.setPackage(browserPackage))
+            } else {
+                context.startActivity(chooserExcludingAniSync(pm, view))
+            }
+        } catch (_: ActivityNotFoundException) {
+            runCatching {
+                context.startActivity(
+                    chooserExcludingAniSync(pm, Intent(Intent.ACTION_VIEW, uri).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+                )
+            }
+        }
+    }
+
+    /** A chooser for [view] with every AniSync handler stripped out (last-resort when no browser resolves). */
+    private fun chooserExcludingAniSync(pm: PackageManager, view: Intent): Intent {
+        val excluded = pm.queryIntentActivities(view, PackageManager.MATCH_ALL)
+            .map { it.activityInfo }
+            .filter { it.packageName.startsWith("com.anisync.android") }
+            .map { ComponentName(it.packageName, it.name) }
+            .toTypedArray()
+        return Intent.createChooser(view, null).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            if (excluded.isNotEmpty()) putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, excluded)
+        }
+    }
 
     fun isDomainVerified(context: Context, domain: String = DOMAIN_ANILIST): Boolean {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/app/src/main/java/com/anisync/android/worker/UserOptionsFlushWorker.kt
+++ b/app/src/main/java/com/anisync/android/worker/UserOptionsFlushWorker.kt
@@ -1,0 +1,49 @@
+package com.anisync.android.worker
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.anisync.android.domain.UserOptionsRepository
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+/**
+ * Background safety net for the local-first options sync: flushes any pending option edits to AniList.
+ * Enqueued on every edit (unique, network-constrained) so changes still reach the server if the app
+ * is killed before the in-process debounce fires. [UserOptionsRepository.flush] is guarded and a
+ * no-op when nothing is pending, so this overlapping with the debounce flush is harmless.
+ */
+@HiltWorker
+class UserOptionsFlushWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted params: WorkerParameters,
+    private val repository: UserOptionsRepository,
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        repository.flush()
+        return Result.success()
+    }
+
+    companion object {
+        private const val WORK_NAME = "UserOptionsFlush"
+
+        fun enqueue(context: Context) {
+            val request = OneTimeWorkRequestBuilder<UserOptionsFlushWorker>()
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build()
+                )
+                .build()
+            WorkManager.getInstance(context.applicationContext)
+                .enqueueUniqueWork(WORK_NAME, ExistingWorkPolicy.KEEP, request)
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -386,6 +386,10 @@
     <string name="settings_view_on_anilist">View on AniList</string>
     <string name="settings_view_on_anilist_desc">Open your profile on AniList</string>
     <string name="settings_open_in_web">Open in web</string>
+    <string name="options_conflict_title">Settings changed elsewhere</string>
+    <string name="options_conflict_message">These options were changed on the AniList website and differ from this device: %1$s. Keep this device\'s changes, or use the website\'s?</string>
+    <string name="options_conflict_keep_local">Keep this device</string>
+    <string name="options_conflict_use_website">Use website</string>
     <string name="settings_logout_warning">Logging out will remove your session. You can sign in again at any time.</string>
     <!-- Multiple accounts -->
     <string name="account_add">Add account</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -385,6 +385,7 @@
     <string name="settings_account_anilist">Signed in with AniList</string>
     <string name="settings_view_on_anilist">View on AniList</string>
     <string name="settings_view_on_anilist_desc">Open your profile on AniList</string>
+    <string name="settings_open_in_web">Open in web</string>
     <string name="settings_logout_warning">Logging out will remove your session. You can sign in again at any time.</string>
     <!-- Multiple accounts -->
     <string name="account_add">Add account</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -317,8 +317,8 @@
     <string name="navigate_back">Go back</string>
     <string name="settings_look_and_feel">Look and Feel</string>
     <string name="settings_look_and_feel_desc">Theme, language, streaming service</string>
-    <string name="settings_anilist_account">AniList Account</string>
-    <string name="settings_anilist_account_desc">Adult content, languages, score format, activity</string>
+    <string name="settings_anilist_account">AniList Settings</string>
+    <string name="settings_anilist_account_desc">Accounts, adult content, languages, score format</string>
     <string name="settings_notifications">Notifications</string>
     <string name="settings_notifications_desc">Episode alerts, forum activity</string>
     <string name="settings_storage">Storage</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -317,6 +317,8 @@
     <string name="navigate_back">Go back</string>
     <string name="settings_look_and_feel">Look and Feel</string>
     <string name="settings_look_and_feel_desc">Theme, language, streaming service</string>
+    <string name="settings_anilist_account">AniList Account</string>
+    <string name="settings_anilist_account_desc">Adult content, languages, score format, activity</string>
     <string name="settings_notifications">Notifications</string>
     <string name="settings_notifications_desc">Episode alerts, forum activity</string>
     <string name="settings_storage">Storage</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -387,7 +387,9 @@
     <string name="settings_view_on_anilist_desc">Open your profile on AniList</string>
     <string name="settings_open_in_web">Open in web</string>
     <string name="options_conflict_title">Settings changed elsewhere</string>
-    <string name="options_conflict_message">These options were changed on the AniList website and differ from this device: %1$s. Keep this device\'s changes, or use the website\'s?</string>
+    <string name="options_conflict_intro">These options changed on the AniList website and differ from this device:</string>
+    <string name="options_conflict_field_values">This device: %1$s   ·   Website: %2$s</string>
+    <string name="options_conflict_question">Keep this device\'s changes, or use the website\'s?</string>
     <string name="options_conflict_keep_local">Keep this device</string>
     <string name="options_conflict_use_website">Use website</string>
     <string name="settings_logout_warning">Logging out will remove your session. You can sign in again at any time.</string>
@@ -971,14 +973,14 @@
     <string name="support_anisync">Support %s</string>
     <string name="support_description">AniSync is a passion project built entirely in my free time. If you enjoy using the app, consider sponsoring to help keep development alive.</string>
 
-    <!-- Sponsors screen -->
-    <string name="settings_sponsors">Sponsors</string>
-    <string name="settings_sponsors_desc">People supporting AniSync\'s development</string>
-    <string name="sponsors_title">Sponsors</string>
-    <string name="sponsors_hero_headline">Powered by you</string>
-    <string name="sponsors_hero_body">AniSync is ad-free and open source. If you want to help, please consider becoming a sponsor.</string>
-    <string name="sponsors_become_button">Become a Sponsor</string>
-    <string name="sponsors_github_button">Sponsors</string>
+    <!-- Donate screen -->
+    <string name="settings_sponsors">Donate</string>
+    <string name="settings_sponsors_desc">Buy me a coffee to support AniSync</string>
+    <string name="sponsors_title">Donate</string>
+    <string name="sponsors_hero_headline">Buy me a coffee</string>
+    <string name="sponsors_hero_body">AniSync is free, ad-free, and open source — made in my spare time. If it brightens your day, you can buy me a coffee. Monthly supporters get their name and avatar shown here; share a social (like your AniList) and I\'ll link it too.</string>
+    <string name="sponsors_become_button">Buy a coffee</string>
+    <string name="sponsors_github_button">GitHub</string>
     <string name="sponsors_kofi_button">Ko-fi</string>
     <string name="sponsors_refresh">Refresh</string>
     <string name="sponsors_updated_at">Updated %1$s</string>

--- a/app/src/test/java/com/anisync/android/data/UserOptionsMappingTest.kt
+++ b/app/src/test/java/com/anisync/android/data/UserOptionsMappingTest.kt
@@ -1,0 +1,105 @@
+package com.anisync.android.data
+
+import com.anisync.android.domain.AdultMode
+import com.anisync.android.domain.AniListListActivityStatus
+import com.anisync.android.domain.AniListStaffNameLanguage
+import com.anisync.android.domain.AniListTitleLanguage
+import com.anisync.android.domain.AniListUserOptions
+import com.anisync.android.domain.ScoreFormat
+import com.anisync.android.domain.UserActivity
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UserOptionsMappingTest {
+
+    // ── resolveAdultIsAdult (search floor — fixes the inert toggle) ───────────────────────────────
+
+    @Test
+    fun `ANY with adult off hides adult`() {
+        assertEquals(false, resolveAdultIsAdult(AdultMode.ANY, showAdultContent = false))
+    }
+
+    @Test
+    fun `ANY with adult on leaves filter off`() {
+        assertNull(resolveAdultIsAdult(AdultMode.ANY, showAdultContent = true))
+    }
+
+    @Test
+    fun `HIDE always hides regardless of preference`() {
+        assertEquals(false, resolveAdultIsAdult(AdultMode.HIDE, showAdultContent = true))
+        assertEquals(false, resolveAdultIsAdult(AdultMode.HIDE, showAdultContent = false))
+    }
+
+    @Test
+    fun `ONLY always shows only adult regardless of preference`() {
+        assertEquals(true, resolveAdultIsAdult(AdultMode.ONLY, showAdultContent = false))
+        assertEquals(true, resolveAdultIsAdult(AdultMode.ONLY, showAdultContent = true))
+    }
+
+    // ── filterAdultActivities (feed — fixes #53) ─────────────────────────────────────────────────
+
+    private fun activity(id: Int, isAdult: Boolean) =
+        UserActivity(id = id, timestamp = 0L, mediaIsAdult = isAdult)
+
+    @Test
+    fun `feed drops adult list activity when adult content off`() {
+        val feed = listOf(activity(1, isAdult = false), activity(2, isAdult = true))
+        val filtered = feed.filterAdultActivities(showAdultContent = false)
+        assertEquals(listOf(1), filtered.map { it.id })
+    }
+
+    @Test
+    fun `feed keeps adult list activity when adult content on`() {
+        val feed = listOf(activity(1, isAdult = false), activity(2, isAdult = true))
+        val filtered = feed.filterAdultActivities(showAdultContent = true)
+        assertEquals(listOf(1, 2), filtered.map { it.id })
+    }
+
+    // ── Title / staff-name language mapping (6→3 collapse) ───────────────────────────────────────
+
+    @Test
+    fun `stylised title languages collapse to their base`() {
+        assertEquals(TitleLanguage.ROMAJI, AniListTitleLanguage.ROMAJI.toLocalTitleLanguage())
+        assertEquals(TitleLanguage.ROMAJI, AniListTitleLanguage.ROMAJI_STYLISED.toLocalTitleLanguage())
+        assertEquals(TitleLanguage.ENGLISH, AniListTitleLanguage.ENGLISH.toLocalTitleLanguage())
+        assertEquals(TitleLanguage.ENGLISH, AniListTitleLanguage.ENGLISH_STYLISED.toLocalTitleLanguage())
+        assertEquals(TitleLanguage.NATIVE, AniListTitleLanguage.NATIVE.toLocalTitleLanguage())
+        assertEquals(TitleLanguage.NATIVE, AniListTitleLanguage.NATIVE_STYLISED.toLocalTitleLanguage())
+    }
+
+    @Test
+    fun `staff name language maps one to one`() {
+        assertEquals(StaffNameLanguage.ROMAJI_WESTERN, AniListStaffNameLanguage.ROMAJI_WESTERN.toLocalStaffNameLanguage())
+        assertEquals(StaffNameLanguage.ROMAJI, AniListStaffNameLanguage.ROMAJI.toLocalStaffNameLanguage())
+        assertEquals(StaffNameLanguage.NATIVE, AniListStaffNameLanguage.NATIVE.toLocalStaffNameLanguage())
+    }
+
+    // ── Persistence round-trip (per-account cache JSON) ──────────────────────────────────────────
+
+    @Test
+    fun `options survive a json round trip including enum-keyed map`() {
+        val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+        val original = AniListUserOptions(
+            titleLanguage = AniListTitleLanguage.NATIVE_STYLISED,
+            displayAdultContent = true,
+            airingNotifications = false,
+            profileColor = "purple",
+            activityMergeTime = 60,
+            staffNameLanguage = AniListStaffNameLanguage.NATIVE,
+            restrictMessagesToFollowing = true,
+            disabledListActivity = mapOf(
+                AniListListActivityStatus.PLANNING to true,
+                AniListListActivityStatus.COMPLETED to false,
+            ),
+            scoreFormat = ScoreFormat.POINT_5,
+        )
+
+        val restored = json.decodeFromString<AniListUserOptions>(json.encodeToString(original))
+
+        assertEquals(original, restored)
+        assertTrue(restored.disabledListActivity[AniListListActivityStatus.PLANNING] == true)
+    }
+}

--- a/app/src/test/java/com/anisync/android/domain/UserOptionsSyncTest.kt
+++ b/app/src/test/java/com/anisync/android/domain/UserOptionsSyncTest.kt
@@ -1,0 +1,92 @@
+package com.anisync.android.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Covers the pure helpers behind local-first sync: dirty tracking, patch building, and the
+ *  conflict rule (a field is in conflict when it is dirty *and* changed on the server since baseline). */
+class UserOptionsSyncTest {
+
+    private val base = AniListUserOptions(
+        titleLanguage = AniListTitleLanguage.ROMAJI,
+        displayAdultContent = false,
+        scoreFormat = ScoreFormat.POINT_10,
+        activityMergeTime = 0,
+    )
+
+    @Test
+    fun `differingFields finds exactly the changed fields`() {
+        val other = base.copy(displayAdultContent = true, scoreFormat = ScoreFormat.POINT_5)
+        assertEquals(
+            setOf(UserOptionField.DISPLAY_ADULT_CONTENT, UserOptionField.SCORE_FORMAT),
+            base.differingFields(other),
+        )
+    }
+
+    @Test
+    fun `applyPatch applies only the set fields`() {
+        val patched = base.applyPatch(UserOptionsPatch(displayAdultContent = true))
+        assertTrue(patched.displayAdultContent)
+        assertEquals(base.scoreFormat, patched.scoreFormat)
+        assertEquals(base.titleLanguage, patched.titleLanguage)
+    }
+
+    @Test
+    fun `affectedFields reflects the patch's non-null members`() {
+        val patch = UserOptionsPatch(
+            titleLanguage = AniListTitleLanguage.ENGLISH,
+            airingNotifications = false,
+        )
+        assertEquals(
+            setOf(UserOptionField.TITLE_LANGUAGE, UserOptionField.AIRING_NOTIFICATIONS),
+            patch.affectedFields(),
+        )
+    }
+
+    @Test
+    fun `takeFields takes only the requested fields from the source`() {
+        val server = base.copy(displayAdultContent = true, titleLanguage = AniListTitleLanguage.NATIVE)
+        val merged = base.takeFields(setOf(UserOptionField.DISPLAY_ADULT_CONTENT), server)
+        assertTrue(merged.displayAdultContent) // taken from server
+        assertEquals(AniListTitleLanguage.ROMAJI, merged.titleLanguage) // kept from base
+    }
+
+    // The repository's conflict detection is exactly this intersection.
+    private fun conflicts(
+        baseline: AniListUserOptions,
+        fresh: AniListUserOptions,
+        dirty: Set<UserOptionField>,
+    ): Set<UserOptionField> = dirty intersect baseline.differingFields(fresh)
+
+    @Test
+    fun `dirty field also changed on server is a conflict`() {
+        val fresh = base.copy(displayAdultContent = true)
+        val dirty = setOf(UserOptionField.DISPLAY_ADULT_CONTENT)
+        assertEquals(setOf(UserOptionField.DISPLAY_ADULT_CONTENT), conflicts(base, fresh, dirty))
+    }
+
+    @Test
+    fun `dirty field unchanged on server is not a conflict`() {
+        val dirty = setOf(UserOptionField.DISPLAY_ADULT_CONTENT)
+        assertTrue(conflicts(base, fresh = base, dirty = dirty).isEmpty())
+    }
+
+    @Test
+    fun `clean field changed on server is not a conflict`() {
+        val fresh = base.copy(scoreFormat = ScoreFormat.POINT_5) // server changed a field we didn't touch
+        val dirty = setOf(UserOptionField.DISPLAY_ADULT_CONTENT)
+        assertTrue(conflicts(base, fresh, dirty).isEmpty())
+    }
+
+    @Test
+    fun `patchForFields then applyPatch round-trips only selected fields`() {
+        val source = base.copy(scoreFormat = ScoreFormat.POINT_5, airingNotifications = false)
+        val patch = source.patchForFields(setOf(UserOptionField.SCORE_FORMAT))
+        assertEquals(setOf(UserOptionField.SCORE_FORMAT), patch.affectedFields())
+
+        val applied = base.applyPatch(patch)
+        assertEquals(ScoreFormat.POINT_5, applied.scoreFormat) // selected → taken
+        assertEquals(base.airingNotifications, applied.airingNotifications) // unselected → unchanged
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBomStable" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }


### PR DESCRIPTION
## Summary

Reworks AniList user-options support end to end. AniList account options were barely wired into the app: `displayAdultContent` was never queried, the activity feed never filtered adult media, and the search "show adult content" toggle was inert.

**Fixes #53** (NSFW blocked on the account still showing in the activity feed), plus the dead search toggle, and adds a full options surface with background sync.

## What's included
- **Respect account options** — query the full `UserOptions` via `GetViewer`; mirror behaviour-affecting values into local settings. Feed drops adult `ListActivity` and search floors `isAdult` off the effective preference.
- **AniList Settings screen** — merged account management (add / switch / remove / logout) with editable account options (adult content, title & staff-name language, score format, airing notifications, message restriction, activity merge time, list-activity, profile color). Pushes via `UpdateUser`.
- **Local-first sync** — edits apply instantly (optimistic) and coalesce into a pending patch flushed in the background (debounce + app-background + a WorkManager safety net). One `UpdateUser` for N toggles; offline edits survive.
- **Conflict handling** — when a field changed both on device and on the website, an app-wide dialog lets the user keep the device's values or adopt the website's; spells out each side's value per field.
- **Polish** — "Open in web" opens a real browser (not the app) via `<queries>` + explicit browser targeting; title language simplified to 3 options with examples; Donate + Translate top-bar shortcuts on the main Settings screen; Sponsors screen reworked into "Donate" ("buy me a coffee"); red logout icon; wrapping profile-color grid.

## Testing
- `./gradlew :app:assembleStableDebug` + `:app:testStableDebugUnitTest` (new unit tests for the search floor, feed filter, language mappings, conflict/patch helpers).
- Device-verified on a real account: feed/search adult gating, pull + mirror, optimistic edits, WorkManager flush (`SUCCESS`), the Donate/Translate shortcuts, profile-color grid, and the conflict prompt.