### PR TITLE
feat: AMOLED theme + CineMatch-style Settings redesign

### DIFF
--- a/app/src/main/java/com/anisync/android/MainActivity.kt
+++ b/app/src/main/java/com/anisync/android/MainActivity.kt
@@ -169,6 +169,7 @@ class MainActivity : AppCompatActivity() {
 
             setContent {
                 val themeMode by appSettings.themeMode.collectAsStateWithLifecycle(initialValue = ThemeMode.SYSTEM)
+                val amoledEnabled by appSettings.amoledEnabled.collectAsStateWithLifecycle(initialValue = false)
                 val selectedPaletteId by appSettings.selectedPaletteId.collectAsStateWithLifecycle(
                     initialValue = "dynamic"
                 )
@@ -227,6 +228,7 @@ class MainActivity : AppCompatActivity() {
                     AppTheme(
                         darkTheme = useDarkTheme,
                         dynamicColor = useDynamicColor,
+                        amoled = amoledEnabled,
                         seedColor = seedColor,
                         paletteStyle = paletteStyle,
                         typographyOverrides = typographyOverrides

--- a/app/src/main/java/com/anisync/android/data/AppSettings.kt
+++ b/app/src/main/java/com/anisync/android/data/AppSettings.kt
@@ -137,6 +137,11 @@ class AppSettings @Inject constructor(
     )
     val themeMode: StateFlow<ThemeMode> = _themeMode.asStateFlow()
 
+    // AMOLED ("pure black") dark theme. Only takes effect while the dark theme is active; it forces
+    // background/surface to true black to save power on OLED panels. Device-local; default off.
+    private val _amoledEnabled = MutableStateFlow(prefs.getBoolean(KEY_AMOLED_ENABLED, false))
+    val amoledEnabled: StateFlow<Boolean> = _amoledEnabled.asStateFlow()
+
     // Avatar shape setting
     private val _avatarShape = MutableStateFlow(readAvatarShape())
     val avatarShape: StateFlow<AvatarShape> = _avatarShape.asStateFlow()
@@ -514,6 +519,12 @@ class AppSettings @Inject constructor(
     fun setThemeMode(mode: ThemeMode) {
         _themeMode.value = mode
         prefs.edit().putInt(KEY_THEME_MODE, mode.ordinal).apply()
+    }
+
+    /** Enable or disable the AMOLED ("pure black") dark theme. */
+    fun setAmoledEnabled(enabled: Boolean) {
+        _amoledEnabled.value = enabled
+        prefs.edit().putBoolean(KEY_AMOLED_ENABLED, enabled).apply()
     }
 
     fun setAvatarShape(shape: AvatarShape) {
@@ -909,6 +920,7 @@ class AppSettings @Inject constructor(
 companion object {
         private const val PREFS_NAME = "anisync_settings"
         private const val KEY_THEME_MODE = "theme_mode"
+        private const val KEY_AMOLED_ENABLED = "amoled_enabled"
         private const val KEY_AVATAR_SHAPE = "avatar_shape"
         private const val KEY_HAPTIC_ENABLED = "haptic_enabled"
         private const val KEY_NAV_BAR_STYLE = "nav_bar_style"

--- a/app/src/main/java/com/anisync/android/presentation/navigation/NavHost.kt
+++ b/app/src/main/java/com/anisync/android/presentation/navigation/NavHost.kt
@@ -57,6 +57,7 @@ import com.anisync.android.presentation.settings.AcknowledgmentsScreen
 import com.anisync.android.presentation.settings.AniListSettingsScreen
 import com.anisync.android.presentation.settings.DeveloperToolsScreen
 import com.anisync.android.presentation.settings.FontSettingsScreen
+import com.anisync.android.presentation.settings.LanguageScreen
 import com.anisync.android.presentation.settings.LinksScreen
 import com.anisync.android.presentation.settings.LookAndFeelScreen
 import com.anisync.android.presentation.settings.MediaUploadSettingsScreen
@@ -65,6 +66,7 @@ import com.anisync.android.presentation.settings.OpenSourceLicensesScreen
 import com.anisync.android.presentation.settings.SettingsScreen
 import com.anisync.android.presentation.settings.SponsorsScreen
 import com.anisync.android.presentation.settings.StorageScreen
+import com.anisync.android.presentation.settings.ThemeScreen
 import com.anisync.android.presentation.settings.UpdatesScreen
 import com.anisync.android.presentation.util.AniLinkCallbacks
 import com.anisync.android.presentation.util.LocalAniLinkCallbacks
@@ -1215,6 +1217,32 @@ fun AniSyncNavHost(
                 popExitTransition = { sharedAxisZPopExit() }
             ) {
                 LookAndFeelScreen(
+                    onBackClick = { navController.popBackStack() },
+                    onNavigateToTheme = { navController.navigate(SettingsTheme) },
+                    onNavigateToLanguage = { navController.navigate(SettingsLanguage) }
+                )
+            }
+
+            // Theme picker (light/dark/system + AMOLED)
+            composable<SettingsTheme>(
+                enterTransition = { sharedAxisZEnter() },
+                exitTransition = { sharedAxisZExit() },
+                popEnterTransition = { sharedAxisZPopEnter() },
+                popExitTransition = { sharedAxisZPopExit() }
+            ) {
+                ThemeScreen(
+                    onBackClick = { navController.popBackStack() }
+                )
+            }
+
+            // App language picker
+            composable<SettingsLanguage>(
+                enterTransition = { sharedAxisZEnter() },
+                exitTransition = { sharedAxisZExit() },
+                popEnterTransition = { sharedAxisZPopEnter() },
+                popExitTransition = { sharedAxisZPopExit() }
+            ) {
+                LanguageScreen(
                     onBackClick = { navController.popBackStack() }
                 )
             }

--- a/app/src/main/java/com/anisync/android/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/navigation/Screen.kt
@@ -295,6 +295,18 @@ object Settings
 object SettingsLookAndFeel
 
 /**
+ * Theme picker subscreen — light/dark/system mode + AMOLED pure-black toggle.
+ */
+@Serializable
+object SettingsTheme
+
+/**
+ * App language picker subscreen.
+ */
+@Serializable
+object SettingsLanguage
+
+/**
  * AniList settings: account management (add / switch / remove / logout) merged with the AniList
  * account options (adult content, languages, score format, activity, profile color).
  */

--- a/app/src/main/java/com/anisync/android/presentation/settings/AcknowledgmentsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AcknowledgmentsScreen.kt
@@ -2,7 +2,6 @@ package com.anisync.android.presentation.settings
 
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -66,8 +65,7 @@ fun AcknowledgmentsScreen(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        SectionHeader(stringResource(R.string.acknowledgments_section_data))
-        Spacer(modifier = Modifier.height(8.dp))
+        SettingsSectionLabel(stringResource(R.string.acknowledgments_section_data))
         SettingsGroup {
             dataProviders.forEach { item ->
                 SettingsItem(
@@ -80,8 +78,7 @@ fun AcknowledgmentsScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        SectionHeader(stringResource(R.string.acknowledgments_section_community))
-        Spacer(modifier = Modifier.height(8.dp))
+        SettingsSectionLabel(stringResource(R.string.acknowledgments_section_community))
         SettingsGroup {
             community.forEach { item ->
                 SettingsItem(
@@ -94,14 +91,4 @@ fun AcknowledgmentsScreen(
 
         Spacer(modifier = Modifier.height(24.dp))
     }
-}
-
-@Composable
-private fun SectionHeader(text: String) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.labelLarge,
-        color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier.padding(horizontal = 4.dp)
-    )
 }

--- a/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/AniListOptionsScreen.kt
@@ -16,8 +16,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -38,7 +36,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.anisync.android.data.StaffNameLanguage
 import com.anisync.android.data.TitleLanguage
@@ -46,6 +43,7 @@ import com.anisync.android.domain.AniListListActivityStatus
 import com.anisync.android.domain.AniListStaffNameLanguage
 import com.anisync.android.domain.AniListTitleLanguage
 import com.anisync.android.domain.ScoreFormat
+import com.anisync.android.presentation.settings.components.SettingsPickerSheet
 import com.anisync.android.ui.theme.AniListProfileColors
 
 /**
@@ -113,7 +111,6 @@ internal fun AniListOptionsContent(
                 },
                 onDismiss = { showStaffSheet = false },
             )
-
         }
 
         var showScoreSheet by remember { mutableStateOf(false) }
@@ -224,17 +221,14 @@ private fun SectionHeader(text: String) {
 }
 
 @Composable
-internal fun SectionLabel(text: String) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.titleSmall,
-        fontWeight = FontWeight.SemiBold,
-        color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier.padding(start = 8.dp, top = 12.dp, bottom = 2.dp),
-    )
-}
+internal fun SectionLabel(text: String) = SettingsSectionLabel(text)
 
-@OptIn(ExperimentalMaterial3Api::class)
+// ── Pickers (bottom sheets) ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Thin adapter onto the shared [SettingsPickerSheet] so this screen's plain-string pickers read the
+ * same as every other picker in Settings. These are quick choices, so they stay as bottom sheets.
+ */
 @Composable
 private fun <T> OptionPickerSheet(
     title: String,
@@ -245,64 +239,15 @@ private fun <T> OptionPickerSheet(
     onDismiss: () -> Unit,
     subtitle: (T) -> String? = { null },
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-        dragHandle = { BottomSheetDefaults.DragHandle() },
-    ) {
-        Column(modifier = Modifier.fillMaxWidth().padding(bottom = 32.dp)) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.headlineSmall,
-                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
-            )
-            Spacer(Modifier.height(8.dp))
-            LazyColumn(contentPadding = PaddingValues(horizontal = 16.dp)) {
-                items(options) { option ->
-                    val isSelected = option == selected
-                    val sub = subtitle(option)
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(16.dp))
-                            .clickable { onSelect(option) }
-                            .background(
-                                if (isSelected) MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f)
-                                else Color.Transparent
-                            )
-                            .padding(vertical = 16.dp, horizontal = 20.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = label(option),
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = if (isSelected) MaterialTheme.colorScheme.onSecondaryContainer
-                                else MaterialTheme.colorScheme.onSurface,
-                            )
-                            if (sub != null) {
-                                Text(
-                                    text = sub,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = if (isSelected) MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.8f)
-                                    else MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                            }
-                        }
-                        if (isSelected) {
-                            Icon(
-                                imageVector = Icons.Default.Check,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary,
-                            )
-                        }
-                    }
-                }
-            }
-        }
-    }
+    SettingsPickerSheet(
+        title = title,
+        items = options,
+        selected = selected,
+        itemLabel = { label(it) },
+        itemSubtitle = { subtitle(it) },
+        onSelect = onSelect,
+        onDismiss = onDismiss,
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)

--- a/app/src/main/java/com/anisync/android/presentation/settings/LanguageScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/LanguageScreen.kt
@@ -1,0 +1,43 @@
+package com.anisync.android.presentation.settings
+
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.anisync.android.R
+import com.anisync.android.data.AppLocale
+
+/**
+ * App language picker subscreen — a radio list of [AppLocale]s. Selecting one applies the locale
+ * immediately via the view model (which also drives AppCompatDelegate).
+ */
+@Composable
+fun LanguageScreen(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    SettingsScreenScaffold(
+        title = stringResource(R.string.settings_app_language),
+        onBackClick = onBackClick,
+        modifier = modifier
+    ) {
+        SettingsGroup(modifier = Modifier.selectableGroup()) {
+            AppLocale.entries.forEach { locale ->
+                RadioSettingsItem(
+                    title = locale.displayName,
+                    subtitle = if (locale == AppLocale.SYSTEM) {
+                        stringResource(R.string.settings_app_language_system_desc)
+                    } else null,
+                    selected = uiState.appLocale == locale,
+                    onClick = { viewModel.onAction(SettingsAction.SetAppLocale(locale)) }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/anisync/android/presentation/settings/LookAndFeelScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/LookAndFeelScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Label
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Contrast
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.Face
 import androidx.compose.material.icons.filled.HighQuality
@@ -113,6 +114,7 @@ fun LookAndFeelScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val themeMode = uiState.themeMode
+    val amoledEnabled = uiState.amoledEnabled
     val preferredStreamingService = uiState.preferredStreamingService
     val hapticEnabled = uiState.hapticEnabled
     val appLocale = uiState.appLocale
@@ -285,6 +287,7 @@ fun LookAndFeelScreen(
                 seedColor = seedColor,
                 isDarkMode = isDarkMode,
                 paletteStyle = paletteStyle,
+                amoled = amoledEnabled,
                 modifier = Modifier.padding(vertical = 16.dp)
             )
         }
@@ -351,6 +354,14 @@ fun LookAndFeelScreen(
                     ThemeMode.SYSTEM -> stringResource(R.string.theme_system)
                 },
                 onClick = { showThemeModeDialog = true }
+            )
+            SettingsDivider()
+            SwitchSettingsItem(
+                icon = Icons.Default.Contrast,
+                title = stringResource(R.string.setting_amoled),
+                subtitle = stringResource(R.string.setting_amoled_desc),
+                checked = amoledEnabled,
+                onCheckedChange = { viewModel.onAction(SettingsAction.SetAmoledEnabled(it)) }
             )
         }
 

--- a/app/src/main/java/com/anisync/android/presentation/settings/LookAndFeelScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/LookAndFeelScreen.kt
@@ -1,6 +1,5 @@
 package com.anisync.android.presentation.settings
 
-import android.os.Build
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -18,7 +17,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -27,21 +25,15 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Label
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Contrast
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.Face
 import androidx.compose.material.icons.filled.HighQuality
-import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Navigation
-import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.PlayCircle
 import androidx.compose.material.icons.filled.RoundedCorner
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material.icons.filled.Vibration
 import androidx.compose.material.icons.filled.VideoLibrary
-import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.outlined.DynamicFeed
 import androidx.compose.material.icons.outlined.Explore
 import androidx.compose.material.icons.outlined.Forum
@@ -54,17 +46,13 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -79,29 +67,17 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.anisync.android.R
-import com.anisync.android.data.AppLocale
 import com.anisync.android.data.AppSettings
 import com.anisync.android.data.CoverQuality
 import com.anisync.android.data.NavBarStyle
 import com.anisync.android.data.StreamingService
 import com.anisync.android.data.ThemeMode
-import com.anisync.android.data.TitleLanguage
-import com.anisync.android.presentation.settings.components.ColorPickerSheet
-import com.anisync.android.presentation.settings.components.ColorSchemeSelector
-import com.anisync.android.presentation.settings.components.PaletteStyleSelector
-import com.anisync.android.presentation.settings.components.PhonePreview
-import com.anisync.android.ui.theme.PresetPalettes
-import com.anisync.android.ui.theme.ThemePalette
 
-private val TitleLanguages = TitleLanguage.entries
 private val StreamingServices = StreamingService.entries
-private val ThemeModes = ThemeMode.entries
-private val AppLocales = AppLocale.entries
 private val CoverQualities = CoverQuality.entries
 private val NavBarStyles = NavBarStyle.entries
 private val AvatarShapes = com.anisync.android.data.AvatarShape.entries
@@ -109,12 +85,13 @@ private val AvatarShapes = com.anisync.android.data.AvatarShape.entries
 @Composable
 fun LookAndFeelScreen(
     onBackClick: () -> Unit,
+    onNavigateToTheme: () -> Unit,
+    onNavigateToLanguage: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val themeMode = uiState.themeMode
-    val amoledEnabled = uiState.amoledEnabled
     val preferredStreamingService = uiState.preferredStreamingService
     val hapticEnabled = uiState.hapticEnabled
     val appLocale = uiState.appLocale
@@ -124,16 +101,7 @@ fun LookAndFeelScreen(
     val navBarCornerRadius = uiState.navBarCornerRadius
     val avatarShape = uiState.avatarShape
     val avatarBackgroundEnabled = uiState.avatarBackgroundEnabled
-    val disableAvatarShapeProfile = uiState.disableAvatarShapeProfile
-    val respectUserProfileColors = uiState.respectUserProfileColors
 
-    val selectedPaletteId = uiState.selectedPaletteId
-    val customSeedColor = uiState.customSeedColor
-    val paletteStyle = uiState.paletteStyle
-
-    var showColorPicker by rememberSaveable { mutableStateOf(false) }
-    var showThemeModeDialog by rememberSaveable { mutableStateOf(false) }
-    var showAppLanguageSheet by rememberSaveable { mutableStateOf(false) }
     var showStreamingServiceSheet by rememberSaveable { mutableStateOf(false) }
     var showCoverQualitySheet by rememberSaveable { mutableStateOf(false) }
     var showNavBarStyleSheet by rememberSaveable { mutableStateOf(false) }
@@ -148,48 +116,6 @@ fun LookAndFeelScreen(
         }
     }
 
-    val supportseDynamicColor = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-    val palettes = remember(customSeedColor, supportseDynamicColor) {
-        val presets = if (supportseDynamicColor) {
-            PresetPalettes.all
-        } else {
-            PresetPalettes.all.filter { !it.isDynamic }
-        }
-        if (customSeedColor != null) {
-            listOf(ThemePalette("custom", "Custom", customSeedColor!!)) + presets
-        } else {
-            presets
-        }
-    }
-
-    LaunchedEffect(selectedPaletteId, palettes, uiState.isLoaded) {
-        if (uiState.isLoaded && palettes.none { it.id == selectedPaletteId }) {
-            viewModel.onAction(SettingsAction.SetSelectedPalette(palettes.firstOrNull()?.id ?: "dynamic"))
-        }
-    }
-
-    val onColorSelected = remember(viewModel) {
-        { color: Color ->
-            viewModel.onAction(SettingsAction.SetCustomSeedColor(color))
-            viewModel.onAction(SettingsAction.SetSelectedPalette("custom"))
-        }
-    }
-    val onPaletteSelected = remember(viewModel) {
-        { palette: ThemePalette -> viewModel.onAction(SettingsAction.SetSelectedPalette(palette.id)) }
-    }
-    val onStyleSelected = remember(viewModel) {
-        { style: com.materialkolor.PaletteStyle -> viewModel.onAction(SettingsAction.SetPaletteStyle(style)) }
-    }
-
-    if (showColorPicker) {
-        ColorPickerSheet(
-            currentColor = customSeedColor,
-            onColorSelected = onColorSelected,
-            onDismiss = { showColorPicker = false }
-        )
-    }
-
-
     if (showStreamingServiceSheet) {
         StreamingServiceSelectionSheet(
             currentService = preferredStreamingService,
@@ -198,28 +124,6 @@ fun LookAndFeelScreen(
                 showStreamingServiceSheet = false
             },
             onDismiss = { showStreamingServiceSheet = false }
-        )
-    }
-
-    if (showThemeModeDialog) {
-        ThemeModeSelectionDialog(
-            currentMode = themeMode,
-            onModeSelected = {
-                viewModel.onAction(SettingsAction.SetThemeMode(it))
-                showThemeModeDialog = false
-            },
-            onDismiss = { showThemeModeDialog = false }
-        )
-    }
-
-    if (showAppLanguageSheet) {
-        AppLanguageSelectionSheet(
-            currentLocale = appLocale,
-            onLocaleSelected = {
-                viewModel.onAction(SettingsAction.SetAppLocale(it))
-                showAppLanguageSheet = false
-            },
-            onDismiss = { showAppLanguageSheet = false }
         )
     }
 
@@ -270,111 +174,36 @@ fun LookAndFeelScreen(
         onBackClick = onBackClick,
         modifier = modifier
     ) {
-        Text(
-            text = stringResource(R.string.preview),
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-        )
-
-        val selectedPalette = remember(palettes, selectedPaletteId) {
-            palettes.find { it.id == selectedPaletteId }
-        }
-        val seedColor = if (selectedPalette?.isDynamic == true) null else selectedPalette?.seedColor
-
-        if (uiState.isLoaded) {
-            PhonePreview(
-                seedColor = seedColor,
-                isDarkMode = isDarkMode,
-                paletteStyle = paletteStyle,
-                amoled = amoledEnabled,
-                modifier = Modifier.padding(vertical = 16.dp)
-            )
-        }
-
-        Spacer(modifier = Modifier.height(24.dp))
-
-        Text(
-            text = stringResource(R.string.color_scheme),
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-        )
-
-        ColorSchemeSelector(
-            palettes = palettes,
-            selectedPaletteId = selectedPaletteId,
-            isDarkMode = isDarkMode,
-            paletteStyle = paletteStyle,
-            onPaletteSelected = onPaletteSelected
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            OutlinedButton(
-                onClick = { showColorPicker = true },
-                modifier = Modifier.weight(1f)
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Palette,
-                    contentDescription = stringResource(R.string.custom_color),
-                    modifier = Modifier.size(18.dp)
-                )
-                Spacer(Modifier.width(8.dp))
-                Text(stringResource(R.string.custom_color))
-            }
-        }
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        PaletteStyleSelector(
-            selectedStyle = paletteStyle,
-            onStyleSelected = onStyleSelected,
-            enabled = selectedPaletteId != "dynamic",
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-        )
-
-        Spacer(modifier = Modifier.height(24.dp))
-
+        // "Dark mode" opens the Theme subscreen (preview, color scheme, mode, AMOLED, profile
+        // colors) and quick-toggles dark on/off via the trailing switch. App language also opens a
+        // subscreen (chevron). The rest are quick choices that open bottom sheets — no chevron.
         SettingsGroup {
-            SelectionSettingsItem(
+            SplitToggleSettingsItem(
                 icon = Icons.Default.DarkMode,
-                title = stringResource(R.string.setting_theme),
-                currentValue = when (themeMode) {
+                title = stringResource(R.string.dark_mode),
+                subtitle = when (themeMode) {
                     ThemeMode.LIGHT -> stringResource(R.string.theme_light)
                     ThemeMode.DARK -> stringResource(R.string.theme_dark)
                     ThemeMode.SYSTEM -> stringResource(R.string.theme_system)
                 },
-                onClick = { showThemeModeDialog = true }
-            )
-            SettingsDivider()
-            SwitchSettingsItem(
-                icon = Icons.Default.Contrast,
-                title = stringResource(R.string.setting_amoled),
-                subtitle = stringResource(R.string.setting_amoled_desc),
-                checked = amoledEnabled,
-                onCheckedChange = { viewModel.onAction(SettingsAction.SetAmoledEnabled(it)) }
+                checked = isDarkMode,
+                onCheckedChange = { dark ->
+                    viewModel.onAction(
+                        SettingsAction.SetThemeMode(if (dark) ThemeMode.DARK else ThemeMode.LIGHT)
+                    )
+                },
+                onClick = onNavigateToTheme
             )
         }
-
-        Spacer(modifier = Modifier.height(16.dp))
 
         SettingsGroup {
             SelectionSettingsItem(
                 icon = Icons.Default.Translate,
                 title = stringResource(R.string.settings_app_language),
                 currentValue = appLocale.displayName,
-                onClick = { showAppLanguageSheet = true }
+                onClick = onNavigateToLanguage,
+                showArrow = true
             )
-            SettingsDivider()
             SelectionSettingsItem(
                 icon = Icons.Default.HighQuality,
                 title = stringResource(R.string.settings_cover_quality),
@@ -383,8 +212,6 @@ fun LookAndFeelScreen(
             )
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
-
         SettingsGroup {
             SelectionSettingsItem(
                 icon = Icons.Default.Navigation,
@@ -392,11 +219,6 @@ fun LookAndFeelScreen(
                 currentValue = navBarStyleLabel(navBarStyle),
                 onClick = { showNavBarStyleSheet = true }
             )
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        SettingsGroup {
             SelectionSettingsItem(
                 icon = Icons.Default.Face,
                 title = stringResource(R.string.setting_avatar_shape),
@@ -405,22 +227,6 @@ fun LookAndFeelScreen(
             )
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
-
-        SettingsGroup {
-            SwitchSettingsItem(
-                icon = Icons.Default.Palette,
-                title = stringResource(R.string.setting_respect_profile_colors),
-                subtitle = stringResource(R.string.setting_respect_profile_colors_desc),
-                checked = respectUserProfileColors,
-                onCheckedChange = {
-                    viewModel.onAction(SettingsAction.SetRespectUserProfileColors(it))
-                }
-            )
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
         SettingsGroup {
             SelectionSettingsItem(
                 icon = Icons.Default.PlayCircle,
@@ -428,7 +234,6 @@ fun LookAndFeelScreen(
                 currentValue = preferredStreamingService.displayName,
                 onClick = { showStreamingServiceSheet = true }
             )
-            SettingsDivider()
             SwitchSettingsItem(
                 icon = Icons.Default.Vibration,
                 title = stringResource(R.string.setting_haptic_feedback),
@@ -437,160 +242,6 @@ fun LookAndFeelScreen(
             )
             // "Show adult content" now lives under Settings ▸ AniList Account, where it follows the
             // AniList account option by default and can be overridden per device.
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun TitleLanguageSelectionSheet(
-    currentLanguage: TitleLanguage,
-    onLanguageSelected: (TitleLanguage) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-        dragHandle = { BottomSheetDefaults.DragHandle() }
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 32.dp)
-        ) {
-            Text(
-                text = stringResource(R.string.settings_title_language),
-                style = MaterialTheme.typography.headlineMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            LazyColumn(
-                contentPadding = PaddingValues(horizontal = 16.dp),
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                items(
-                    items = TitleLanguages,
-                    key = { it.name },
-                ) { language ->
-                    val isSelected = currentLanguage == language
-
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(16.dp))
-                            .clickable { onLanguageSelected(language) }
-                            .background(if (isSelected) MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f) else Color.Transparent)
-                            .padding(vertical = 16.dp, horizontal = 20.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = getTitleLanguageLabel(language),
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = if (isSelected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface,
-                            )
-                            Text(
-                                text = getTitleLanguageExample(language),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = if (isSelected) MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.8f) else MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-
-                        if (isSelected) {
-                            Spacer(Modifier.width(16.dp))
-                            Icon(
-                                imageVector = Icons.Default.Check,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary
-                            )
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun AppLanguageSelectionSheet(
-    currentLocale: AppLocale,
-    onLocaleSelected: (AppLocale) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-        dragHandle = { BottomSheetDefaults.DragHandle() }
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 32.dp)
-        ) {
-            Text(
-                text = stringResource(R.string.settings_app_language),
-                style = MaterialTheme.typography.headlineMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            LazyColumn(
-                contentPadding = PaddingValues(horizontal = 16.dp),
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                items(
-                    items = AppLocales,
-                    key = { it.name },
-                ) { locale ->
-                    val isSelected = currentLocale == locale
-
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(16.dp))
-                            .clickable { onLocaleSelected(locale) }
-                            .background(if (isSelected) MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f) else Color.Transparent)
-                            .padding(vertical = 16.dp, horizontal = 20.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = locale.displayName,
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = if (isSelected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface,
-                            )
-                            if (locale == AppLocale.SYSTEM) {
-                                Text(
-                                    text = stringResource(R.string.settings_app_language_system_desc),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = if (isSelected) MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.8f) else MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                            }
-                        }
-
-                        if (isSelected) {
-                            Spacer(Modifier.width(16.dp))
-                            Icon(
-                                imageVector = Icons.Default.Check,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary
-                            )
-                        }
-                    }
-                }
-            }
         }
     }
 }
@@ -736,7 +387,7 @@ fun CoverQualitySelectionSheet(
             Spacer(modifier = Modifier.height(24.dp))
 
             // Central Fixed-Size Preview Image
-            val imageUrl = when(currentQuality) {
+            val imageUrl = when (currentQuality) {
                 CoverQuality.MEDIUM -> "https://s4.anilist.co/file/anilistcdn/media/anime/cover/small/bx105333-GybuoSoOZfpH.jpg"
                 CoverQuality.LARGE -> "https://s4.anilist.co/file/anilistcdn/media/anime/cover/medium/bx105333-GybuoSoOZfpH.jpg"
                 CoverQuality.EXTRA_LARGE -> "https://s4.anilist.co/file/anilistcdn/media/anime/cover/large/bx105333-GybuoSoOZfpH.jpg"
@@ -819,110 +470,8 @@ private fun rememberBrandColors(): Map<StreamingService, Color?> {
 }
 
 // -----------------------------------------------------------------------------------------
-// Original Dialogs (Theme Mode)
-// -----------------------------------------------------------------------------------------
-
-@Composable
-fun ThemeModeSelectionDialog(
-    currentMode: ThemeMode,
-    onModeSelected: (ThemeMode) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    Dialog(onDismissRequest = onDismiss) {
-        Card(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            shape = RoundedCornerShape(28.dp),
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-            ),
-        ) {
-            LazyColumn(
-                modifier = Modifier.padding(24.dp),
-                horizontalAlignment = Alignment.Start,
-            ) {
-                item {
-                    Text(
-                        text = stringResource(R.string.theme_mode_dialog_title),
-                        style = MaterialTheme.typography.headlineSmall,
-                        color = MaterialTheme.colorScheme.onSurface,
-                    )
-
-                    Spacer(modifier = Modifier.height(16.dp))
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-                    Spacer(modifier = Modifier.height(16.dp))
-                }
-
-                items(
-                    items = ThemeModes,
-                    key = { it.name },
-                ) { mode ->
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
-                            .clickable { onModeSelected(mode) }
-                            .padding(vertical = 12.dp, horizontal = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        RadioButton(
-                            selected = currentMode == mode,
-                            onClick = { onModeSelected(mode) },
-                        )
-                        Spacer(Modifier.width(12.dp))
-                        Text(
-                            text = when (mode) {
-                                ThemeMode.LIGHT -> stringResource(R.string.theme_light)
-                                ThemeMode.DARK -> stringResource(R.string.theme_dark)
-                                ThemeMode.SYSTEM -> stringResource(R.string.theme_system)
-                            },
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        )
-                    }
-                }
-
-                item {
-                    Spacer(modifier = Modifier.height(24.dp))
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-                    Spacer(modifier = Modifier.height(16.dp))
-
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.End,
-                    ) {
-                        TextButton(onClick = onDismiss) {
-                            Text(stringResource(R.string.cancel))
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-// -----------------------------------------------------------------------------------------
 // Helper Components
 // -----------------------------------------------------------------------------------------
-
-@Composable
-private fun getTitleLanguageLabel(language: TitleLanguage): String {
-    return when (language) {
-        TitleLanguage.ROMAJI -> stringResource(R.string.title_language_romaji)
-        TitleLanguage.ENGLISH -> stringResource(R.string.title_language_english)
-        TitleLanguage.NATIVE -> stringResource(R.string.title_language_native)
-    }
-}
-
-@Composable
-private fun getTitleLanguageExample(language: TitleLanguage): String {
-    return when (language) {
-        TitleLanguage.ROMAJI -> stringResource(R.string.title_language_romaji_example)
-        TitleLanguage.ENGLISH -> stringResource(R.string.title_language_english_example)
-        TitleLanguage.NATIVE -> stringResource(R.string.title_language_native_example)
-    }
-}
 
 @Composable
 private fun coverQualityLabel(quality: CoverQuality): String = stringResource(
@@ -1158,7 +707,8 @@ fun NavBarStyleSelectionSheet(
                         Spacer(Modifier.width(16.dp))
                         Switch(
                             checked = showLabels,
-                            onCheckedChange = onShowLabelsChange
+                            onCheckedChange = onShowLabelsChange,
+                            colors = appSwitchColors()
                         )
                     }
 
@@ -1342,7 +892,8 @@ fun AvatarShapeSelectionSheet(
                     Spacer(Modifier.width(16.dp))
                     Switch(
                         checked = frameEnabled,
-                        onCheckedChange = onFrameEnabledChange
+                        onCheckedChange = onFrameEnabledChange,
+                        colors = appSwitchColors()
                     )
                 }
             }

--- a/app/src/main/java/com/anisync/android/presentation/settings/NotificationsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/NotificationsScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -145,11 +144,13 @@ fun NotificationsScreen(
         }
 
         SettingsGroup {
-            Surface(
-                color = MaterialTheme.colorScheme.surfaceContainer,
-                shape = RoundedCornerShape(10.dp),
-                modifier = Modifier.fillMaxWidth().clickable {
-                    if (!isNotificationsEnabled) {
+            SwitchSettingsItem(
+                icon = Icons.Default.Notifications,
+                title = stringResource(R.string.settings_allow_notifications),
+                subtitle = stringResource(R.string.settings_allow_notifications_desc),
+                checked = isNotificationsEnabled,
+                onCheckedChange = { enabled ->
+                    if (enabled) {
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                             permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                         } else {
@@ -159,60 +160,13 @@ fun NotificationsScreen(
                         viewModel.onAction(SettingsAction.ToggleNotifications(false))
                     }
                 }
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(20.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Row(
-                        modifier = Modifier.weight(1f),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            Icons.Default.Notifications,
-                            contentDescription = stringResource(R.string.control_notifications),
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                        Spacer(Modifier.width(16.dp))
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                stringResource(R.string.settings_allow_notifications),
-                                style = MaterialTheme.typography.titleMedium
-                            )
-                            Text(
-                                stringResource(R.string.settings_allow_notifications_desc),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    }
-                    Switch(
-                        checked = isNotificationsEnabled,
-                        onCheckedChange = { enabled ->
-                            if (enabled) {
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                                    permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-                                } else {
-                                    viewModel.onAction(SettingsAction.ToggleNotifications(true))
-                                }
-                            } else {
-                                viewModel.onAction(SettingsAction.ToggleNotifications(false))
-                            }
-                        }
-                    )
-                }
-            }
+            )
         }
 
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Spacer(modifier = Modifier.height(8.dp))
 
-            NotificationGroupHeader(
-                title = stringResource(R.string.notification_group_airing)
-            )
+            SettingsSectionLabel(stringResource(R.string.notification_group_airing))
 
             SettingsGroup {
                 SwitchSettingsItem(
@@ -254,9 +208,7 @@ fun NotificationsScreen(
 
             Spacer(modifier = Modifier.height(8.dp))
 
-            NotificationGroupHeader(
-                title = stringResource(R.string.notification_group_forum)
-            )
+            SettingsSectionLabel(stringResource(R.string.notification_group_forum))
 
             SettingsGroup {
                 SwitchSettingsItem(
@@ -302,9 +254,7 @@ fun NotificationsScreen(
 
             Spacer(modifier = Modifier.height(8.dp))
 
-            NotificationGroupHeader(
-                title = stringResource(R.string.notification_group_activity)
-            )
+            SettingsSectionLabel(stringResource(R.string.notification_group_activity))
 
             SettingsGroup {
                 SwitchSettingsItem(
@@ -341,19 +291,6 @@ fun NotificationsScreen(
             }
         }
     }
-}
-
-@Composable
-private fun NotificationGroupHeader(
-    title: String,
-    modifier: Modifier = Modifier
-) {
-    Text(
-        text = title,
-        style = MaterialTheme.typography.labelLarge,
-        color = MaterialTheme.colorScheme.primary,
-        modifier = modifier.padding(horizontal = 20.dp, vertical = 4.dp)
-    )
 }
 
 @Composable

--- a/app/src/main/java/com/anisync/android/presentation/settings/SettingsComponents.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/SettingsComponents.kt
@@ -16,15 +16,22 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchColors
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -32,7 +39,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.anisync.android.presentation.components.CollapsingTopBarScaffold
@@ -80,6 +86,23 @@ fun SettingsScreenScaffold(
             }
         }
     }
+}
+
+/**
+ * Small section label shown above a [SettingsGroup] or a bespoke control block. Kept subtle
+ * (labelLarge / primary) so groups still carry the visual weight.
+ */
+@Composable
+fun SettingsSectionLabel(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = modifier.padding(horizontal = 4.dp, vertical = 4.dp)
+    )
 }
 
 /**
@@ -161,6 +184,19 @@ fun SettingsItem(
 }
 
 /**
+ * Shared switch palette so every toggle in Settings reads the same: primary track when on, a muted
+ * container track with an outlined thumb when off.
+ */
+@Composable
+fun appSwitchColors(): SwitchColors = SwitchDefaults.colors(
+    checkedThumbColor = MaterialTheme.colorScheme.onPrimary,
+    checkedTrackColor = MaterialTheme.colorScheme.primary,
+    uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+    uncheckedTrackColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+    uncheckedBorderColor = MaterialTheme.colorScheme.outline,
+)
+
+/**
  * A settings item with a trailing switch toggle.
  */
 @Composable
@@ -184,10 +220,82 @@ fun SwitchSettingsItem(
             Switch(
                 checked = checked,
                 onCheckedChange = onCheckedChange,
-                enabled = enabled
+                enabled = enabled,
+                colors = appSwitchColors()
             )
         }
     )
+}
+
+/**
+ * A row that does two things: tapping the label area opens a sub-screen, while a trailing switch
+ * (separated by a vertical pipe) flips a value inline. The pipe hints the row is more than a toggle.
+ */
+@Composable
+fun SplitToggleSettingsItem(
+    title: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    subtitle: String? = null,
+    icon: ImageVector? = null,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp)),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.height(IntrinsicSize.Min),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable(onClick = onClick)
+                    .padding(16.dp),
+            ) {
+                if (icon != null) {
+                    Box(
+                        modifier = Modifier.padding(end = 16.dp).size(24.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                    }
+                }
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    if (subtitle != null) {
+                        Text(
+                            text = subtitle,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .padding(vertical = 14.dp)
+                    .width(1.dp)
+                    .fillMaxHeight()
+                    .background(MaterialTheme.colorScheme.outlineVariant),
+            )
+            Box(
+                modifier = Modifier.padding(16.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Switch(checked = checked, onCheckedChange = onCheckedChange, colors = appSwitchColors())
+            }
+        }
+    }
 }
 
 /**
@@ -221,7 +329,9 @@ fun RadioSettingsItem(
 }
 
 /**
- * A clickable settings item that displays a current value on the right.
+ * A clickable settings item showing the current value as its subtitle. Set [showArrow] when the row
+ * opens a sub-screen — only those rows get the trailing chevron. Rows that open a bottom-sheet
+ * picker leave it off, since the sheet (not a screen) is what appears.
  */
 @Composable
 fun SelectionSettingsItem(
@@ -230,24 +340,25 @@ fun SelectionSettingsItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     icon: ImageVector? = null,
-    enabled: Boolean = true
+    enabled: Boolean = true,
+    showArrow: Boolean = false
 ) {
     SettingsItem(
         title = title,
-        subtitle = null,
+        subtitle = currentValue,
         icon = icon,
         enabled = enabled,
         onClick = onClick,
         modifier = modifier,
         trailingContent = {
-            Text(
-                text = currentValue,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.widthIn(max = 140.dp)
-            )
+            if (showArrow) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = if (enabled) MaterialTheme.colorScheme.onSurfaceVariant
+                    else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+                )
+            }
         }
     )
 }

--- a/app/src/main/java/com/anisync/android/presentation/settings/SettingsUiState.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/SettingsUiState.kt
@@ -16,6 +16,7 @@ import com.materialkolor.PaletteStyle
 
 sealed interface SettingsAction {
     data class SetThemeMode(val mode: ThemeMode) : SettingsAction
+    data class SetAmoledEnabled(val enabled: Boolean) : SettingsAction
     data class SetTitleLanguage(val language: TitleLanguage) : SettingsAction
     data class SetCoverQuality(val quality: CoverQuality) : SettingsAction
     data class SetHapticEnabled(val enabled: Boolean) : SettingsAction
@@ -108,6 +109,7 @@ data class SettingsUiState(
 
     // Look & Feel
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
+    val amoledEnabled: Boolean = false,
     val titleLanguage: TitleLanguage = TitleLanguage.ROMAJI,
     val coverQuality: CoverQuality = CoverQuality.LARGE,
     val hapticEnabled: Boolean = true,

--- a/app/src/main/java/com/anisync/android/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/SettingsViewModel.kt
@@ -206,8 +206,9 @@ class SettingsViewModel @Inject constructor(
     val uiState: StateFlow<SettingsUiState> = combine(
         coreUiState,
         fontPlaygroundFlow,
-    ) { core, fontPlayground ->
-        core.copy(fontPlayground = fontPlayground)
+        appSettings.amoledEnabled,
+    ) { core, fontPlayground, amoled ->
+        core.copy(fontPlayground = fontPlayground, amoledEnabled = amoled)
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5000),
@@ -217,6 +218,7 @@ class SettingsViewModel @Inject constructor(
     fun onAction(action: SettingsAction) {
         when (action) {
             is SettingsAction.SetThemeMode -> appSettings.setThemeMode(action.mode)
+            is SettingsAction.SetAmoledEnabled -> appSettings.setAmoledEnabled(action.enabled)
             is SettingsAction.SetTitleLanguage -> appSettings.setTitleLanguage(action.language)
             is SettingsAction.SetCoverQuality -> appSettings.setCoverQuality(action.quality)
             is SettingsAction.SetHapticEnabled -> appSettings.setHapticEnabled(action.enabled)

--- a/app/src/main/java/com/anisync/android/presentation/settings/ThemeScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/ThemeScreen.kt
@@ -1,0 +1,181 @@
+package com.anisync.android.presentation.settings
+
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Contrast
+import androidx.compose.material.icons.filled.Palette
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.anisync.android.R
+import com.anisync.android.data.ThemeMode
+import com.anisync.android.presentation.settings.components.ColorPickerSheet
+import com.anisync.android.presentation.settings.components.ColorSchemeSelector
+import com.anisync.android.presentation.settings.components.PaletteStyleSelector
+import com.anisync.android.presentation.settings.components.PhonePreview
+import com.anisync.android.ui.theme.PresetPalettes
+import com.anisync.android.ui.theme.ThemePalette
+
+/**
+ * Theme subscreen — the app's full theming hub: live preview, color scheme + palette style, custom
+ * seed color, light/dark/system mode, AMOLED toggle, and the "use profile colors" preference.
+ */
+@Composable
+fun ThemeScreen(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val themeMode = uiState.themeMode
+    val amoledEnabled = uiState.amoledEnabled
+    val respectUserProfileColors = uiState.respectUserProfileColors
+    val selectedPaletteId = uiState.selectedPaletteId
+    val customSeedColor = uiState.customSeedColor
+    val paletteStyle = uiState.paletteStyle
+
+    val isSystemDark = isSystemInDarkTheme()
+    val isDarkMode = remember(themeMode, isSystemDark) {
+        when (themeMode) {
+            ThemeMode.DARK -> true
+            ThemeMode.LIGHT -> false
+            ThemeMode.SYSTEM -> isSystemDark
+        }
+    }
+
+    val supportsDynamicColor = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+    val palettes = remember(customSeedColor, supportsDynamicColor) {
+        val presets = if (supportsDynamicColor) {
+            PresetPalettes.all
+        } else {
+            PresetPalettes.all.filter { !it.isDynamic }
+        }
+        if (customSeedColor != null) {
+            listOf(ThemePalette("custom", "Custom", customSeedColor!!)) + presets
+        } else {
+            presets
+        }
+    }
+
+    LaunchedEffect(selectedPaletteId, palettes, uiState.isLoaded) {
+        if (uiState.isLoaded && palettes.none { it.id == selectedPaletteId }) {
+            viewModel.onAction(SettingsAction.SetSelectedPalette(palettes.firstOrNull()?.id ?: "dynamic"))
+        }
+    }
+
+    var showColorPicker by rememberSaveable { mutableStateOf(false) }
+    if (showColorPicker) {
+        ColorPickerSheet(
+            currentColor = customSeedColor,
+            onColorSelected = { color ->
+                viewModel.onAction(SettingsAction.SetCustomSeedColor(color))
+                viewModel.onAction(SettingsAction.SetSelectedPalette("custom"))
+            },
+            onDismiss = { showColorPicker = false }
+        )
+    }
+
+    SettingsScreenScaffold(
+        title = stringResource(R.string.setting_theme),
+        onBackClick = onBackClick,
+        modifier = modifier
+    ) {
+        SettingsSectionLabel(stringResource(R.string.preview))
+
+        val selectedPalette = remember(palettes, selectedPaletteId) {
+            palettes.find { it.id == selectedPaletteId }
+        }
+        val seedColor = if (selectedPalette?.isDynamic == true) null else selectedPalette?.seedColor
+
+        if (uiState.isLoaded) {
+            PhonePreview(
+                seedColor = seedColor,
+                isDarkMode = isDarkMode,
+                paletteStyle = paletteStyle,
+                amoled = amoledEnabled
+            )
+        }
+
+        SettingsSectionLabel(stringResource(R.string.color_scheme))
+
+        ColorSchemeSelector(
+            palettes = palettes,
+            selectedPaletteId = selectedPaletteId,
+            isDarkMode = isDarkMode,
+            paletteStyle = paletteStyle,
+            onPaletteSelected = { viewModel.onAction(SettingsAction.SetSelectedPalette(it.id)) }
+        )
+
+        PaletteStyleSelector(
+            selectedStyle = paletteStyle,
+            onStyleSelected = { viewModel.onAction(SettingsAction.SetPaletteStyle(it)) },
+            enabled = selectedPaletteId != "dynamic",
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        SettingsGroup {
+            SettingsItem(
+                icon = Icons.Default.Palette,
+                title = stringResource(R.string.custom_color),
+                subtitle = stringResource(R.string.custom_color_description),
+                onClick = { showColorPicker = true }
+            )
+        }
+
+        SettingsGroup(modifier = Modifier.selectableGroup()) {
+            ThemeMode.entries.forEach { mode ->
+                RadioSettingsItem(
+                    title = stringResource(mode.labelRes()),
+                    subtitle = stringResource(mode.subtitleRes()),
+                    selected = themeMode == mode,
+                    onClick = { viewModel.onAction(SettingsAction.SetThemeMode(mode)) }
+                )
+            }
+        }
+
+        SettingsGroup {
+            SwitchSettingsItem(
+                icon = Icons.Default.Contrast,
+                title = stringResource(R.string.setting_amoled),
+                subtitle = stringResource(R.string.setting_amoled_desc),
+                checked = amoledEnabled,
+                onCheckedChange = { viewModel.onAction(SettingsAction.SetAmoledEnabled(it)) }
+            )
+        }
+
+        SettingsGroup {
+            SwitchSettingsItem(
+                icon = Icons.Default.Palette,
+                title = stringResource(R.string.setting_respect_profile_colors),
+                subtitle = stringResource(R.string.setting_respect_profile_colors_desc),
+                checked = respectUserProfileColors,
+                onCheckedChange = {
+                    viewModel.onAction(SettingsAction.SetRespectUserProfileColors(it))
+                }
+            )
+        }
+    }
+}
+
+private fun ThemeMode.labelRes(): Int = when (this) {
+    ThemeMode.LIGHT -> R.string.theme_light
+    ThemeMode.DARK -> R.string.theme_dark
+    ThemeMode.SYSTEM -> R.string.theme_system
+}
+
+private fun ThemeMode.subtitleRes(): Int = when (this) {
+    ThemeMode.LIGHT -> R.string.theme_light_desc
+    ThemeMode.DARK -> R.string.theme_dark_desc
+    ThemeMode.SYSTEM -> R.string.theme_system_desc
+}

--- a/app/src/main/java/com/anisync/android/presentation/settings/UpdatesScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/UpdatesScreen.kt
@@ -115,68 +115,59 @@ fun UpdatesScreen(
                 checked = uiState.isAutoUpdateEnabled,
                 onCheckedChange = { viewModel.onAction(SettingsAction.SetAutoUpdateEnabled(it)) }
             )
-            Spacer(modifier = Modifier.height(16.dp))
+        }
 
-            Text(
-                text = stringResource(R.string.update_channel),
-                style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(start = 24.dp, bottom = 8.dp)
+        SettingsSectionLabel(stringResource(R.string.update_channel))
+
+        SettingsGroup {
+            RadioSettingsItem(
+                title = stringResource(R.string.channel_stable),
+                subtitle = stringResource(R.string.channel_stable_desc),
+                selected = !uiState.isPrereleaseAllowed,
+                onClick = { viewModel.onAction(SettingsAction.SetPrereleaseAllowed(false)) }
             )
+            RadioSettingsItem(
+                title = stringResource(R.string.channel_prerelease),
+                subtitle = stringResource(R.string.channel_prerelease_desc),
+                selected = uiState.isPrereleaseAllowed,
+                onClick = { viewModel.onAction(SettingsAction.SetPrereleaseAllowed(true)) }
+            )
+        }
 
-            SettingsGroup {
-                RadioSettingsItem(
-                    title = stringResource(R.string.channel_stable),
-                    subtitle = stringResource(R.string.channel_stable_desc),
-                    selected = !uiState.isPrereleaseAllowed,
-                    onClick = { viewModel.onAction(SettingsAction.SetPrereleaseAllowed(false)) }
-                )
-                SettingsDivider()
-                RadioSettingsItem(
-                    title = stringResource(R.string.channel_prerelease),
-                    subtitle = stringResource(R.string.channel_prerelease_desc),
-                    selected = uiState.isPrereleaseAllowed,
-                    onClick = { viewModel.onAction(SettingsAction.SetPrereleaseAllowed(true)) }
-                )
-            }
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            SettingsGroup {
-                SettingsItem(
-                    title = stringResource(R.string.check_for_updates),
-                    subtitle = stringResource(R.string.settings_version, BuildConfig.VERSION_NAME),
-                    icon = Icons.Outlined.Refresh,
-                    onClick = {
-                        if (updateState !is UpdateState.Checking) {
-                            viewModel.onAction(SettingsAction.CheckForUpdate)
-                        }
-                    },
-                    trailingContent = {
-                        if (updateState is UpdateState.Checking) {
-                            CircularProgressIndicator(modifier = Modifier.size(24.dp))
-                        }
+        SettingsGroup {
+            SettingsItem(
+                title = stringResource(R.string.check_for_updates),
+                subtitle = stringResource(R.string.settings_version, BuildConfig.VERSION_NAME),
+                icon = Icons.Outlined.Refresh,
+                onClick = {
+                    if (updateState !is UpdateState.Checking) {
+                        viewModel.onAction(SettingsAction.CheckForUpdate)
                     }
-                )
-            }
+                },
+                trailingContent = {
+                    if (updateState is UpdateState.Checking) {
+                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                    }
+                }
+            )
+        }
 
-            val dialogRelease = when (val state = updateState) {
-                is UpdateState.UpdateAvailable -> state.release
-                is UpdateState.Downloading -> state.release
-                is UpdateState.ReadyToInstall -> state.release
-                else -> null
-            }
+        val dialogRelease = when (val state = updateState) {
+            is UpdateState.UpdateAvailable -> state.release
+            is UpdateState.Downloading -> state.release
+            is UpdateState.ReadyToInstall -> state.release
+            else -> null
+        }
 
-            if (dialogRelease != null) {
-                UpdateDialog(
-                    updateState = updateState,
-                    release = dialogRelease,
-                    onDismiss = { viewModel.onAction(SettingsAction.DismissUpdate) },
-                    onDownload = { viewModel.onAction(SettingsAction.StartDownload(dialogRelease)) },
-                    onCancel = { viewModel.onAction(SettingsAction.CancelDownload) },
-                    onInstall = { requestInstall() }
-                )
-            }
+        if (dialogRelease != null) {
+            UpdateDialog(
+                updateState = updateState,
+                release = dialogRelease,
+                onDismiss = { viewModel.onAction(SettingsAction.DismissUpdate) },
+                onDownload = { viewModel.onAction(SettingsAction.StartDownload(dialogRelease)) },
+                onCancel = { viewModel.onAction(SettingsAction.CancelDownload) },
+                onInstall = { requestInstall() }
+            )
         }
     }
 }

--- a/app/src/main/java/com/anisync/android/presentation/settings/components/PhonePreview.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/components/PhonePreview.kt
@@ -62,6 +62,7 @@ import com.anisync.android.presentation.util.LocalAppSettings
 import com.anisync.android.type.MediaFormat
 import com.anisync.android.type.MediaType
 import com.anisync.android.ui.theme.PreviewTheme
+import com.anisync.android.ui.theme.toAmoled
 import com.materialkolor.PaletteStyle
 
 // OPTIMIZATION: Move constant data structures to top-level to avoid allocation on every recomposition.
@@ -88,7 +89,8 @@ fun PhonePreview(
     seedColor: Color?,
     isDarkMode: Boolean,
     paletteStyle: PaletteStyle,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    amoled: Boolean = false
 ) {
     val context = LocalContext.current
     val appSettings = remember { AppSettings(context) }
@@ -130,16 +132,19 @@ fun PhonePreview(
                 seedColor = seedColor,
                 isDark = isDarkMode,
                 style = paletteStyle,
+                amoled = amoled,
                 content = themeContent
             )
         } else if (dynamicColorScheme != null) {
             // OPTIMIZATION: Use the memoized scheme
-            PreviewTheme(colorScheme = dynamicColorScheme, content = themeContent)
+            val scheme = if (amoled && isDarkMode) dynamicColorScheme.toAmoled() else dynamicColorScheme
+            PreviewTheme(colorScheme = scheme, content = themeContent)
         } else {
             PreviewTheme(
                 seedColor = Color(0xFF6750A4),
                 isDark = isDarkMode,
                 style = paletteStyle,
+                amoled = amoled,
                 content = themeContent
             )
         }

--- a/app/src/main/java/com/anisync/android/presentation/settings/components/SettingsPickerSheet.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/components/SettingsPickerSheet.kt
@@ -1,0 +1,80 @@
+package com.anisync.android.presentation.settings.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.anisync.android.presentation.settings.RadioSettingsItem
+import com.anisync.android.presentation.settings.SettingsGroup
+
+/**
+ * A single-choice bottom-sheet picker built from the shared settings vocabulary: a heading followed
+ * by a [SettingsGroup] of [RadioSettingsItem]s. Use this for plain enumerations (theme mode, app
+ * language, …) so every picker reads the same. Richer pickers that need previews or grids keep their
+ * bespoke sheet.
+ *
+ * The caller owns dismissal: have [onSelect] apply the value and close the sheet.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun <T> SettingsPickerSheet(
+    title: String,
+    items: List<T>,
+    selected: T?,
+    itemLabel: @Composable (T) -> String,
+    onSelect: (T) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    itemSubtitle: @Composable (T) -> String? = { null },
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        dragHandle = { BottomSheetDefaults.DragHandle() },
+        modifier = modifier,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 32.dp)
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            SettingsGroup(
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .selectableGroup()
+            ) {
+                items.forEach { item ->
+                    RadioSettingsItem(
+                        title = itemLabel(item),
+                        subtitle = itemSubtitle(item),
+                        selected = item == selected,
+                        onClick = { onSelect(item) },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/anisync/android/ui/theme/PreviewTheme.kt
+++ b/app/src/main/java/com/anisync/android/ui/theme/PreviewTheme.kt
@@ -20,6 +20,7 @@ import com.materialkolor.rememberDynamicColorScheme
  * @param seedColor The seed color to generate the color scheme from
  * @param isDark Whether to generate a dark or light color scheme
  * @param style The palette style to use for color generation
+ * @param amoled Whether to use pure-black backgrounds (only applied when [isDark] is true)
  * @param content The content to render with this theme
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -28,15 +29,18 @@ fun PreviewTheme(
     seedColor: Color,
     isDark: Boolean,
     style: PaletteStyle = PaletteStyle.TonalSpot,
+    amoled: Boolean = false,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = rememberDynamicColorScheme(
+    val base = rememberDynamicColorScheme(
         seedColor = seedColor,
         isDark = isDark,
         isAmoled = false,
         style = style
     )
-    
+    // Match AppTheme: apply our own cohesive AMOLED transform rather than MaterialKolor's isAmoled.
+    val colorScheme = if (isDark && amoled) base.toAmoled() else base
+
     MaterialTheme(
         colorScheme = colorScheme,
         typography = AppTypography,

--- a/app/src/main/java/com/anisync/android/ui/theme/Theme.kt
+++ b/app/src/main/java/com/anisync/android/ui/theme/Theme.kt
@@ -1,6 +1,7 @@
 package com.anisync.android.ui.theme
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MotionScheme
@@ -257,6 +258,28 @@ val unspecified_scheme = ColorFamily(
     Color.Unspecified, Color.Unspecified, Color.Unspecified, Color.Unspecified
 )
 
+/**
+ * Converts a dark [ColorScheme] into an AMOLED ("pure black") one.
+ *
+ * Blackening only `background`/`surface` (what MaterialKolor's own `isAmoled` does) leaves the
+ * `surfaceContainer*` roles at mid-grey, so cards, the search bar and the nav pill float as grey
+ * patches on a pure-black base. Instead — following Seal's high-contrast theme — we also blacken the
+ * lowest container and **shift the whole elevation ladder down one tonal step**. The base goes truly
+ * black while elevated surfaces stay near-black greys that keep their *relative* depth, so the result
+ * reads as one cohesive pitch-black theme rather than grey-on-black.
+ *
+ * The right-hand sides reference the original (receiver) values, so each role is pulled from the step
+ * below it. Only meaningful on a dark scheme.
+ */
+internal fun ColorScheme.toAmoled(): ColorScheme = copy(
+    background = Color.Black,
+    surface = Color.Black,
+    surfaceContainerLowest = Color.Black,
+    surfaceContainerLow = surfaceContainerLowest,
+    surfaceContainer = surfaceContainerLow,
+    surfaceContainerHigh = surfaceContainerLow,
+    surfaceContainerHighest = surfaceContainer,
+)
 
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -265,6 +288,8 @@ fun AppTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
+    // Pure-black ("AMOLED") backgrounds. Only honored while [darkTheme] is active.
+    amoled: Boolean = false,
     // Custom seed color for MaterialKolor-generated schemes
     seedColor: Color? = null,
     // Palette style for MaterialKolor color generation
@@ -273,25 +298,36 @@ fun AppTheme(
     typographyOverrides: TypographyOverrides = TypographyOverrides.None,
     content: @Composable () -> Unit
 ) {
+    // AMOLED is a dark-only treatment; ignore it in light mode so toggling it can't blacken a
+    // light theme (relevant under SYSTEM mode during the day).
+    val useAmoled = amoled && darkTheme
+
     // Priority order for color scheme selection:
     // 1. Custom seed color (user-selected palette)
     // 2. Android 12+ dynamic colors (wallpaper-based)
     // 3. Static fallback scheme
     val colorScheme = when {
-        // Priority 1: Custom seed color from user selection
-        seedColor != null -> rememberDynamicColorScheme(
-            seedColor = seedColor,
-            isDark = darkTheme,
-            isAmoled = false,
-            style = paletteStyle
-        )
+        // Priority 1: Custom seed color from user selection.
+        // isAmoled is left off here: MaterialKolor's variant only blackens background/surface, which
+        // looks patchy. We apply our own toAmoled() (Seal-style container shift) for a cohesive look
+        // consistent with the other two paths.
+        seedColor != null -> {
+            val base = rememberDynamicColorScheme(
+                seedColor = seedColor,
+                isDark = darkTheme,
+                isAmoled = false,
+                style = paletteStyle
+            )
+            if (useAmoled) base.toAmoled() else base
+        }
         // Priority 2: Dynamic color (Android 12+)
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            val base = if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            if (useAmoled) base.toAmoled() else base
         }
         // Priority 3: Static fallback
-        darkTheme -> darkScheme
+        darkTheme -> if (useAmoled) darkScheme.toAmoled() else darkScheme
         else -> lightScheme
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -232,6 +232,8 @@
     <string name="theme_light">Light</string>
     <string name="theme_dark">Dark</string>
     <string name="theme_system">System</string>
+    <string name="setting_amoled">AMOLED dark theme</string>
+    <string name="setting_amoled_desc">Use pure black backgrounds in dark mode to save power on OLED screens</string>
 
     <!-- Theme Palette Selection -->
     <string name="color_and_style">Color &amp; Style</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -232,6 +232,9 @@
     <string name="theme_light">Light</string>
     <string name="theme_dark">Dark</string>
     <string name="theme_system">System</string>
+    <string name="theme_light_desc">Always use the light theme</string>
+    <string name="theme_dark_desc">Always use the dark theme</string>
+    <string name="theme_system_desc">Follow the device setting</string>
     <string name="setting_amoled">AMOLED dark theme</string>
     <string name="setting_amoled_desc">Use pure black backgrounds in dark mode to save power on OLED screens</string>
 


### PR DESCRIPTION
## Summary
- **AMOLED pure-black dark theme** (Settings ▸ Look & Feel ▸ Theme ▸ *AMOLED dark theme*). Forces background/surface to true black and shifts the whole `surfaceContainer` ladder down for a cohesive pitch-black look. Closes #58.
- **Settings redesign**: shared design-system components (connected-card groups, shared switch palette, section labels), a **"Dark Mode" split-toggle** row, and drill-down subscreens for **Theme** (preview, color scheme, custom color, mode, AMOLED, profile colors) and **App language**. Other pickers stay quick-choice bottom sheets; only sub-screen rows show the chevron.

## Commits
- feat(theme): add AMOLED pure-black dark theme
- feat(settings): add shared settings design-system components
- feat(settings): restructure Settings into a CineMatch-style system

## Testing
`./gradlew assembleStableDebug` green; installed and verified on a physical device (SM-G996B).