### PR TITLE
feat(social): hide blocked users from feed, forum & notifications

### DIFF
--- a/app/src/main/graphql/Activity.graphql
+++ b/app/src/main/graphql/Activity.graphql
@@ -14,6 +14,7 @@ query GetActivity($id: Int!) {
       siteUrl
       user {
         id
+        isBlocked
         name
         avatar {
           large
@@ -30,6 +31,7 @@ query GetActivity($id: Int!) {
         createdAt
         user {
           id
+          isBlocked
           name
           avatar {
             large
@@ -51,6 +53,7 @@ query GetActivity($id: Int!) {
       siteUrl
       messenger {
         id
+        isBlocked
         name
         moderatorRoles
         avatar {
@@ -59,6 +62,7 @@ query GetActivity($id: Int!) {
       }
       recipient {
         id
+        isBlocked
         name
         avatar {
           large
@@ -75,6 +79,7 @@ query GetActivity($id: Int!) {
         createdAt
         user {
           id
+          isBlocked
           name
           avatar {
             large
@@ -96,6 +101,7 @@ query GetActivity($id: Int!) {
       siteUrl
       user {
         id
+        isBlocked
         name
         avatar {
           large
@@ -125,6 +131,7 @@ query GetActivity($id: Int!) {
         createdAt
         user {
           id
+          isBlocked
           name
           avatar {
             large

--- a/app/src/main/graphql/Feed.graphql
+++ b/app/src/main/graphql/Feed.graphql
@@ -19,6 +19,13 @@ query GetActivityFeed(
       hasRepliesOrTypeText: $hasRepliesOrTypeText
     ) {
       ...ActivityFields
+      # isBlocked lives here (not in the shared ActivityFields fragment): the fragment is also
+      # embedded in the folded GetFullUserProfile across 4 activity lists, where adding the per-user
+      # isBlocked lookup pushes that query past AniList's limit (returns null). The feed is a single
+      # list, so it can carry it. Used to hide blocked users' activities (issue #76).
+      ... on ListActivity { user { isBlocked } }
+      ... on TextActivity { user { isBlocked } }
+      ... on MessageActivity { messenger { isBlocked } recipient { isBlocked } }
     }
   }
 }

--- a/app/src/main/graphql/ForumOverview.graphql
+++ b/app/src/main/graphql/ForumOverview.graphql
@@ -15,6 +15,7 @@ query GetForumOverview($page: Int = 1, $perPage: Int = 15, $sort: [ThreadSort] =
       createdAt
       user {
         id
+        isBlocked
         name
         avatar {
           large

--- a/app/src/main/graphql/ForumThreadDetail.graphql
+++ b/app/src/main/graphql/ForumThreadDetail.graphql
@@ -17,6 +17,7 @@ query GetForumThread($id: Int!) {
         siteUrl
         user {
             id
+            isBlocked
             name
             avatar {
                 large
@@ -63,6 +64,7 @@ query GetForumComments(
             childComments
             user {
                 id
+                isBlocked
                 name
                 avatar {
                     large

--- a/app/src/main/graphql/ForumThreads.graphql
+++ b/app/src/main/graphql/ForumThreads.graphql
@@ -32,6 +32,7 @@ query GetForumThreads(
       createdAt
       user {
         id
+        isBlocked
         name
         avatar {
           large

--- a/app/src/main/graphql/Notifications.graphql
+++ b/app/src/main/graphql/Notifications.graphql
@@ -37,6 +37,7 @@ query GetNotifications(
         createdAt
         user {
           id
+          isBlocked
           name
           avatar {
             large
@@ -51,6 +52,7 @@ query GetNotifications(
         createdAt
         user {
           id
+          isBlocked
           name
           avatar {
             large
@@ -92,6 +94,7 @@ query GetNotifications(
         createdAt
         user {
           id
+          isBlocked
           name
           avatar {
             large
@@ -133,6 +136,7 @@ query GetNotifications(
         createdAt
         user {
           id
+          isBlocked
           name
           avatar {
             large
@@ -174,6 +178,7 @@ query GetNotifications(
         createdAt
         user {
           id
+          isBlocked
           name
           avatar {
             large
@@ -215,6 +220,7 @@ query GetNotifications(
         createdAt
         user {
           id
+          isBlocked
           name
           avatar {
             large
@@ -256,6 +262,7 @@ query GetNotifications(
         createdAt
         user {
           id
+          isBlocked
           name
           avatar {
             large
@@ -273,6 +280,7 @@ query GetNotifications(
         createdAt
         user {
           id
+          isBlocked
           name
           avatar {
             large
@@ -294,6 +302,7 @@ query GetNotifications(
         createdAt
         user {
           id
+          isBlocked
           name
           avatar {
             large
@@ -315,6 +324,7 @@ query GetNotifications(
         createdAt
         user {
           id
+          isBlocked
           name
           avatar {
             large
@@ -336,6 +346,7 @@ query GetNotifications(
         createdAt
         user {
           id
+          isBlocked
           name
           avatar {
             large
@@ -353,6 +364,7 @@ query GetNotifications(
         createdAt
         user {
           id
+          isBlocked
           name
           avatar {
             large

--- a/app/src/main/java/com/anisync/android/data/ActivityRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/ActivityRepositoryImpl.kt
@@ -262,6 +262,7 @@ class ActivityRepositoryImpl @Inject constructor(
 
     private fun GetActivityQuery.Activity.toDomain(): ActivityDetail? {
         onListActivity?.let { l ->
+            if (l.user?.isBlocked == true) return null
             val mediaTitle = l.media?.title?.userPreferred ?: "media"
             val mediaUrl = l.media?.siteUrl
             val statusText = (l.status ?: "Updated").trim()
@@ -289,7 +290,7 @@ class ActivityRepositoryImpl @Inject constructor(
                 recipientId = null,
                 recipientName = null,
                 recipientAvatarUrl = null,
-                replies = l.replies?.filterNotNull()?.map { r ->
+                replies = l.replies?.filterNotNull()?.filterNot { it.user?.isBlocked == true }?.map { r ->
                     ActivityReply(
                         id = r.id,
                         body = r.text.orEmpty(),
@@ -305,6 +306,7 @@ class ActivityRepositoryImpl @Inject constructor(
             )
         }
         onTextActivity?.let { t ->
+            if (t.user?.isBlocked == true) return null
             return ActivityDetail(
                 id = t.id,
                 body = t.text.orEmpty(),
@@ -323,7 +325,7 @@ class ActivityRepositoryImpl @Inject constructor(
                 recipientId = null,
                 recipientName = null,
                 recipientAvatarUrl = null,
-                replies = t.replies?.filterNotNull()?.map { r ->
+                replies = t.replies?.filterNotNull()?.filterNot { it.user?.isBlocked == true }?.map { r ->
                     ActivityReply(
                         id = r.id,
                         body = r.text.orEmpty(),
@@ -339,6 +341,7 @@ class ActivityRepositoryImpl @Inject constructor(
             )
         }
         onMessageActivity?.let { m ->
+            if (m.messenger?.isBlocked == true || m.recipient?.isBlocked == true) return null
             return ActivityDetail(
                 id = m.id,
                 body = m.message.orEmpty(),
@@ -357,7 +360,7 @@ class ActivityRepositoryImpl @Inject constructor(
                 recipientName = m.recipient?.name,
                 recipientAvatarUrl = m.recipient?.avatar?.large,
                 isAuthorMod = !m.messenger?.moderatorRoles.isNullOrEmpty(),
-                replies = m.replies?.filterNotNull()?.map { r ->
+                replies = m.replies?.filterNotNull()?.filterNot { it.user?.isBlocked == true }?.map { r ->
                     ActivityReply(
                         id = r.id,
                         body = r.text.orEmpty(),

--- a/app/src/main/java/com/anisync/android/data/FeedRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/FeedRepositoryImpl.kt
@@ -65,6 +65,14 @@ class FeedRepositoryImpl @Inject constructor(
         val pageData = response.data?.Page
         val items = pageData?.activities
             ?.filterNotNull()
+            // Hide activity from users the viewer has blocked on AniList (issue #76). isBlocked is
+            // selected inline on the feed query (not the shared ActivityFields fragment) — see Feed.graphql.
+            ?.filterNot { activity ->
+                activity.onListActivity?.user?.isBlocked == true ||
+                    activity.onTextActivity?.user?.isBlocked == true ||
+                    activity.onMessageActivity?.messenger?.isBlocked == true ||
+                    activity.onMessageActivity?.recipient?.isBlocked == true
+            }
             ?.mapNotNull { it.activityFields.toDomain() }
             ?.filterAdultActivities(showAdult)
             ?.distinctBy { it.id }

--- a/app/src/main/java/com/anisync/android/data/ForumRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/ForumRepositoryImpl.kt
@@ -89,7 +89,7 @@ class ForumRepositoryImpl @Inject constructor(
 
             val pageData = response.data?.Page
             val threads =
-                pageData?.threads?.filterNotNull()?.map { it.toForumThread() } ?: emptyList()
+                pageData?.threads?.filterNotNull()?.filterNot { it.user?.isBlocked == true }?.map { it.toForumThread() } ?: emptyList()
 
             PaginatedResult(
                 items = threads,
@@ -159,7 +159,7 @@ class ForumRepositoryImpl @Inject constructor(
 
                 val pageData = response.data?.Page
                 val threads =
-                    pageData?.threads?.filterNotNull()?.map { it.toForumThread() } ?: emptyList()
+                    pageData?.threads?.filterNotNull()?.filterNot { it.user?.isBlocked == true }?.map { it.toForumThread() } ?: emptyList()
 
                 PaginatedResult(
                     items = threads,
@@ -362,13 +362,18 @@ class ForumRepositoryImpl @Inject constructor(
 
     /**
      * Handles recursive conversion of both Apollo types and nested Map types
-     * resulting from the Json scalar Any-mapping.
+     * resulting from the Json scalar Any-mapping. Comments authored by a blocked user are
+     * dropped along with their reply subtree (issue #76); non-blocked replies nested under a
+     * non-blocked comment are kept and filtered at their own level. (Top-level comments carry a
+     * typed `isBlocked`; for `childComments`, served as an opaque JSON scalar, we read `isBlocked`
+     * from the map when AniList includes it.)
      */
     private fun mapToForumComment(node: Any?): ForumComment? {
         if (node == null) return null
 
         return when (node) {
             is GetForumCommentsQuery.ThreadComment -> {
+                if (node.user?.isBlocked == true) return null
                 val children =
                     (node.childComments as? List<*>)?.mapNotNull { mapToForumComment(it) }
                         ?: emptyList()
@@ -390,6 +395,7 @@ class ForumRepositoryImpl @Inject constructor(
             is Map<*, *> -> {
                 val userMap = node["user"] as? Map<*, *>
                 val avatarMap = userMap?.get("avatar") as? Map<*, *>
+                if (userMap?.get("isBlocked") == true) return null
                 val children =
                     (node["childComments"] as? List<*>)?.mapNotNull { mapToForumComment(it) }
                         ?: emptyList()
@@ -578,7 +584,9 @@ class ForumRepositoryImpl @Inject constructor(
                     subscribed = Optional.present(true)
                 )
             ).fetchPolicy(FetchPolicy.NetworkOnly).execute()
-            val threads = response.data?.Page?.threads?.filterNotNull()?.map { it.toForumThread() }
+            val threads = response.data?.Page?.threads?.filterNotNull()
+                ?.filterNot { it.user?.isBlocked == true }
+                ?.map { it.toForumThread() }
                 ?: emptyList()
             PaginatedResult(
                 items = threads,

--- a/app/src/main/java/com/anisync/android/data/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/NotificationRepositoryImpl.kt
@@ -94,7 +94,7 @@ class NotificationRepositoryImpl @Inject constructor(
             .execute()
 
             val pageData = response.data?.Page
-            val items = pageData?.notifications?.filterNotNull()?.mapNotNull { mapNotification(it) } ?: emptyList()
+            val items = pageData?.notifications?.filterNotNull()?.filterNot { it.actorIsBlocked() }?.mapNotNull { mapNotification(it) } ?: emptyList()
             val info = pageData?.pageInfo
             NotificationPage(
                 items = items,
@@ -140,6 +140,25 @@ class NotificationRepositoryImpl @Inject constructor(
     }
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")
+    /**
+     * True when this notification was triggered by a user the viewer has blocked on AniList, so it
+     * can be hidden (issue #76). Driven by the per-actor `User.isBlocked` flag; media/airing
+     * notifications have no actor and are never blocked.
+     */
+    private fun GetNotificationsQuery.Notification.actorIsBlocked(): Boolean =
+        onFollowingNotification?.user?.isBlocked == true ||
+            onActivityLikeNotification?.user?.isBlocked == true ||
+            onActivityReplyNotification?.user?.isBlocked == true ||
+            onActivityReplySubscribedNotification?.user?.isBlocked == true ||
+            onActivityReplyLikeNotification?.user?.isBlocked == true ||
+            onActivityMentionNotification?.user?.isBlocked == true ||
+            onActivityMessageNotification?.user?.isBlocked == true ||
+            onThreadCommentReplyNotification?.user?.isBlocked == true ||
+            onThreadCommentSubscribedNotification?.user?.isBlocked == true ||
+            onThreadCommentMentionNotification?.user?.isBlocked == true ||
+            onThreadLikeNotification?.user?.isBlocked == true ||
+            onThreadCommentLikeNotification?.user?.isBlocked == true
+
     private fun mapNotification(notification: GetNotificationsQuery.Notification): Notification? {
         return when {
             notification.onAiringNotification != null -> {


### PR DESCRIPTION
## What

Closes #76. AniList's website removes users you've blocked from social surfaces; AniSync still showed their activities, comments, and notifications. This reads AniList's per-user `User.isBlocked` flag and filters those authors out.

## Where it hides blocked users

- **Feed** — activities authored by a blocked user (or, for messages, the other party)
- **Forum** — threads and comments (incl. nested replies)
- **Notifications** — any notification whose actor is blocked
- **Activity detail** — the activity itself + its replies

## Design note

`isBlocked` is an expensive per-user lookup, so it's selected **only on light/single-list queries** — added **inline on the feed query** rather than the shared `ActivityFields` fragment. Folding it into the heavy `GetFullUserProfile` (favourites + 4 activity lists + stats + viewer) or `GetUserSocialData` queries overruns AniList's query limit and nulls the whole response. Consequently a profile's **own activity tab and follower/following/threads/comments lists are intentionally left unfiltered**.

## Limitations

- "Users who blocked *you*" isn't detectable via the public API (no such field); relies on AniList's server-side filtering.
- `isBlocked` is eventually-consistent — right after blocking someone there's a few-seconds lag before they disappear, matching the website.

## Verification

- `./gradlew assembleStableDebug testStableDebugUnitTest` — green
- On-device: profile/feed/forum load correctly; `User.isBlocked` confirmed `true` for a website-blocked user via GraphQL Studio.