### PR TITLE
fix(library): dedupe entries to stop duplicate-key crash

### DIFF
--- a/app/src/main/java/com/anisync/android/data/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/LibraryRepositoryImpl.kt
@@ -179,7 +179,20 @@ class LibraryRepositoryImpl @Inject constructor(
                 }
             }
 
-            val entries = entryMap.values.toList()
+            // Collapse any rows that resolve to the same media into one (AniList media merges, or a
+            // duplicate written by an external sync tool, can produce two list entries for one media).
+            // Keep the most recently updated, carrying over every custom-list membership, so the cache
+            // holds a single row per media and the grid never gets two cards with the same key.
+            val entries = entryMap.values
+                .groupBy { it.mediaId }
+                .map { (_, dups) ->
+                    if (dups.size == 1) {
+                        dups[0]
+                    } else {
+                        val keep = dups.maxByOrNull { it.updatedAt ?: 0L } ?: dups[0]
+                        keep.copy(customLists = dups.flatMap { it.customLists }.distinct())
+                    }
+                }
 
             // Smart merge to preserve locally-added entries during API sync delay.
             // Tag rows with the active account so each account's library persists independently.

--- a/app/src/main/java/com/anisync/android/data/local/dao/LibraryDao.kt
+++ b/app/src/main/java/com/anisync/android/data/local/dao/LibraryDao.kt
@@ -90,25 +90,35 @@ interface LibraryDao {
     @Transaction
     suspend fun smartMergeByType(ownerId: Int, type: MediaType, apiEntries: List<LibraryEntryEntity>) {
         val localEntries = getByType(ownerId, type)
-        val apiMediaIds = apiEntries.mapTo(HashSet(apiEntries.size)) { it.mediaId }
+        // The API list holds one canonical entry id per media (it's deduped by media upstream).
+        val apiIdByMedia = HashMap<Int, Int>(apiEntries.size)
+        for (e in apiEntries) apiIdByMedia[e.mediaId] = e.id
         val now = System.currentTimeMillis()
         val recentThreshold = 5 * 60 * 1000L
 
         val toPreserve = ArrayList<LibraryEntryEntity>()
-        val toDeleteIds = ArrayList<Int>()
+        val toDeleteMediaIds = ArrayList<Int>()
+        val staleDuplicateIds = ArrayList<Int>()
         for (local in localEntries) {
-            if (local.mediaId in apiMediaIds) continue
+            val canonicalId = apiIdByMedia[local.mediaId]
+            if (canonicalId != null) {
+                // Media is on the server → the API row wins. A local row for the same media with a
+                // different entry id is a stale duplicate (e.g. an id=0 optimistic-add row that never
+                // got swapped for the real id) — drop it so the media isn't cached/rendered twice.
+                if (local.id != canonicalId) staleDuplicateIds.add(local.id)
+                continue
+            }
+            // Media not on the server: keep a just-added entry through the sync delay, else it's stale.
             val created = local.createdAt
             if (created != null && (now - created) <= recentThreshold) {
                 toPreserve.add(local)
             } else {
-                toDeleteIds.add(local.mediaId)
+                toDeleteMediaIds.add(local.mediaId)
             }
         }
 
-        if (toDeleteIds.isNotEmpty()) {
-            deleteByMediaIds(ownerId, toDeleteIds)
-        }
+        if (staleDuplicateIds.isNotEmpty()) deleteByIds(ownerId, staleDuplicateIds)
+        if (toDeleteMediaIds.isNotEmpty()) deleteByMediaIds(ownerId, toDeleteMediaIds)
         insertAll(apiEntries)
         if (toPreserve.isNotEmpty()) {
             insertAll(toPreserve)
@@ -117,6 +127,10 @@ interface LibraryDao {
 
     @Query("DELETE FROM library_entries WHERE ownerId = :ownerId AND mediaId IN (:mediaIds)")
     suspend fun deleteByMediaIds(ownerId: Int, mediaIds: List<Int>)
+
+    /** Delete specific entries by their MediaList (entry) id. Used to drop stale duplicate rows. */
+    @Query("DELETE FROM library_entries WHERE ownerId = :ownerId AND id IN (:ids)")
+    suspend fun deleteByIds(ownerId: Int, ids: List<Int>)
 
     /**
      * Update status and progress for a specific media entry in an account.

--- a/app/src/main/java/com/anisync/android/presentation/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/library/LibraryViewModel.kt
@@ -199,8 +199,14 @@ class LibraryViewModel @Inject constructor(
 
                     class SortableEntry(val entry: LibraryEntry, val sortTitle: String)
 
+                    // Guard against any duplicate-media rows still cached locally (e.g. a stale id=0
+                    // optimistic-add row not yet reconciled by a sync): render one card per media,
+                    // otherwise the lazy grid crashes on the colliding key.
+                    val dedupedEntries = entries
+                        .groupBy { it.mediaId }
+                        .map { (_, dups) -> dups.maxByOrNull { it.updatedAt ?: 0L } ?: dups.first() }
                     val sortableEntries =
-                        entries.map { SortableEntry(it, it.getTitle(titleLang).lowercase()) }
+                        dedupedEntries.map { SortableEntry(it, it.getTitle(titleLang).lowercase()) }
 
                     val titleDir = if (ascending) 1 else -1
                     val keyDir = -titleDir


### PR DESCRIPTION
Follow-up from the #69 discussion — the duplicate lazy-key crash also hits the **library** itself, and the proper fix is at the data layer rather than index-suffixing the keys (which would just render the phantom duplicate as two cards and break the sort animation).

## Why it happens
The library is cached by **MediaList entry id**, but the grid keys (and most ops) address entries by **media id**. So if the cache ever holds two rows for one media, their lazy keys collide and it crashes. Two rows for one media come from:
- An AniList media merge, or an external sync tool, or
- Our own optimistic add: a new entry goes in with a placeholder `id = 0`, and once the real entry syncs in, `smartMerge` keeps both.

## Fix
- **LibraryViewModel** renders one entry per media id — an offline-safe guard, so an already-cached duplicate can never crash the grid.
- **LibraryRepositoryImpl** collapses network entries to one row per media id (carrying over custom-list membership), so the cache never persists a duplicate.
- **smartMergeByType** drops any local row whose media is on the server but whose entry id differs (the leftover `id = 0` row), via a new `deleteByIds`.

No schema change.

## Testing
- [x] Physical device — library loads + sorts normally, and a pull-to-refresh sync keeps every entry intact (no drops, no dupes).
