### PR TITLE
fix(library): persist the chosen sort across restarts

### DIFF
--- a/app/src/main/java/com/anisync/android/data/AppSettings.kt
+++ b/app/src/main/java/com/anisync/android/data/AppSettings.kt
@@ -353,6 +353,14 @@ class AppSettings @Inject constructor(
     private val _libraryGridView = MutableStateFlow(prefs.getBoolean(KEY_LIBRARY_GRID_VIEW, true))
     val libraryGridView: StateFlow<Boolean> = _libraryGridView.asStateFlow()
 
+    // Library sort option + direction, stored by LibrarySort enum name. Persisted so the chosen sort
+    // survives app restarts instead of resetting to the default (Airing Soon) on every launch.
+    private val _librarySortOption =
+        MutableStateFlow(prefs.getString(KEY_LIBRARY_SORT_OPTION, DEFAULT_LIBRARY_SORT) ?: DEFAULT_LIBRARY_SORT)
+    val librarySortOption: StateFlow<String> = _librarySortOption.asStateFlow()
+    private val _librarySortAscending = MutableStateFlow(prefs.getBoolean(KEY_LIBRARY_SORT_ASCENDING, true))
+    val librarySortAscending: StateFlow<Boolean> = _librarySortAscending.asStateFlow()
+
     // Last selected feed content filter (All / Status / List).
     private val _feedFilter = MutableStateFlow(readFeedFilter())
     val feedFilter: StateFlow<FeedFilter> = _feedFilter.asStateFlow()
@@ -759,6 +767,18 @@ class AppSettings @Inject constructor(
     }
 
     /**
+     * Persist the library sort option (by [LibrarySort] enum name) and direction.
+     */
+    fun setLibrarySort(optionName: String, ascending: Boolean) {
+        _librarySortOption.value = optionName
+        _librarySortAscending.value = ascending
+        prefs.edit()
+            .putString(KEY_LIBRARY_SORT_OPTION, optionName)
+            .putBoolean(KEY_LIBRARY_SORT_ASCENDING, ascending)
+            .apply()
+    }
+
+    /**
      * Persist the last selected feed content filter.
      */
     fun setFeedFilter(filter: FeedFilter) {
@@ -979,6 +999,9 @@ companion object {
         private const val KEY_FEED_SCOPE = "feed_scope"
         private const val KEY_FEED_FILTER = "feed_filter"
         private const val KEY_LIBRARY_GRID_VIEW = "library_grid_view"
+        private const val KEY_LIBRARY_SORT_OPTION = "library_sort_option"
+        private const val KEY_LIBRARY_SORT_ASCENDING = "library_sort_ascending"
+        private const val DEFAULT_LIBRARY_SORT = "AIRING_SOON"
         private const val KEY_LIBRARY_MEDIA_TYPE_MANGA = "library_media_type_manga"
         private const val KEY_DISCOVER_MEDIA_TYPE_MANGA = "discover_media_type_manga"
         private const val KEY_FORUM_FEED = "forum_feed"

--- a/app/src/main/java/com/anisync/android/presentation/library/LibraryScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/library/LibraryScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,6 +25,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -297,6 +300,9 @@ fun LibraryScreen(
             isSearchQueryEmpty = isSearchQueryEmpty,
             isGridView = uiState.isGridView,
             isAscending = isAscending,
+            // Highlight the sort affordance whenever the active sort differs from the default
+            // (Airing Soon, ascending), so it's obvious the list isn't in its default order.
+            isNonDefaultSort = sortOption != LibrarySort.AIRING_SOON || !isAscending,
             showListManagement = showListManagement,
             onSearch = { keyboardController?.hide() },
             onBackClick = {
@@ -815,6 +821,7 @@ private fun LibrarySearchBarInputField(
     isSearchQueryEmpty: Boolean,
     isGridView: Boolean,
     isAscending: Boolean,
+    isNonDefaultSort: Boolean,
     showListManagement: Boolean,
     onSearch: () -> Unit,
     onBackClick: () -> Unit,
@@ -874,7 +881,30 @@ private fun LibrarySearchBarInputField(
                     }
 
                     IconButton(onClick = onToggleSort) {
-                        SortIcon(isAscending = isAscending)
+                        Box(
+                            contentAlignment = Alignment.Center,
+                            modifier = Modifier
+                                .size(32.dp)
+                                .then(
+                                    if (isNonDefaultSort) {
+                                        Modifier.background(
+                                            MaterialTheme.colorScheme.tertiaryContainer,
+                                            CircleShape
+                                        )
+                                    } else {
+                                        Modifier
+                                    }
+                                )
+                        ) {
+                            SortIcon(
+                                isAscending = isAscending,
+                                activeColor = if (isNonDefaultSort) {
+                                    MaterialTheme.colorScheme.onTertiaryContainer
+                                } else {
+                                    MaterialTheme.colorScheme.onSurface
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/anisync/android/presentation/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/library/LibraryViewModel.kt
@@ -57,7 +57,10 @@ class LibraryViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(
         LibraryUiState(
             mediaType = appSettings.libraryMediaType.value,
-            isGridView = appSettings.libraryGridView.value
+            isGridView = appSettings.libraryGridView.value,
+            sortOption = runCatching { LibrarySort.valueOf(appSettings.librarySortOption.value) }
+                .getOrDefault(LibrarySort.AIRING_SOON),
+            isAscending = appSettings.librarySortAscending.value
         )
     )
     val uiState: StateFlow<LibraryUiState> = _uiState.asStateFlow()
@@ -111,6 +114,7 @@ class LibraryViewModel @Inject constructor(
             }
 
             is LibraryAction.OnSortOptionChange -> {
+                appSettings.setLibrarySort(action.sort.name, action.ascending)
                 _uiState.update {
                     it.copy(
                         sortOption = action.sort,


### PR DESCRIPTION
Fixes #65 — the library sort kept resetting to "Airing Soon" on every cold start.

The sort option + direction only lived in the screen's UI state, so it was never saved. Now it's persisted in `AppSettings` (by `LibrarySort` enum name), the same way the grid/list view density already is: the initial sort is seeded from prefs, and written back whenever you change it. Shared across anime/manga, matching the current behaviour.

Also makes a non-default sort obvious: the sort icon gets a tonal `tertiaryContainer` circle (theme colours) whenever the active sort isn't the default (Airing Soon, ascending), so it's clear at a glance the list isn't in its default order.

## Testing
- [x] Physical device — set sort to Score, force-stopped, reopened → stays on Score (was resetting before).
- [x] Sort icon shows the tonal circle when non-default, plain when default.
