### PR TITLE
fix(profile): load activity heatmap on entry without pull-to-refresh

### DIFF
--- a/app/src/main/java/com/anisync/android/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/ProfileViewModel.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -1049,11 +1050,12 @@ class ProfileViewModel @Inject constructor(
 
         viewModelScope.launch {
             statsState.update { it.copy(isStatsLoading = true, statsErrorMessage = null) }
+            // The Overview tab's cold-open auto-refresh fires this before the profile is
+            // necessarily in uiState (the stats fetch races the profile load). Bailing on a
+            // null id left the activity-history heatmap empty until a manual pull-to-refresh;
+            // instead, await the first non-null id so it populates on its own.
             val userId = uiState.value.profile?.id
-            if (userId == null) {
-                statsState.update { it.copy(isStatsLoading = false) }
-                return@launch
-            }
+                ?: uiState.map { it.profile?.id }.filterNotNull().first()
 
             when (val result = statisticsRepository.getUserStatistics(userId)) {
                 is Result.Success -> {


### PR DESCRIPTION
## Problem
Entering your own or another user's profile, the **Activity History** heatmap (Overview tab) did not appear until a manual pull-to-refresh.

## Root cause
The heatmap reads `uiState.statsData?.activityHistory`, populated by `fetchStats()`. On the Overview tab nothing fires `fetchStats` on entry except the cold-open auto-refresh. Inside, it snapshotted `uiState.value.profile?.id` and **bailed when null**:

```kotlin
val userId = uiState.value.profile?.id
if (userId == null) { statsState.update { it.copy(isStatsLoading = false) }; return@launch }
```

That snapshot races the profile load, so the id was usually still null when the 500ms auto-refresh ran — `fetchStats` returned early and never retried. The heatmap stayed empty until a pull re-fired `fetchStats` after the profile had loaded.

## Fix
Await the first non-null profile id instead of bailing (same `uiState.map { it.profile?.id }.filterNotNull()` pattern `observeTargetProfileForFollowState` already uses):

```kotlin
val userId = uiState.value.profile?.id
    ?: uiState.map { it.profile?.id }.filterNotNull().first()
```

Self-heals (the parked `first()` resolves whenever the profile loads); the `isStatsLoading` guard still dedups; tab-tap fetches already have the id so `first()` returns immediately.

## Verification
Built `installStableDebug`, tapped Profile, **no pull** — heatmap ("409 activities across 120 days" + grid) rendered on its own once the stats query returned. One-file change.