### PR TITLE
feat(security): add app lock via biometric or device credential

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -274,6 +274,7 @@ dependencies {
     implementation(libs.kotlinx.collections.immutable)
     implementation(libs.reorderable)
     implementation(libs.okhttp)
+    implementation(libs.androidx.biometric)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/anisync/android/AniSyncApplication.kt
+++ b/app/src/main/java/com/anisync/android/AniSyncApplication.kt
@@ -37,6 +37,9 @@ class AniSyncApplication : Application(), Configuration.Provider, ImageLoaderFac
     @Inject
     lateinit var userOptionsSyncManager: com.anisync.android.data.UserOptionsSyncManager
 
+    @Inject
+    lateinit var appLockManager: com.anisync.android.data.security.AppLockManager
+
     private val applicationScope = CoroutineScope(
         SupervisorJob() + CoroutineExceptionHandler { _, throwable ->
             Log.e("AniSyncApp", "Unhandled coroutine exception", throwable)
@@ -62,6 +65,10 @@ class AniSyncApplication : Application(), Configuration.Provider, ImageLoaderFac
         AppCompatDelegate.setDefaultNightMode(AppSettings.persistedNightMode(this))
 
         installCrashHandler()
+
+        // App lock: observe app-level background/foreground so the lock re-arms when AniSync is sent
+        // to the background. Registered here (main thread, once) rather than per-activity.
+        appLockManager.bindTo(androidx.lifecycle.ProcessLifecycleOwner.get().lifecycle)
 
         val mainThreadTime = measureTimeMillis {
             com.anisync.android.worker.NotificationChannels.createChannels(this)

--- a/app/src/main/java/com/anisync/android/MainActivity.kt
+++ b/app/src/main/java/com/anisync/android/MainActivity.kt
@@ -217,8 +217,8 @@ class MainActivity : AppCompatActivity() {
             // versions can't do both, so they keep screenshots and don't hide the recents preview.
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 lifecycleScope.launch {
-                    appLockManager.enabled.collect { locked ->
-                        setRecentsScreenshotEnabled(!locked)
+                    appLockManager.enabled.collect { lockEnabled ->
+                        setRecentsScreenshotEnabled(!lockEnabled)
                     }
                 }
             }

--- a/app/src/main/java/com/anisync/android/MainActivity.kt
+++ b/app/src/main/java/com/anisync/android/MainActivity.kt
@@ -117,6 +117,9 @@ class MainActivity : AppCompatActivity() {
     @Inject
     lateinit var userOptionsRepository: com.anisync.android.domain.UserOptionsRepository
 
+    @Inject
+    lateinit var appLockManager: com.anisync.android.data.security.AppLockManager
+
     private val _newIntents = MutableSharedFlow<Intent>(extraBufferCapacity = 4)
     val newIntents: SharedFlow<Intent> = _newIntents.asSharedFlow()
 
@@ -206,6 +209,17 @@ class MainActivity : AppCompatActivity() {
                         "PerfMetrics",
                         "Update check completed in ${updateCheckTime}ms via IO Thread"
                     )
+                }
+            }
+
+            // App lock: on Android 13+ keep AniSync's content out of the recents/app-switcher preview
+            // while the lock is on, without FLAG_SECURE — so in-app screenshots still work. Older
+            // versions can't do both, so they keep screenshots and don't hide the recents preview.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                lifecycleScope.launch {
+                    appLockManager.enabled.collect { locked ->
+                        setRecentsScreenshotEnabled(!locked)
+                    }
                 }
             }
 
@@ -391,6 +405,10 @@ class MainActivity : AppCompatActivity() {
                                         }
                                     )
                             )
+
+                            // App-lock privacy gate: drawn above the content AND the status-bar strip
+                            // so nothing shows while locked. No-op when the feature is off/unlocked.
+                            com.anisync.android.presentation.security.AppLockGate(appLockManager)
                           }
                           }
                         }

