### PR TITLE
feat(share): shareable cards for media, stats, reviews and favourites

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -275,6 +275,7 @@ dependencies {
     implementation(libs.reorderable)
     implementation(libs.okhttp)
     implementation(libs.androidx.biometric)
+    implementation(libs.capturable)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
@@ -130,7 +130,6 @@ import com.anisync.android.domain.ForumThread
 import com.anisync.android.domain.LibraryStatus
 import com.anisync.android.domain.MediaDetails
 import com.anisync.android.domain.MediaFollowingEntry
-import com.anisync.android.domain.MediaReview
 import com.anisync.android.domain.url
 import com.anisync.android.presentation.components.AnimatedFavoriteButton
 import com.anisync.android.presentation.components.CustomPullToRefreshIndicator
@@ -154,7 +153,6 @@ import com.anisync.android.presentation.details.components.UserNotesCard
 import com.anisync.android.presentation.details.components.RecommendMediaSheet
 import com.anisync.android.presentation.details.components.RecommendationItem
 import com.anisync.android.presentation.details.components.RelationItem
-import com.anisync.android.presentation.details.components.ReviewDetailsSheet
 import com.anisync.android.presentation.details.components.ReviewsListSheet
 import com.anisync.android.presentation.details.components.StaffItem
 import com.anisync.android.presentation.details.components.mediaStatsTabContent
@@ -166,6 +164,9 @@ import com.anisync.android.presentation.util.rememberCopyToClipboard
 import com.anisync.android.presentation.util.rememberHapticFeedback
 import com.anisync.android.presentation.util.toIcon
 import com.anisync.android.presentation.util.toLabel
+import com.anisync.android.presentation.share.MediaShareCard
+import com.anisync.android.presentation.share.ShareImageSheet
+import com.anisync.android.util.AniListUrls
 import com.anisync.android.util.getTitle
 
 
@@ -186,6 +187,7 @@ fun MediaDetailsScreen(
     onRelatedSeeAllClick: (Int, String) -> Unit = { _, _ -> },
     onRecommendationsSeeAllClick: (Int, String) -> Unit = { _, _ -> },
     onWriteReviewClick: (Int, String) -> Unit = { _, _ -> },
+    onReviewClick: (Int) -> Unit = {},
     onDiscussionClick: (threadId: Int, threadTitle: String) -> Unit = { _, _ -> },
     onViewAllDiscussions: (mediaId: Int, mediaTitle: String) -> Unit = { _, _ -> },
     onStartDiscussion: (mediaId: Int, title: String, coverUrl: String?) -> Unit = { _, _, _ -> },
@@ -214,6 +216,7 @@ fun MediaDetailsScreen(
     val spatialSpec = AppMotion.rememberSpatialSpec()
     val containerKey = TransitionKeys.container(sourceScreen, mediaId)
     var fabMenuExpanded by rememberSaveable { mutableStateOf(false) }
+    var showShareImageSheet by rememberSaveable { mutableStateOf(false) }
     val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     // Hoisted to the screen (alongside listState) so the selected tab survives a character/staff
     // round-trip. When the details content flashes through Loading on re-entry (the cached flow
@@ -663,6 +666,11 @@ fun MediaDetailsScreen(
                                         state.details.getTitle(titleLanguage)
                                     )
                                 },
+                                onReviewClick = { reviewId ->
+                                    shouldKeepChromeOverlayForReturn = true
+                                    hasObservedDetailsReEnter = false
+                                    onReviewClick(reviewId)
+                                },
                                 onEditNotes = viewModel::openEditSheet,
                                 discussions = discussions,
                                 onDiscussionClick = { threadId, threadTitle ->
@@ -688,8 +696,7 @@ fun MediaDetailsScreen(
                                 onRecommendMedia = viewModel::recommendMedia,
                                 onUserClick = onUserClick,
                                 onFavouriteClick = viewModel::toggleFavourite,
-                                onShareClick = { viewModel.shareMedia(context) },
-                                onRateReview = viewModel::rateReview,
+                                onShareClick = { showShareImageSheet = true },
                                 onRateRecommendation = viewModel::rateRecommendation,
                                 sharedTransitionScope = sharedTransitionScope,
                                 animatedVisibilityScope = animatedVisibilityScope,
@@ -739,6 +746,17 @@ fun MediaDetailsScreen(
                         viewModel.closeEditSheet()
                     }
                 )
+            }
+        }
+
+        if (showShareImageSheet) {
+            (uiState as? DetailsUiState.Success)?.details?.let { details ->
+                ShareImageSheet(
+                    onDismiss = { showShareImageSheet = false },
+                    caption = AniListUrls.mediaUrl(details.id, details.type)
+                ) {
+                    MediaShareCard(details = details)
+                }
             }
         }
     }
@@ -939,6 +957,7 @@ fun DetailsPageContent(
     onRelatedSeeAllClick: () -> Unit,
     onRecommendationsSeeAllClick: () -> Unit,
     onWriteReviewClick: () -> Unit,
+    onReviewClick: (Int) -> Unit,
     onEditNotes: () -> Unit,
     discussions: List<ForumThread>,
     onDiscussionClick: (Int, String) -> Unit,
@@ -948,7 +967,6 @@ fun DetailsPageContent(
     onUserClick: (String) -> Unit,
     onFavouriteClick: () -> Unit,
     onShareClick: () -> Unit,
-    onRateReview: (Int, com.anisync.android.type.ReviewRating) -> Unit,
     onRateRecommendation: (Int, com.anisync.android.type.RecommendationRating) -> Unit,
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedVisibilityScope,
@@ -986,7 +1004,6 @@ fun DetailsPageContent(
         listOfNotNull(details.coverUrl, details.bannerUrl)
     }
 
-    var selectedReview by remember { mutableStateOf<MediaReview?>(null) }
     var showAllReviewsSheet by remember { mutableStateOf(false) }
     var showAllFollowingSheet by remember { mutableStateOf(false) }
     var showRecommendSheet by remember { mutableStateOf(false) }
@@ -1433,7 +1450,7 @@ fun DetailsPageContent(
                         ) { review ->
                             ReviewCard(
                                 review = review,
-                                onClick = { selectedReview = review },
+                                onClick = { onReviewClick(review.id) },
                                 onUserClick = onUserClick,
                                 showBanner = false,
                                 modifier = Modifier
@@ -1510,55 +1527,6 @@ fun DetailsPageContent(
         }
     }
 
-    // Sync selectedReview with the latest data from details.reviews when API refreshed
-    LaunchedEffect(details.reviews) {
-        selectedReview?.let { current ->
-            val updated = details.reviews.find { it.id == current.id }
-            if (updated != null && updated != current) {
-                selectedReview = updated
-            }
-        }
-    }
-
-    selectedReview?.let { review ->
-        ReviewDetailsSheet(
-            review = review,
-            onRateReview = { reviewId, rating ->
-                onRateReview(reviewId, rating)
-                // Optimistic UI update
-                val oldRating = review.userRating
-                val newRatingStr = if (rating.name == "NO_VOTE") null else rating.name
-
-                var updatedRating = review.rating
-                var updatedAmount = review.ratingAmount
-
-                // Remove old vote effect
-                when (oldRating) {
-                    "UP_VOTE" -> updatedRating -= 1
-                    "DOWN_VOTE" -> updatedRating += 1
-                }
-                // Remove old vote from total if transitioning to NO_VOTE
-                if (oldRating != null && newRatingStr == null) updatedAmount -= 1
-                // Add new vote to total if transitioning from NO_VOTE
-                if (oldRating == null && newRatingStr != null) updatedAmount += 1
-
-                // Add new vote effect
-                when (newRatingStr) {
-                    "UP_VOTE" -> updatedRating += 1
-                    "DOWN_VOTE" -> updatedRating -= 1
-                }
-
-                selectedReview = review.copy(
-                    userRating = newRatingStr,
-                    rating = updatedRating,
-                    ratingAmount = updatedAmount
-                )
-            },
-            onUserClick = onUserClick,
-            onDismiss = { selectedReview = null }
-        )
-    }
-
     if (showCharSortSheet) {
         SettingsPickerSheet(
             title = stringResource(R.string.sort),
@@ -1604,7 +1572,10 @@ fun DetailsPageContent(
         ReviewsListSheet(
             mediaId = details.id,
             onDismiss = { showAllReviewsSheet = false },
-            onReviewClick = { selectedReview = it },
+            onReviewClick = {
+                showAllReviewsSheet = false
+                onReviewClick(it.id)
+            },
             onUserClick = onUserClick
         )
     }

--- a/app/src/main/java/com/anisync/android/presentation/navigation/NavHost.kt
+++ b/app/src/main/java/com/anisync/android/presentation/navigation/NavHost.kt
@@ -574,6 +574,9 @@ fun AniSyncNavHost(
                     onWriteReviewClick = { mediaId, mediaTitle ->
                         navController.navigate(WriteReview(mediaId, mediaTitle))
                     },
+                    onReviewClick = { reviewId ->
+                        navController.navigate(ReviewDetail(reviewId, sourceScreen = "media_details"))
+                    },
                     onDiscussionClick = { threadId, threadTitle ->
                         navController.navigate(ForumThreadDetail(threadId, threadTitle))
                     },

--- a/app/src/main/java/com/anisync/android/presentation/profile/ProfileContent.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/ProfileContent.kt
@@ -4,12 +4,14 @@ import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
@@ -24,8 +26,10 @@ import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Tv
+import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -33,6 +37,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -60,6 +68,9 @@ import com.anisync.android.presentation.profile.sections.profileMediaTab
 import com.anisync.android.presentation.profile.sections.profileReviewsTab
 import com.anisync.android.presentation.profile.sections.profileSocialTab
 import com.anisync.android.presentation.profile.sections.profileStatsTab
+import com.anisync.android.presentation.share.FavouritesShareCard
+import com.anisync.android.presentation.share.ProfileStatsShareCard
+import com.anisync.android.presentation.share.ShareImageSheet
 import com.anisync.android.type.MediaType
 import com.anisync.android.util.ShareUtils
 
@@ -101,6 +112,10 @@ fun ProfileContent(
     // density and gain columns on wider windows; studio chips are wider so they start 2-up.
     val portraitColumns = profileGridColumns(baseMinSize = 150.dp)
     val studioColumns = profileGridColumns(baseMinSize = 240.dp, compactColumns = 2)
+
+    // Share-as-image sheets for the Stats and Favourites tabs, hosted at screen scope below.
+    var statsShareVisible by remember { mutableStateOf(false) }
+    var favouritesShareVisible by remember { mutableStateOf(false) }
 
     if (LocalAdaptiveInfo.current.supportsTwoPane) {
         ProfileWideLayout(
@@ -214,7 +229,10 @@ fun ProfileContent(
             onLastReplyClick = onLastReplyClick,
             portraitColumns = portraitColumns,
             studioColumns = studioColumns,
-            statsColumns = statsColumns
+            statsColumns = statsColumns,
+            showShareActions = true,
+            onShareStats = { statsShareVisible = true },
+            onShareFavourites = { favouritesShareVisible = true }
         )
     }
     }
@@ -227,6 +245,45 @@ fun ProfileContent(
                 onAction(ProfileAction.SetBiographySheetVisible(false))
             }
         )
+    }
+
+    val profileUrl = "https://anilist.co/user/${profile.name}"
+
+    if (statsShareVisible) {
+        uiState.statsData?.let { stats ->
+            ShareImageSheet(
+                onDismiss = { statsShareVisible = false },
+                caption = profileUrl
+            ) {
+                ProfileStatsShareCard(
+                    profile = profile,
+                    stats = stats,
+                    type = uiState.selectedStatsType
+                )
+            }
+        }
+    }
+
+    if (favouritesShareVisible) {
+        val isAnime = uiState.selectedFavoritesFilter == ProfileFavoritesFilter.ANIME
+        val entries = if (isAnime) profile.favoriteAnime else profile.favoriteMangaOverview
+        if (entries.isNotEmpty()) {
+            ShareImageSheet(
+                onDismiss = { favouritesShareVisible = false },
+                caption = profileUrl
+            ) {
+                FavouritesShareCard(
+                    heading = stringResource(
+                        if (isAnime) R.string.share_fav_heading_anime
+                        else R.string.share_fav_heading_manga
+                    ),
+                    eyebrow = stringResource(R.string.share_fav_eyebrow),
+                    entries = entries,
+                    bannerUrl = profile.bannerUrl,
+                    handle = profile.name
+                )
+            }
+        }
     }
 
     uiState.selectedReview?.let { review ->
@@ -302,7 +359,10 @@ internal fun LazyListScope.profileSelectedTabContent(
     onLastReplyClick: (activityId: Int, replyId: Int) -> Unit,
     portraitColumns: Int,
     studioColumns: Int,
-    statsColumns: Int
+    statsColumns: Int,
+    showShareActions: Boolean = false,
+    onShareStats: () -> Unit = {},
+    onShareFavourites: () -> Unit = {}
 ) {
     when (uiState.selectedTab) {
         ProfileTab.OVERVIEW -> {
@@ -394,6 +454,16 @@ internal fun LazyListScope.profileSelectedTabContent(
         }
 
         ProfileTab.FAVORITES -> {
+            val favShareable = when (uiState.selectedFavoritesFilter) {
+                ProfileFavoritesFilter.ANIME -> profile.favoriteAnime.isNotEmpty()
+                ProfileFavoritesFilter.MANGA -> profile.favoriteMangaOverview.isNotEmpty()
+                else -> false
+            }
+            if (showShareActions && favShareable) {
+                item(key = "favourites_share_action") {
+                    ShareTabAction(onClick = onShareFavourites)
+                }
+            }
             profileFavoritesTab(
                 profile = profile,
                 selectedFilter = uiState.selectedFavoritesFilter,
@@ -420,6 +490,11 @@ internal fun LazyListScope.profileSelectedTabContent(
         }
 
         ProfileTab.STATS -> {
+            if (showShareActions && uiState.statsData != null) {
+                item(key = "stats_share_action") {
+                    ShareTabAction(onClick = onShareStats)
+                }
+            }
             profileStatsTab(
                 uiState = uiState,
                 onStatsTypeSelected = { onAction(ProfileAction.SelectStatsType(it)) },
@@ -428,6 +503,27 @@ internal fun LazyListScope.profileSelectedTabContent(
                 onStudioClick = onStudioClick,
                 statsColumns = statsColumns
             )
+        }
+    }
+}
+
+/** Right-aligned "Share as image" affordance rendered above a shareable profile tab's content. */
+@Composable
+private fun ShareTabAction(onClick: () -> Unit, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, end = 16.dp, top = 12.dp),
+        horizontalArrangement = Arrangement.End
+    ) {
+        FilledTonalButton(onClick = onClick) {
+            Icon(
+                imageVector = Icons.Outlined.Image,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(stringResource(R.string.share_as_image))
         }
     }
 }

--- a/app/src/main/java/com/anisync/android/presentation/review/ReviewDetailScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/review/ReviewDetailScreen.kt
@@ -30,6 +30,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -52,6 +55,8 @@ import com.anisync.android.presentation.components.ReviewAuthorBar
 import com.anisync.android.presentation.components.ReviewScorePill
 import com.anisync.android.presentation.components.ReviewVoteActions
 import com.anisync.android.presentation.components.TranslateIconButton
+import com.anisync.android.presentation.share.ReviewShareCard
+import com.anisync.android.presentation.share.ShareImageSheet
 import com.anisync.android.presentation.util.AppMotion
 import com.anisync.android.presentation.util.TransitionKeys
 import com.anisync.android.ui.theme.emphasis
@@ -71,6 +76,7 @@ fun ReviewDetailScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    var showShareImage by remember { mutableStateOf(false) }
 
     LaunchedEffect(reviewId) { viewModel.load(reviewId) }
 
@@ -88,7 +94,8 @@ fun ReviewDetailScreen(
             )
             IconButton(
                 onClick = {
-                    ShareUtils.shareText(context, "https://anilist.co/review/$reviewId")
+                    if (uiState.review != null) showShareImage = true
+                    else ShareUtils.shareText(context, "https://anilist.co/review/$reviewId")
                 }
             ) {
                 Icon(
@@ -125,6 +132,15 @@ fun ReviewDetailScreen(
             uiState.review != null -> {
                 val review = uiState.review!!
                 val mediaId = uiState.mediaId
+
+                if (showShareImage) {
+                    ShareImageSheet(
+                        onDismiss = { showShareImage = false },
+                        caption = "https://anilist.co/review/$reviewId"
+                    ) {
+                        ReviewShareCard(review = review)
+                    }
+                }
 
                 Column(
                     modifier = Modifier

--- a/app/src/main/java/com/anisync/android/presentation/share/FavouritesShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/FavouritesShareCard.kt
@@ -1,0 +1,107 @@
+package com.anisync.android.presentation.share
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.anisync.android.domain.LibraryEntry
+import com.anisync.android.domain.url
+import com.anisync.android.ui.theme.LocalExpressiveTypography
+
+/**
+ * A "poster wall" share card: the viewer's top favourites as a 3-wide cover grid under a banner
+ * header. Built for the profile Favourites tab (anime / manga), it caps at six covers so the
+ * exported image stays a clean, legible tile — not a wall of thumbnails.
+ */
+@Composable
+fun FavouritesShareCard(
+    heading: String,
+    eyebrow: String,
+    entries: List<LibraryEntry>,
+    bannerUrl: String? = null,
+    handle: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    val expressive = LocalExpressiveTypography.current
+    val covers = entries.take(6)
+
+    ShareCardScaffold(modifier = modifier, handle = handle) {
+        ShareCardBannerBox(bannerUrl = bannerUrl, height = 92.dp, scrimAlpha = 0.78f) {
+            Column(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(16.dp)
+            ) {
+                Text(
+                    text = eyebrow.uppercase(),
+                    style = expressive.statLabel,
+                    color = Color.White.copy(alpha = 0.85f)
+                )
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = heading,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+
+        Column(modifier = Modifier.padding(16.dp)) {
+            covers.chunked(3).forEach { rowEntries ->
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(bottom = 10.dp),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    rowEntries.forEach { entry ->
+                        CoverTile(entry = entry, modifier = Modifier.weight(1f))
+                    }
+                    // Pad the final row so a lone cover keeps the same tile width.
+                    repeat(3 - rowEntries.size) { Spacer(Modifier.weight(1f)) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CoverTile(entry: LibraryEntry, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .aspectRatio(2f / 3f)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        val coverUrl = entry.coverUrl ?: entry.cover.url()
+        if (coverUrl != null) {
+            AsyncImage(
+                model = coverUrl,
+                contentDescription = entry.titleUserPreferred,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/anisync/android/presentation/share/MediaShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/MediaShareCard.kt
@@ -1,0 +1,331 @@
+package com.anisync.android.presentation.share
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.TrendingUp
+import androidx.compose.material.icons.filled.Business
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.anisync.android.R
+import com.anisync.android.domain.LibraryStatus
+import com.anisync.android.domain.MediaDetails
+import com.anisync.android.domain.url
+import com.anisync.android.presentation.util.formatCompactNumber
+import com.anisync.android.presentation.util.formatDecimal
+import com.anisync.android.type.MediaType
+import com.anisync.android.ui.theme.LocalExpressiveTypography
+
+/**
+ * Shareable card for a single media entry: banner with the title and community score, cover,
+ * studio, popularity/favourites, top genres, and an **adaptive** footer strip that reflects the
+ * viewer's own list state — progress while watching, a neutral count while planning/completed,
+ * or the media's release status (incl. upcoming/TBA) when it isn't on their list at all.
+ */
+@Composable
+fun MediaShareCard(
+    details: MediaDetails,
+    handle: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    val isManga = details.type == MediaType.MANGA
+    val coverUrl = details.coverUrl ?: details.cover.url()
+    val score = details.score
+    val accent = parseCoverColor(details.coverColor) ?: MaterialTheme.colorScheme.primary
+    val onAccent = if (accent.luminance() > 0.5f) Color.Black else Color.White
+
+    ShareCardScaffold(modifier = modifier, handle = handle) {
+        ShareCardBannerBox(
+            bannerUrl = details.bannerUrl ?: coverUrl,
+            height = 168.dp
+        ) {
+            if (score != null && score > 0) {
+                Row(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(14.dp)
+                        .clip(RoundedCornerShape(50))
+                        .background(accent)
+                        .padding(horizontal = 12.dp, vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Star,
+                        contentDescription = null,
+                        tint = onAccent,
+                        modifier = Modifier.size(14.dp)
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    // Out of 10 to match the app's own header star rating (85 → "8.5").
+                    Text(
+                        text = formatDecimal(score / 10.0),
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = onAccent
+                    )
+                }
+            }
+            Column(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(16.dp)
+            ) {
+                val meta = listOfNotNull(
+                    details.format,
+                    details.seasonYear?.toString() ?: details.year?.toString()
+                ).joinToString(" · ")
+                if (meta.isNotBlank()) {
+                    Text(
+                        text = meta.uppercase(),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = Color.White.copy(alpha = 0.85f),
+                        maxLines = 1
+                    )
+                    Spacer(Modifier.height(2.dp))
+                }
+                Text(
+                    text = details.titleUserPreferred,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(3.dp)
+                .background(accent)
+        )
+
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Row {
+                Box(
+                    modifier = Modifier
+                        .width(84.dp)
+                        .height(120.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                ) {
+                    if (coverUrl != null) {
+                        AsyncImage(
+                            model = coverUrl,
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    }
+                }
+                Spacer(Modifier.width(16.dp))
+                Column {
+                    val studioName = details.studio?.name ?: details.studios.firstOrNull()?.name
+                    if (!studioName.isNullOrBlank()) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                imageVector = Icons.Filled.Business,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(14.dp)
+                            )
+                            Spacer(Modifier.width(6.dp))
+                            Text(
+                                text = studioName,
+                                style = MaterialTheme.typography.labelLarge,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                        Spacer(Modifier.height(14.dp))
+                    }
+                    Row(horizontalArrangement = Arrangement.spacedBy(20.dp)) {
+                        details.popularity?.takeIf { it > 0 }?.let {
+                            MiniStat(
+                                icon = Icons.AutoMirrored.Filled.TrendingUp,
+                                value = formatCompactNumber(it),
+                                label = stringResource(R.string.share_media_popularity),
+                                accent = accent
+                            )
+                        }
+                        details.favourites?.takeIf { it > 0 }?.let {
+                            MiniStat(
+                                icon = Icons.Filled.Favorite,
+                                value = formatCompactNumber(it),
+                                label = stringResource(R.string.share_media_favourites),
+                                accent = accent
+                            )
+                        }
+                    }
+                }
+            }
+
+            val genres = details.genres.take(3)
+            if (genres.isNotEmpty()) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    genres.forEach { genre -> ShareChip(genre) }
+                }
+            }
+
+            MediaStatusStrip(details = details, isManga = isManga)
+        }
+    }
+}
+
+/** Icon + value + eyebrow, used for the popularity / favourites figures. */
+@Composable
+private fun MiniStat(icon: ImageVector, value: String, label: String, accent: Color) {
+    Column {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = accent,
+                modifier = Modifier.size(15.dp)
+            )
+            Spacer(Modifier.width(4.dp))
+            Text(
+                text = value,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+        Text(
+            text = label.uppercase(),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+/**
+ * The adaptive footer strip. Left is the headline (viewer's list status when tracked, else the
+ * media's release status); right is the fitting detail (progress, a neutral count, airing episode,
+ * or a release year / TBA). Never shows "0 / 25" for a planned-but-unstarted entry.
+ */
+@Composable
+private fun MediaStatusStrip(details: MediaDetails, isManga: Boolean) {
+    val status = details.listStatus
+    val onList = status != null && status != LibraryStatus.UNKNOWN
+    val total = if (isManga) details.chapters else details.episodes
+    val unit = stringResource(if (isManga) R.string.share_media_chapters else R.string.share_media_episodes)
+
+    val leftLabel: String
+    val rightText: String?
+    if (onList) {
+        // The viewer's own tracked status — a filled, coloured pill.
+        leftLabel = stringResource(listStatusLabel(status!!, isManga))
+        val progress = details.listProgress ?: 0
+        rightText = when (status) {
+            LibraryStatus.CURRENT, LibraryStatus.REPEATING, LibraryStatus.PAUSED, LibraryStatus.DROPPED ->
+                "$progress / ${total?.toString() ?: "?"} $unit"
+            LibraryStatus.COMPLETED, LibraryStatus.PLANNING ->
+                total?.takeIf { it > 0 }?.let { "$it $unit" }
+            else -> null
+        }
+    } else {
+        // Not on the viewer's list — the show's own airing state, worded and styled so it never
+        // reads as a personal "Completed"/tracked status.
+        leftLabel = stringResource(mediaReleaseLabel(details.status))
+        rightText = when (details.status) {
+            "FINISHED" -> total?.takeIf { it > 0 }?.let { "$it $unit" }
+            "RELEASING" -> details.nextAiringEpisode?.let {
+                stringResource(R.string.share_media_ep_number, it.episode)
+            } ?: total?.takeIf { it > 0 }?.let { "$it $unit" }
+            "NOT_YET_RELEASED" ->
+                (details.seasonYear ?: details.year)?.toString() ?: stringResource(R.string.share_media_tba)
+            else -> total?.takeIf { it > 0 }?.let { "$it $unit" }
+        }
+    }
+
+    val container = if (onList) MaterialTheme.colorScheme.secondaryContainer
+    else MaterialTheme.colorScheme.surfaceContainerHighest
+    val onContainer = if (onList) MaterialTheme.colorScheme.onSecondaryContainer
+    else MaterialTheme.colorScheme.onSurfaceVariant
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .background(container)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = leftLabel,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            color = onContainer
+        )
+        if (rightText != null) {
+            Spacer(Modifier.weight(1f))
+            Text(
+                text = rightText,
+                style = MaterialTheme.typography.labelLarge,
+                color = onContainer.copy(alpha = 0.85f)
+            )
+        }
+    }
+}
+
+private fun listStatusLabel(status: LibraryStatus, isManga: Boolean): Int = when (status) {
+    LibraryStatus.CURRENT -> if (isManga) R.string.status_reading else R.string.status_watching
+    LibraryStatus.PLANNING -> R.string.status_planning
+    LibraryStatus.COMPLETED -> R.string.status_completed
+    LibraryStatus.DROPPED -> R.string.status_dropped
+    LibraryStatus.PAUSED -> R.string.status_paused
+    LibraryStatus.REPEATING -> if (isManga) R.string.status_rereading else R.string.status_rewatching
+    LibraryStatus.UNKNOWN -> R.string.status_planning
+}
+
+private fun mediaReleaseLabel(status: String): Int = when (status) {
+    "RELEASING" -> R.string.share_media_status_airing
+    "FINISHED" -> R.string.share_media_status_finished
+    "NOT_YET_RELEASED" -> R.string.share_media_status_upcoming
+    "CANCELLED" -> R.string.share_media_status_cancelled
+    "HIATUS" -> R.string.share_media_status_hiatus
+    else -> R.string.share_media_status_finished
+}
+
+/** Parses AniList's `#RRGGBB` cover color; null when absent or malformed. */
+private fun parseCoverColor(hex: String?): Color? {
+    if (hex.isNullOrBlank()) return null
+    return try {
+        Color(android.graphics.Color.parseColor(hex))
+    } catch (_: IllegalArgumentException) {
+        null
+    }
+}

--- a/app/src/main/java/com/anisync/android/presentation/share/ProfileStatsShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/ProfileStatsShareCard.kt
@@ -1,0 +1,135 @@
+package com.anisync.android.presentation.share
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.anisync.android.R
+import com.anisync.android.presentation.components.UserAvatar
+import com.anisync.android.domain.UserProfile
+import com.anisync.android.presentation.profile.ProfileStatsType
+import com.anisync.android.presentation.profile.StatisticsUiModel
+import com.anisync.android.presentation.util.formatCompactNumber
+import com.anisync.android.presentation.util.formatDecimal
+import com.anisync.android.ui.theme.LocalExpressiveTypography
+
+/**
+ * Shareable card summarising a user's anime **or** manga statistics. The header rides the user's
+ * own AniList banner (falling back to an accent when they have none), with their avatar and the
+ * headline total below, then three secondary stat tiles and a top-genres row. Reads its numbers
+ * straight off [StatisticsUiModel] so it always matches the Stats tab.
+ */
+@Composable
+fun ProfileStatsShareCard(
+    profile: UserProfile,
+    stats: StatisticsUiModel,
+    type: ProfileStatsType,
+    modifier: Modifier = Modifier,
+) {
+    val expressive = LocalExpressiveTypography.current
+    val isAnime = type == ProfileStatsType.ANIME
+
+    ShareCardScaffold(modifier = modifier, handle = profile.name) {
+        ShareCardBannerBox(bannerUrl = profile.bannerUrl, height = 108.dp, scrimAlpha = 0.78f) {
+            Row(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // UserAvatar honours the user's chosen avatar shape + frame (LocalAvatarShape).
+                UserAvatar(
+                    contentDescription = null,
+                    size = 52.dp,
+                    url = profile.avatarUrl,
+                    borderColor = Color.White.copy(alpha = 0.9f),
+                    borderWidth = 2.dp
+                )
+                Spacer(Modifier.width(14.dp))
+                Column {
+                    Text(
+                        text = profile.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = stringResource(
+                            if (isAnime) R.string.share_stats_eyebrow_anime
+                            else R.string.share_stats_eyebrow_manga
+                        ).uppercase(),
+                        style = expressive.statLabel,
+                        color = Color.White.copy(alpha = 0.85f)
+                    )
+                }
+            }
+        }
+
+        Column(modifier = Modifier.padding(20.dp)) {
+            val total = if (isAnime) stats.animeStats.totalCount else (stats.mangaStats?.totalCount ?: 0)
+            Row(verticalAlignment = Alignment.Bottom) {
+                Text(
+                    text = formatCompactNumber(total),
+                    style = expressive.statNumericLarge,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Spacer(Modifier.width(10.dp))
+                Text(
+                    text = stringResource(
+                        if (isAnime) R.string.share_stats_unit_anime
+                        else R.string.share_stats_unit_manga
+                    ),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = 12.dp)
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                if (isAnime) {
+                    val a = stats.animeStats
+                    ShareStatTile(formatDecimal(a.daysWatched), stringResource(R.string.share_stats_days), Modifier.weight(1f))
+                    ShareStatTile(formatCompactNumber(a.episodesWatched), stringResource(R.string.share_stats_episodes), Modifier.weight(1f))
+                    ShareStatTile(formatDecimal(a.meanScore), stringResource(R.string.share_stats_mean), Modifier.weight(1f))
+                } else {
+                    val m = stats.mangaStats
+                    ShareStatTile(formatCompactNumber(m?.chaptersRead ?: 0), stringResource(R.string.share_stats_chapters), Modifier.weight(1f))
+                    ShareStatTile(formatCompactNumber(m?.volumesRead ?: 0), stringResource(R.string.share_stats_volumes), Modifier.weight(1f))
+                    ShareStatTile(formatDecimal(m?.meanScore ?: 0.0), stringResource(R.string.share_stats_mean), Modifier.weight(1f))
+                }
+            }
+
+            val genres = (if (isAnime) stats.animeStats.genreDistribution
+            else stats.mangaStats?.genreDistribution.orEmpty()).take(3)
+            if (genres.isNotEmpty()) {
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = stringResource(R.string.share_stats_top_genres).uppercase(),
+                    style = expressive.statLabel,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(8.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    genres.forEach { g -> ShareChip(g.genre) }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/anisync/android/presentation/share/ReviewShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/ReviewShareCard.kt
@@ -1,0 +1,106 @@
+package com.anisync.android.presentation.share
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.anisync.android.R
+import com.anisync.android.domain.MediaReview
+import com.anisync.android.ui.theme.LocalExpressiveTypography
+
+/**
+ * Shareable pull-quote card for a review: media banner with a floating score badge, the
+ * review's one-line summary set as a lead quote, and the author byline. Uses [MediaReview.summary]
+ * (plain text) rather than the HTML body so the exported image stays a clean quote.
+ */
+@Composable
+fun ReviewShareCard(
+    review: MediaReview,
+    modifier: Modifier = Modifier,
+) {
+    val expressive = LocalExpressiveTypography.current
+
+    ShareCardScaffold(modifier = modifier, handle = review.userName) {
+        ShareCardBannerBox(
+            bannerUrl = review.mediaBannerUrl ?: review.mediaCoverUrl,
+            height = 140.dp
+        ) {
+            if (review.mediaTitle != null) {
+                Text(
+                    text = review.mediaTitle,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(16.dp)
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(16.dp)
+                    .clip(RoundedCornerShape(50))
+                    .background(MaterialTheme.colorScheme.primary)
+                    .padding(horizontal = 14.dp, vertical = 6.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.share_review_score, review.score),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onPrimary
+                )
+            }
+        }
+
+        Column(modifier = Modifier.padding(20.dp)) {
+            Text(
+                text = "“",
+                style = expressive.statNumericMedium,
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.35f)
+            )
+            Text(
+                text = review.summary,
+                style = expressive.editorialLead,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 5,
+                overflow = TextOverflow.Ellipsis
+            )
+            Spacer(Modifier.height(16.dp))
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.share_review_byline).uppercase(),
+                    style = expressive.statLabel,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = review.userName,
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/anisync/android/presentation/share/ShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/ShareCard.kt
@@ -1,0 +1,384 @@
+package com.anisync.android.presentation.share
+
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.anisync.android.R
+import com.anisync.android.util.ShareUtils
+import dev.shreyaspatil.capturable.capturable
+import dev.shreyaspatil.capturable.controller.rememberCaptureController
+import kotlinx.coroutines.launch
+
+/**
+ * Fixed capture width for every share card — a portrait-leaning social card that reads
+ * well as a chat/story preview. Cards size their height to content.
+ */
+val ShareCardWidth = 340.dp
+
+/** Rounded outer shape shared by all share cards (matches the app's 28dp hero radius). */
+private val ShareCardShape = RoundedCornerShape(28.dp)
+
+/**
+ * Bottom sheet that previews a [card] exactly as it will be shared, then offers: save the PNG to
+ * the gallery, copy the [caption] link to the clipboard, or open the system share sheet with the
+ * PNG. Showing the live card first doubles as the load gate — Coil covers are decoded by the time
+ * the user acts, so the exported image is never blank.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
+@Composable
+fun ShareImageSheet(
+    onDismiss: () -> Unit,
+    caption: String? = null,
+    card: @Composable () -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val controller = rememberCaptureController()
+    var busy by remember { mutableStateOf(false) }
+
+    // Capture once per tap, then run [block] over the bitmap. Guards against concurrent taps.
+    fun runAction(block: suspend (androidx.compose.ui.graphics.ImageBitmap) -> Unit) {
+        if (busy) return
+        scope.launch {
+            busy = true
+            try {
+                block(controller.captureAsync().await())
+            } catch (_: Throwable) {
+                // Node left composition mid-capture — keep the sheet open for a retry.
+            } finally {
+                busy = false
+            }
+        }
+    }
+
+    com.anisync.android.presentation.components.AppModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .windowInsetsPadding(WindowInsets.navigationBars)
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = stringResource(R.string.share_image_preview_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp)
+            )
+
+            // Height-capped + scrollable so a tall card still leaves the action row visible.
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 440.dp)
+                    .verticalScroll(rememberScrollState()),
+                contentAlignment = Alignment.TopCenter
+            ) {
+                Box(
+                    modifier = Modifier
+                        .width(ShareCardWidth)
+                        .clip(ShareCardShape)
+                        .capturable(controller)
+                ) {
+                    card()
+                }
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                SheetAction(
+                    icon = Icons.Filled.Download,
+                    label = stringResource(R.string.share_action_save),
+                    enabled = !busy,
+                    container = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    contentColor = MaterialTheme.colorScheme.onSurface
+                ) {
+                    runAction { bmp ->
+                        val ok = ShareUtils.saveCardToGallery(context, bmp)
+                        Toast.makeText(
+                            context,
+                            context.getString(
+                                if (ok) R.string.share_saved_to_gallery else R.string.share_save_failed
+                            ),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                }
+                SheetAction(
+                    icon = Icons.Filled.ContentCopy,
+                    label = stringResource(R.string.share_action_copy),
+                    enabled = !busy,
+                    container = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    contentColor = MaterialTheme.colorScheme.onSurface
+                ) {
+                    // Copy just the link — no capture needed; pastes cleanly into the Feed composer.
+                    caption?.let { ShareUtils.copyText(context, it) }
+                    Toast.makeText(context, R.string.share_copied, Toast.LENGTH_SHORT).show()
+                }
+                SheetAction(
+                    icon = Icons.Filled.Share,
+                    label = stringResource(R.string.share_action_share),
+                    enabled = !busy,
+                    container = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                ) {
+                    runAction { bmp ->
+                        ShareUtils.shareBitmap(context, bmp, caption)
+                        onDismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** One icon-over-label action tile in the share sheet's action row. */
+@Composable
+private fun RowScope.SheetAction(
+    icon: ImageVector,
+    label: String,
+    enabled: Boolean,
+    container: Color,
+    contentColor: Color,
+    onClick: () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        enabled = enabled,
+        shape = RoundedCornerShape(18.dp),
+        color = container,
+        contentColor = contentColor,
+        modifier = Modifier
+            .weight(1f)
+            .height(64.dp)
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(20.dp))
+            Spacer(Modifier.height(4.dp))
+            Text(text = label, style = MaterialTheme.typography.labelMedium, maxLines = 1)
+        }
+    }
+}
+
+/**
+ * Banner box shared by the share cards: a cropped [bannerUrl] behind a bottom-weighted scrim,
+ * with [content] overlaid (title, badges). Falls back to a solid accent when no banner exists.
+ */
+@Composable
+fun ShareCardBannerBox(
+    bannerUrl: String?,
+    height: Dp,
+    modifier: Modifier = Modifier,
+    scrimAlpha: Float = 0.72f,
+    content: @Composable BoxScope.() -> Unit = {},
+) {
+    Box(modifier = modifier.fillMaxWidth().height(height)) {
+        if (bannerUrl != null) {
+            AsyncImage(
+                model = bannerUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize()
+            )
+        } else {
+            Box(Modifier.fillMaxSize().background(MaterialTheme.colorScheme.primaryContainer))
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        0f to Color.Black.copy(alpha = 0.10f),
+                        1f to Color.Black.copy(alpha = scrimAlpha)
+                    )
+                )
+        )
+        content()
+    }
+}
+
+/**
+ * Opaque, rounded, self-contained surface every share card sits on. Opaque matters: the PNG
+ * is composited over arbitrary chat/story backgrounds, so no theme transparency may leak
+ * through. Ends with the shared AniSync footer so every exported image is attributed.
+ *
+ * [handle] is the AniList username shown in the footer (omitted when unknown).
+ */
+@Composable
+fun ShareCardScaffold(
+    modifier: Modifier = Modifier,
+    handle: String? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .width(ShareCardWidth)
+            .clip(ShareCardShape)
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+    ) {
+        content()
+        ShareCardFooter(handle = handle)
+    }
+}
+
+/** AniSync wordmark + monochrome mark + optional @handle. Kept consistent across all cards. */
+@Composable
+private fun ShareCardFooter(handle: String?) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+            .padding(horizontal = 20.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(28.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.primary),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_launcher_monochrome),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.surfaceContainerHighest,
+                modifier = Modifier.size(26.dp)
+            )
+        }
+        Spacer(Modifier.width(10.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            // Fixed brand name so exported cards always read "AniSync", even from
+            // preview/debug builds where app_name carries a suffix.
+            Text(
+                text = stringResource(R.string.share_card_brand),
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1
+            )
+            if (!handle.isNullOrBlank()) {
+                Text(
+                    text = "@$handle",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+        Text(
+            text = stringResource(R.string.share_card_source),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+/**
+ * One value+label cell for the stat rows. [value] is the big figure, [label] the eyebrow
+ * beneath it. Weighted by the caller so a row of tiles splits the width evenly.
+ */
+@Composable
+fun ShareStatTile(value: String, label: String, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerLow)
+            .padding(vertical = 14.dp, horizontal = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1
+        )
+        Spacer(Modifier.height(2.dp))
+        Text(
+            text = label.uppercase(),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+/** Rounded secondary-container pill for genre tags. Shared by the media and stats cards. */
+@Composable
+fun ShareChip(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSecondaryContainer,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier
+            .clip(RoundedCornerShape(50))
+            .background(MaterialTheme.colorScheme.secondaryContainer)
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+    )
+}

--- a/app/src/main/java/com/anisync/android/util/ShareUtils.kt
+++ b/app/src/main/java/com/anisync/android/util/ShareUtils.kt
@@ -1,9 +1,22 @@
 package com.anisync.android.util
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import com.anisync.android.type.MediaType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
 
 /**
  * Opens the given URL in the system browser. Swallows ActivityNotFoundException
@@ -72,6 +85,80 @@ object ShareUtils {
         }
 
         context.startActivity(Intent.createChooser(shareIntent, null))
+    }
+
+    /**
+     * Writes a captured composable to app cache and launches the system share sheet
+     * with it as a PNG. The optional [text] rides along as EXTRA_TEXT for targets that
+     * accept a caption (Twitter, messengers). Backed by the FileProvider authority
+     * "${packageName}.fileprovider" and the "shared/" cache-path in res/xml/filepaths.xml.
+     *
+     * File I/O runs off the main thread; the chooser launch hops back to it.
+     */
+    suspend fun shareBitmap(context: Context, bitmap: ImageBitmap, text: String? = null) {
+        val uri = withContext(Dispatchers.IO) { writeShareablePng(context, bitmap) }
+
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "image/png"
+            putExtra(Intent.EXTRA_STREAM, uri)
+            text?.let { putExtra(Intent.EXTRA_TEXT, it) }
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        context.startActivity(Intent.createChooser(intent, null))
+    }
+
+    /** Copies a plain-text [text] link to the clipboard (paste into the Feed composer, chats, …). */
+    fun copyText(context: Context, text: String) {
+        val clipboard = context.getSystemService(ClipboardManager::class.java) ?: return
+        clipboard.setPrimaryClip(ClipData.newPlainText("AniSync", text))
+    }
+
+    /**
+     * Saves the captured card to the shared Pictures/AniSync gallery folder. Uses the scoped
+     * MediaStore pipeline on API 29+ (no permission needed) and the legacy insert below it.
+     * Returns true on success.
+     */
+    suspend fun saveCardToGallery(context: Context, bitmap: ImageBitmap): Boolean =
+        withContext(Dispatchers.IO) {
+            val bmp = bitmap.asAndroidBitmap()
+            val name = "AniSync_${System.currentTimeMillis()}.png"
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    val resolver = context.contentResolver
+                    val values = ContentValues().apply {
+                        put(MediaStore.Images.Media.DISPLAY_NAME, name)
+                        put(MediaStore.Images.Media.MIME_TYPE, "image/png")
+                        put(MediaStore.Images.Media.RELATIVE_PATH, "Pictures/AniSync")
+                        put(MediaStore.Images.Media.IS_PENDING, 1)
+                    }
+                    val uri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+                        ?: return@withContext false
+                    resolver.openOutputStream(uri)?.use { out ->
+                        bmp.compress(Bitmap.CompressFormat.PNG, 100, out)
+                    } ?: return@withContext false
+                    values.clear()
+                    values.put(MediaStore.Images.Media.IS_PENDING, 0)
+                    resolver.update(uri, values, null, null)
+                    true
+                } else {
+                    @Suppress("DEPRECATION")
+                    MediaStore.Images.Media.insertImage(
+                        context.contentResolver, bmp, name, "AniSync card"
+                    ) != null
+                }
+            } catch (_: Exception) {
+                false
+            }
+        }
+
+    /** One reusable cache PNG (overwritten each call) exposed as a FileProvider URI. */
+    private fun writeShareablePng(context: Context, bitmap: ImageBitmap): Uri {
+        val dir = File(context.cacheDir, "shared").apply { mkdirs() }
+        val file = File(dir, "anisync_share.png")
+        file.outputStream().use { out ->
+            bitmap.asAndroidBitmap().compress(Bitmap.CompressFormat.PNG, 100, out)
+        }
+        return FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1246,4 +1246,44 @@
     <string name="rail_collapse">Collapse navigation</string>
     <string name="rail_expanded">Navigation expanded</string>
     <string name="rail_collapsed">Navigation collapsed</string>
+
+    <!-- Share-as-image cards -->
+    <string name="share_as_image">Share image</string>
+    <string name="share_image_preview_title">Preview</string>
+    <string name="share_action_save">Save</string>
+    <string name="share_action_copy">Copy</string>
+    <string name="share_action_share">Share</string>
+    <string name="share_saved_to_gallery">Saved to gallery</string>
+    <string name="share_save_failed">Couldn\'t save image</string>
+    <string name="share_copied">Link copied</string>
+    <string name="share_card_source">AniList</string>
+    <string name="share_card_brand" translatable="false">AniSync</string>
+    <string name="share_stats_eyebrow_anime">Anime stats</string>
+    <string name="share_stats_eyebrow_manga">Manga stats</string>
+    <string name="share_stats_unit_anime">anime</string>
+    <string name="share_stats_unit_manga">manga</string>
+    <string name="share_stats_days">Days</string>
+    <string name="share_stats_episodes">Episodes</string>
+    <string name="share_stats_chapters">Chapters</string>
+    <string name="share_stats_volumes">Volumes</string>
+    <string name="share_stats_mean">Score</string>
+    <string name="share_stats_top_genres">Top genres</string>
+    <string name="share_media_episodes">episodes</string>
+    <string name="share_media_chapters">chapters</string>
+    <string name="share_media_popularity">popularity</string>
+    <string name="share_media_favourites">favourites</string>
+    <string name="share_media_ep_number">Ep %1$d</string>
+    <string name="share_media_tba">TBA</string>
+    <!-- Release status shown ONLY when the title is not on the viewer's list; worded to read as
+         the show's airing state, never as a personal tracking status. -->
+    <string name="share_media_status_finished">Finished airing</string>
+    <string name="share_media_status_airing">Airing now</string>
+    <string name="share_media_status_upcoming">Upcoming</string>
+    <string name="share_media_status_cancelled">Cancelled</string>
+    <string name="share_media_status_hiatus">On hiatus</string>
+    <string name="share_review_score">%1$d/100</string>
+    <string name="share_review_byline">Review by</string>
+    <string name="share_fav_eyebrow">Favourites</string>
+    <string name="share_fav_heading_anime">Favourite Anime</string>
+    <string name="share_fav_heading_manga">Favourite Manga</string>
 </resources>

--- a/app/src/main/res/xml/filepaths.xml
+++ b/app/src/main/res/xml/filepaths.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
     <external-files-path name="apk" path="apk/" />
+    <cache-path name="shared_images" path="shared/" />
 </paths>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ appcompat = "1.7.1"
 reorderable = "3.1.0"
 okhttp = "4.12.0"
 biometric = "1.2.0-alpha05"
+capturable = "3.0.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -98,6 +99,7 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 androidx-biometric = { group = "androidx.biometric", name = "biometric-ktx", version.ref = "biometric" }
+capturable = { group = "dev.shreyaspatil", name = "capturable", version.ref = "capturable" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Turns a media page, your stats, a review or your favourites into a clean branded card you can save, share, or paste anywhere. Each card is drawn from the live UI, so it follows your theme and the media's own cover colour.

## What it does
- Media, stats (anime and manga), review and favourites each get their own card — opened from the Share button on the media and review screens, and a "Share image" chip on the profile Stats and Favourites tabs.
- Three actions per card: save it to the gallery, copy the AniList link, or share the image to any app.
- The media card adapts to your own list: progress while watching, a plain count while planning or completed, and the show's release status (including upcoming) when it isn't on your list at all. Popularity, favourites, studio and top genres round it out.

## Notes
- Reviews opened from a media page now open the full review screen, the same one Discover uses, instead of a bottom sheet.
- New dependency: Capturable.
- Verified on-device across all four cards and the save, copy and share actions, including the minified release build.