--- a/app/src/main/java/com/anisync/android/data/AppSettings.kt
+++ b/app/src/main/java/com/anisync/android/data/AppSettings.kt
@@ -172,6 +172,11 @@ class AppSettings @Inject constructor(
     private val _hapticEnabled = MutableStateFlow(prefs.getBoolean(KEY_HAPTIC_ENABLED, true))
     val hapticEnabled: StateFlow<Boolean> = _hapticEnabled.asStateFlow()
 
+    // App lock: require the device screen lock (biometric or PIN/pattern/password) to open the app.
+    // Device-local privacy toggle; default off.
+    private val _appLockEnabled = MutableStateFlow(prefs.getBoolean(KEY_APP_LOCK_ENABLED, false))
+    val appLockEnabled: StateFlow<Boolean> = _appLockEnabled.asStateFlow()
+
     // Navigation bar style (anchored rounded top vs floating pill)
     private val _navBarStyle = MutableStateFlow(readNavBarStyle())
     val navBarStyle: StateFlow<NavBarStyle> = _navBarStyle.asStateFlow()
@@ -602,6 +607,12 @@ class AppSettings @Inject constructor(
     fun setHapticEnabled(enabled: Boolean) {
         _hapticEnabled.value = enabled
         prefs.edit().putBoolean(KEY_HAPTIC_ENABLED, enabled).apply()
+    }
+
+    /** Enable or disable the app lock (device screen-lock gate). */
+    fun setAppLockEnabled(enabled: Boolean) {
+        _appLockEnabled.value = enabled
+        prefs.edit().putBoolean(KEY_APP_LOCK_ENABLED, enabled).apply()
     }
 
     fun setNavBarStyle(style: NavBarStyle) {
@@ -1044,6 +1055,7 @@ companion object {
         private const val KEY_AMOLED_ENABLED = "amoled_enabled"
         private const val KEY_AVATAR_SHAPE = "avatar_shape"
         private const val KEY_HAPTIC_ENABLED = "haptic_enabled"
+        private const val KEY_APP_LOCK_ENABLED = "app_lock_enabled"
         private const val KEY_NAV_BAR_STYLE = "nav_bar_style"
         private const val KEY_NAV_BAR_LABELS = "nav_bar_show_labels"
         private const val KEY_NAV_BAR_CORNER_RADIUS = "nav_bar_corner_radius"

--- a/app/src/main/java/com/anisync/android/data/security/AppLockManager.kt
+++ b/app/src/main/java/com/anisync/android/data/security/AppLockManager.kt
@@ -1,0 +1,53 @@
+package com.anisync.android.data.security
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import com.anisync.android.data.AppSettings
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Holds the app-lock state: whether the app is currently locked and must be unlocked before its
+ * content is shown. Device-local privacy gate — no encryption, it only decides UI visibility.
+ *
+ * Lock lifecycle:
+ *  - **Cold start**: [locked] starts at [AppSettings.appLockEnabled]'s value, so a fresh process is
+ *    locked whenever the feature is on.
+ *  - **Background → foreground**: [onStop] re-arms the lock when the whole app is backgrounded, so
+ *    returning to it requires authentication again.
+ *  - The system credential/biometric prompt is a separate activity that drives the app through
+ *    ON_STOP/ON_START itself; [isAuthenticating] suppresses the re-arm during that round trip so the
+ *    prompt isn't fighting a lock underneath it.
+ */
+@Singleton
+class AppLockManager @Inject constructor(
+    private val appSettings: AppSettings,
+) : DefaultLifecycleObserver {
+
+    private val _locked = MutableStateFlow(appSettings.appLockEnabled.value)
+    val locked: StateFlow<Boolean> = _locked.asStateFlow()
+
+    /** Mirrors the persisted toggle, so the gate can react without touching [AppSettings] directly. */
+    val enabled: StateFlow<Boolean> = appSettings.appLockEnabled
+
+    @Volatile
+    var isAuthenticating: Boolean = false
+
+    /** Registers the app-level background/foreground observer. Call once from the Application. */
+    fun bindTo(processLifecycle: Lifecycle) {
+        processLifecycle.addObserver(this)
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        if (enabled.value && !isAuthenticating) _locked.value = true
+    }
+
+    /** Marks the app unlocked for this foreground session (called after a successful auth). */
+    fun unlock() {
+        _locked.value = false
+    }
+}

--- a/app/src/main/java/com/anisync/android/data/security/AppLockManager.kt
+++ b/app/src/main/java/com/anisync/android/data/security/AppLockManager.kt
@@ -20,8 +20,8 @@ import javax.inject.Singleton
  *  - **Background → foreground**: [onStop] re-arms the lock when the whole app is backgrounded, so
  *    returning to it requires authentication again.
  *  - The system credential/biometric prompt is a separate activity that drives the app through
- *    ON_STOP/ON_START itself; [isAuthenticating] suppresses the re-arm during that round trip so the
- *    prompt isn't fighting a lock underneath it.
+ *    ON_STOP/ON_START itself; the [onUnlockStarted]/[onUnlockDismissed] window suppresses the re-arm
+ *    during that round trip so the prompt isn't fighting a lock underneath it.
  */
 @Singleton
 class AppLockManager @Inject constructor(
@@ -35,7 +35,7 @@ class AppLockManager @Inject constructor(
     val enabled: StateFlow<Boolean> = appSettings.appLockEnabled
 
     @Volatile
-    var isAuthenticating: Boolean = false
+    private var authInProgress = false
 
     /** Registers the app-level background/foreground observer. Call once from the Application. */
     fun bindTo(processLifecycle: Lifecycle) {
@@ -43,11 +43,22 @@ class AppLockManager @Inject constructor(
     }
 
     override fun onStop(owner: LifecycleOwner) {
-        if (enabled.value && !isAuthenticating) _locked.value = true
+        if (enabled.value && !authInProgress) _locked.value = true
     }
 
-    /** Marks the app unlocked for this foreground session (called after a successful auth). */
+    /** The unlock prompt is being shown — pause the background re-arm until it resolves. */
+    fun onUnlockStarted() {
+        authInProgress = true
+    }
+
+    /** Authentication succeeded: clear the lock for this foreground session. */
     fun unlock() {
+        authInProgress = false
         _locked.value = false
+    }
+
+    /** The prompt was dismissed or errored without unlocking; the gate stays up. */
+    fun onUnlockDismissed() {
+        authInProgress = false
     }
 }

--- a/app/src/main/java/com/anisync/android/presentation/security/AppLockAuthenticator.kt
+++ b/app/src/main/java/com/anisync/android/presentation/security/AppLockAuthenticator.kt
@@ -1,0 +1,70 @@
+package com.anisync.android.presentation.security
+
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricManager.Authenticators
+import androidx.biometric.BiometricPrompt
+import androidx.biometric.auth.AuthPromptCallback
+import androidx.biometric.auth.startClass2BiometricOrCredentialAuthentication
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+
+/**
+ * Thin wrapper over AndroidX Biometric that authenticates the user with **whatever screen lock the
+ * phone already uses** — a Class 2 (weak) biometric *or* the device credential (PIN / pattern /
+ * password). The system UI picks the method and enforces its own rules; we never store or verify
+ * anything ourselves. Modelled on Mihon's app-lock helper.
+ */
+object AppLockAuthenticator {
+
+    /** Class-2 biometric OR device credential — i.e. any lock the user has set up. */
+    private val authenticators = Authenticators.BIOMETRIC_WEAK or Authenticators.DEVICE_CREDENTIAL
+
+    /** True when a usable screen lock exists (a biometric is enrolled, or a PIN/pattern/password). */
+    fun Context.isAppLockSupported(): Boolean =
+        BiometricManager.from(this).canAuthenticate(authenticators) == BiometricManager.BIOMETRIC_SUCCESS
+
+    /**
+     * Shows the system unlock prompt. [onSuccess] fires once the user proves it's them; [onError]
+     * fires on an unrecoverable error or when they dismiss it (per-attempt failures are handled by
+     * the system UI and don't call back here).
+     */
+    fun FragmentActivity.authenticateForAppLock(
+        title: String,
+        subtitle: String?,
+        onSuccess: () -> Unit,
+        onError: (CharSequence) -> Unit,
+    ) {
+        startClass2BiometricOrCredentialAuthentication(
+            title = title,
+            subtitle = subtitle,
+            // The prompt itself already stands between the user and the app; a second confirmation tap
+            // after a passive face/fingerprint match just adds friction, so skip it.
+            confirmationRequired = false,
+            executor = ContextCompat.getMainExecutor(this),
+            callback = object : AuthPromptCallback() {
+                override fun onAuthenticationSucceeded(
+                    activity: FragmentActivity?,
+                    result: BiometricPrompt.AuthenticationResult,
+                ) = onSuccess()
+
+                override fun onAuthenticationError(
+                    activity: FragmentActivity?,
+                    errorCode: Int,
+                    errString: CharSequence,
+                ) = onError(errString)
+            },
+        )
+    }
+}
+
+/** Unwraps the [FragmentActivity] backing a Compose [Context], or null if there isn't one. */
+fun Context.findFragmentActivity(): FragmentActivity? {
+    var context = this
+    while (context is ContextWrapper) {
+        if (context is FragmentActivity) return context
+        context = context.baseContext
+    }
+    return null
+}

--- a/app/src/main/java/com/anisync/android/presentation/security/AppLockGate.kt
+++ b/app/src/main/java/com/anisync/android/presentation/security/AppLockGate.kt
@@ -1,5 +1,6 @@
 package com.anisync.android.presentation.security
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -53,6 +54,10 @@ fun AppLockGate(
     val context = LocalContext.current
     val activity = remember(context) { context.findFragmentActivity() }
 
+    // Swallow Back while locked so it can't drive the hidden UI underneath; send the app to the
+    // background instead, the way a real lock screen behaves.
+    BackHandler { activity?.moveTaskToBack(true) }
+
     fun prompt() {
         // Fail open: if we can't resolve the host activity, or the device lock was removed while we
         // were away, never trap the user behind a lock they can't clear.
@@ -61,18 +66,14 @@ fun AppLockGate(
             appLockManager.unlock()
             return
         }
-        // No re-entrancy guard here: the system dialog owns focus while it's up, so this only ever
-        // fires when nothing is showing (auto-launch on appear, or a tap on the Unlock button). The
-        // flag purely tells AppLockManager not to re-arm the lock during the prompt's own ON_STOP.
-        appLockManager.isAuthenticating = true
+        // No re-entrancy guard: the system dialog owns focus while it's up, so this only ever fires
+        // when nothing is showing (auto-launch on appear, or a tap on the Unlock button).
+        appLockManager.onUnlockStarted()
         host.authenticateForAppLock(
             title = context.getString(R.string.app_lock_title),
             subtitle = context.getString(R.string.app_lock_subtitle),
-            onSuccess = {
-                appLockManager.isAuthenticating = false
-                appLockManager.unlock()
-            },
-            onError = { appLockManager.isAuthenticating = false },
+            onSuccess = { appLockManager.unlock() },
+            onError = { appLockManager.onUnlockDismissed() },
         )
     }
 

--- a/app/src/main/java/com/anisync/android/presentation/security/AppLockScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/security/AppLockScreen.kt
@@ -1,0 +1,138 @@
+package com.anisync.android.presentation.security
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Lock
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.anisync.android.R
+import com.anisync.android.data.security.AppLockManager
+import com.anisync.android.presentation.security.AppLockAuthenticator.authenticateForAppLock
+import com.anisync.android.presentation.security.AppLockAuthenticator.isAppLockSupported
+
+/**
+ * Full-screen privacy gate drawn on top of everything while the app is locked. It hides the app
+ * content and auto-launches the system unlock prompt. Renders nothing when the feature is off or
+ * already unlocked. (Keeping the app out of the recents preview is handled separately in
+ * [com.anisync.android.MainActivity] via `setRecentsScreenshotEnabled` on Android 13+.)
+ */
+@Composable
+fun AppLockGate(
+    appLockManager: AppLockManager,
+    modifier: Modifier = Modifier,
+) {
+    // Plain collectAsState (not lifecycle-aware) so the lock state stays current while the app is
+    // stopped: ProcessLifecycleOwner flips `locked` true ~700ms into the background, and we need the
+    // gate on the FIRST resumed frame — otherwise the last screen shows, frozen, until the gate lands.
+    val enabled by appLockManager.enabled.collectAsState()
+    val locked by appLockManager.locked.collectAsState()
+    if (!enabled || !locked) return
+
+    val context = LocalContext.current
+    val activity = remember(context) { context.findFragmentActivity() }
+
+    fun prompt() {
+        // Fail open: if we can't resolve the host activity, or the device lock was removed while we
+        // were away, never trap the user behind a lock they can't clear.
+        val host = activity
+        if (host == null || !context.isAppLockSupported()) {
+            appLockManager.unlock()
+            return
+        }
+        // No re-entrancy guard here: the system dialog owns focus while it's up, so this only ever
+        // fires when nothing is showing (auto-launch on appear, or a tap on the Unlock button). The
+        // flag purely tells AppLockManager not to re-arm the lock during the prompt's own ON_STOP.
+        appLockManager.isAuthenticating = true
+        host.authenticateForAppLock(
+            title = context.getString(R.string.app_lock_title),
+            subtitle = context.getString(R.string.app_lock_subtitle),
+            onSuccess = {
+                appLockManager.isAuthenticating = false
+                appLockManager.unlock()
+            },
+            onError = { appLockManager.isAuthenticating = false },
+        )
+    }
+
+    // Auto-prompt once when the gate first appears (i.e. each time the app locks).
+    LaunchedEffect(Unit) { prompt() }
+
+    Surface(
+        modifier = modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(96.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.secondaryContainer),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Lock,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                    modifier = Modifier.size(44.dp),
+                )
+            }
+
+            Text(
+                text = stringResource(R.string.app_name),
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.padding(top = 24.dp),
+            )
+            Text(
+                text = stringResource(R.string.app_lock_message),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+
+            Button(
+                onClick = { prompt() },
+                modifier = Modifier.padding(top = 32.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Lock,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Text(
+                    text = stringResource(R.string.app_lock_unlock),
+                    modifier = Modifier.padding(start = 8.dp),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/anisync/android/presentation/settings/LookAndFeelScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/LookAndFeelScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.automirrored.filled.Label
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.Face
 import androidx.compose.material.icons.filled.HighQuality
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Navigation
 import androidx.compose.material.icons.filled.PlayCircle
 import androidx.compose.material.icons.filled.RoundedCorner
@@ -94,6 +95,7 @@ fun LookAndFeelScreen(
     val themeMode = uiState.themeMode
     val preferredStreamingService = uiState.preferredStreamingService
     val hapticEnabled = uiState.hapticEnabled
+    val appLockEnabled = uiState.appLockEnabled
     val appLocale = uiState.appLocale
     val coverQuality = uiState.coverQuality
     val navBarStyle = uiState.navBarStyle
@@ -241,6 +243,18 @@ fun LookAndFeelScreen(
             )
             // "Show adult content" now lives under Settings ▸ AniList Account, where it follows the
             // AniList account option by default and can be overridden per device.
+        }
+
+        SettingsGroup {
+            // Privacy: gate the app behind the device's own screen lock (biometric or PIN/pattern/
+            // password). The toggle is refused in the ViewModel when no screen lock is set up.
+            SwitchSettingsItem(
+                icon = Icons.Default.Lock,
+                title = stringResource(R.string.settings_app_lock),
+                subtitle = stringResource(R.string.settings_app_lock_desc),
+                checked = appLockEnabled,
+                onCheckedChange = { viewModel.onAction(SettingsAction.SetAppLockEnabled(it)) }
+            )
         }
     }
 }

--- a/app/src/main/java/com/anisync/android/presentation/settings/SettingsUiState.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/SettingsUiState.kt
@@ -20,6 +20,7 @@ sealed interface SettingsAction {
     data class SetTitleLanguage(val language: TitleLanguage) : SettingsAction
     data class SetCoverQuality(val quality: CoverQuality) : SettingsAction
     data class SetHapticEnabled(val enabled: Boolean) : SettingsAction
+    data class SetAppLockEnabled(val enabled: Boolean) : SettingsAction
     data class SetNavBarStyle(val style: NavBarStyle) : SettingsAction
     data class SetNavBarShowLabels(val show: Boolean) : SettingsAction
     data class SetNavBarCornerRadius(val radius: Float) : SettingsAction
@@ -113,6 +114,7 @@ data class SettingsUiState(
     val titleLanguage: TitleLanguage = TitleLanguage.ROMAJI,
     val coverQuality: CoverQuality = CoverQuality.LARGE,
     val hapticEnabled: Boolean = true,
+    val appLockEnabled: Boolean = false,
     val navBarStyle: NavBarStyle = NavBarStyle.ANCHORED,
     val navBarShowLabels: Boolean = true,
     val navBarCornerRadius: Float = 28f,

--- a/app/src/main/java/com/anisync/android/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/SettingsViewModel.kt
@@ -19,6 +19,7 @@ import com.anisync.android.domain.GetProfileUseCase
 import com.anisync.android.domain.UserProfile
 import com.anisync.android.presentation.components.alert.ToastManager
 import com.anisync.android.presentation.components.alert.ToastType
+import com.anisync.android.presentation.security.AppLockAuthenticator.isAppLockSupported
 import com.anisync.android.ui.theme.FontAxisOverrides
 import com.anisync.android.worker.NotificationDebugService
 import com.anisync.android.worker.NotificationScheduler
@@ -207,8 +208,9 @@ class SettingsViewModel @Inject constructor(
         coreUiState,
         fontPlaygroundFlow,
         appSettings.amoledEnabled,
-    ) { core, fontPlayground, amoled ->
-        core.copy(fontPlayground = fontPlayground, amoledEnabled = amoled)
+        appSettings.appLockEnabled,
+    ) { core, fontPlayground, amoled, appLock ->
+        core.copy(fontPlayground = fontPlayground, amoledEnabled = amoled, appLockEnabled = appLock)
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5000),
@@ -222,6 +224,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsAction.SetTitleLanguage -> appSettings.setTitleLanguage(action.language)
             is SettingsAction.SetCoverQuality -> appSettings.setCoverQuality(action.quality)
             is SettingsAction.SetHapticEnabled -> appSettings.setHapticEnabled(action.enabled)
+            is SettingsAction.SetAppLockEnabled -> setAppLockEnabled(action.enabled)
             is SettingsAction.SetNavBarStyle -> appSettings.setNavBarStyle(action.style)
             is SettingsAction.SetNavBarShowLabels -> appSettings.setNavBarShowLabels(action.show)
             is SettingsAction.SetNavBarCornerRadius -> appSettings.setNavBarCornerRadius(action.radius)
@@ -377,6 +380,18 @@ class SettingsViewModel @Inject constructor(
             LocaleListCompat.forLanguageTags(locale.tag)
         }
         AppCompatDelegate.setApplicationLocales(localeList)
+    }
+
+    /**
+     * Turns the app lock on/off. Refuses to enable it when the device has no usable screen lock —
+     * without one there'd be no way to authenticate, which would lock the user out of their own app.
+     */
+    private fun setAppLockEnabled(enabled: Boolean) {
+        if (enabled && !context.isAppLockSupported()) {
+            Toast.makeText(context, R.string.app_lock_unavailable, Toast.LENGTH_LONG).show()
+            return
+        }
+        appSettings.setAppLockEnabled(enabled)
     }
 
     private fun toggleNotifications(enabled: Boolean) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -340,6 +340,15 @@
     <string name="navigate_back">Go back</string>
     <string name="settings_look_and_feel">Look and Feel</string>
     <string name="settings_look_and_feel_desc">Theme, language, streaming service</string>
+
+    <!-- App lock (biometric / device credential) -->
+    <string name="settings_app_lock">App lock</string>
+    <string name="settings_app_lock_desc">Require your fingerprint, face, or screen lock to open AniSync</string>
+    <string name="app_lock_title">Unlock AniSync</string>
+    <string name="app_lock_subtitle">Verify it\'s you to continue</string>
+    <string name="app_lock_message">AniSync is locked</string>
+    <string name="app_lock_unlock">Unlock</string>
+    <string name="app_lock_unavailable">Set up a screen lock (PIN, pattern, password, or biometrics) in your device settings first</string>
     <string name="settings_anilist_account">AniList Settings</string>
     <string name="settings_anilist_account_desc">Accounts, adult content, languages, score format</string>
     <string name="settings_notifications">Notifications</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ runtime = "1.11.0"
 appcompat = "1.7.1"
 reorderable = "3.1.0"
 okhttp = "4.12.0"
+biometric = "1.2.0-alpha05"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -96,6 +97,7 @@ media3-datasource-okhttp = { group = "androidx.media3", name = "media3-datasourc
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+androidx-biometric = { group = "androidx.biometric", name = "biometric-ktx", version.ref = "biometric" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Adds an optional app lock (#86): gates AniSync behind the device's own screen lock — a Class 2 biometric or the PIN/pattern/password — via AndroidX Biometric. No app-managed secrets; the system UI picks the method and enforces its own rules.

## Behaviour
- Toggle under Settings > Look and Feel. Refused when no screen lock is set up; fails open if the lock is later removed, so the user is never trapped out.
- Locks on cold start and on return from background (`ProcessLifecycleOwner`, so rotation doesn't re-lock).
- Android 13+ hides the recents/app-switcher preview via `setRecentsScreenshotEnabled` without `FLAG_SECURE`, so in-app screenshots still work; older versions keep screenshots and show the preview.
- Back on the lock screen sends the app to the background instead of driving the hidden UI underneath.

## Notes
- Modelled on Mihon's app-lock helper. New dependency: `androidx.biometric:biometric-ktx`.
- Verified on-device (Android 12): biometric + PIN unlock, cold start, background/return, Unlock button, Back behaviour.

Closes #86
