### PR TITLE
feat(notifications): per-target tray stacking, channel groups and follower alerts

### DIFF
--- a/app/src/main/graphql/Notifications.graphql
+++ b/app/src/main/graphql/Notifications.graphql
@@ -19,16 +19,7 @@ query GetNotifications(
         contexts
         createdAt
         media {
-          id
-          title {
-            userPreferred
-          }
-          coverImage {
-            medium
-            large
-            extraLarge
-          }
-          type
+          ...NotifMedia
         }
       }
       ... on FollowingNotification {
@@ -37,12 +28,7 @@ query GetNotifications(
         context
         createdAt
         user {
-          id
-          isBlocked
-          name
-          avatar {
-            large
-          }
+          ...NotifUser
         }
       }
       ... on ActivityLikeNotification {
@@ -52,39 +38,10 @@ query GetNotifications(
         context
         createdAt
         user {
-          id
-          isBlocked
-          name
-          avatar {
-            large
-          }
+          ...NotifUser
         }
         activity {
-          __typename
-          ... on TextActivity {
-            id
-            text(asHtml: true)
-          }
-          ... on ListActivity {
-            id
-            type
-            status
-            progress
-            media {
-              id
-              title { userPreferred }
-              coverImage {
-                medium
-                large
-                extraLarge
-              }
-              type
-            }
-          }
-          ... on MessageActivity {
-            id
-            message(asHtml: true)
-          }
+          ...NotifActivity
         }
       }
       ... on ActivityReplyNotification {
@@ -94,39 +51,10 @@ query GetNotifications(
         context
         createdAt
         user {
-          id
-          isBlocked
-          name
-          avatar {
-            large
-          }
+          ...NotifUser
         }
         activity {
-          __typename
-          ... on TextActivity {
-            id
-            text(asHtml: true)
-          }
-          ... on ListActivity {
-            id
-            type
-            status
-            progress
-            media {
-              id
-              title { userPreferred }
-              coverImage {
-                medium
-                large
-                extraLarge
-              }
-              type
-            }
-          }
-          ... on MessageActivity {
-            id
-            message(asHtml: true)
-          }
+          ...NotifActivity
         }
       }
       ... on ActivityReplySubscribedNotification {
@@ -136,39 +64,10 @@ query GetNotifications(
         context
         createdAt
         user {
-          id
-          isBlocked
-          name
-          avatar {
-            large
-          }
+          ...NotifUser
         }
         activity {
-          __typename
-          ... on TextActivity {
-            id
-            text(asHtml: true)
-          }
-          ... on ListActivity {
-            id
-            type
-            status
-            progress
-            media {
-              id
-              title { userPreferred }
-              coverImage {
-                medium
-                large
-                extraLarge
-              }
-              type
-            }
-          }
-          ... on MessageActivity {
-            id
-            message(asHtml: true)
-          }
+          ...NotifActivity
         }
       }
       ... on ActivityReplyLikeNotification {
@@ -178,39 +77,10 @@ query GetNotifications(
         context
         createdAt
         user {
-          id
-          isBlocked
-          name
-          avatar {
-            large
-          }
+          ...NotifUser
         }
         activity {
-          __typename
-          ... on TextActivity {
-            id
-            text(asHtml: true)
-          }
-          ... on ListActivity {
-            id
-            type
-            status
-            progress
-            media {
-              id
-              title { userPreferred }
-              coverImage {
-                medium
-                large
-                extraLarge
-              }
-              type
-            }
-          }
-          ... on MessageActivity {
-            id
-            message(asHtml: true)
-          }
+          ...NotifActivity
         }
       }
       ... on ActivityMentionNotification {
@@ -220,39 +90,10 @@ query GetNotifications(
         context
         createdAt
         user {
-          id
-          isBlocked
-          name
-          avatar {
-            large
-          }
+          ...NotifUser
         }
         activity {
-          __typename
-          ... on TextActivity {
-            id
-            text(asHtml: true)
-          }
-          ... on ListActivity {
-            id
-            type
-            status
-            progress
-            media {
-              id
-              title { userPreferred }
-              coverImage {
-                medium
-                large
-                extraLarge
-              }
-              type
-            }
-          }
-          ... on MessageActivity {
-            id
-            message(asHtml: true)
-          }
+          ...NotifActivity
         }
       }
       ... on ActivityMessageNotification {
@@ -262,12 +103,7 @@ query GetNotifications(
         context
         createdAt
         user {
-          id
-          isBlocked
-          name
-          avatar {
-            large
-          }
+          ...NotifUser
         }
         message {
           id
@@ -280,12 +116,7 @@ query GetNotifications(
         context
         createdAt
         user {
-          id
-          isBlocked
-          name
-          avatar {
-            large
-          }
+          ...NotifUser
         }
         thread {
           id
@@ -302,12 +133,7 @@ query GetNotifications(
         context
         createdAt
         user {
-          id
-          isBlocked
-          name
-          avatar {
-            large
-          }
+          ...NotifUser
         }
         thread {
           id
@@ -324,12 +150,7 @@ query GetNotifications(
         context
         createdAt
         user {
-          id
-          isBlocked
-          name
-          avatar {
-            large
-          }
+          ...NotifUser
         }
         thread {
           id
@@ -346,12 +167,7 @@ query GetNotifications(
         context
         createdAt
         user {
-          id
-          isBlocked
-          name
-          avatar {
-            large
-          }
+          ...NotifUser
         }
         thread {
           id
@@ -364,12 +180,7 @@ query GetNotifications(
         context
         createdAt
         user {
-          id
-          isBlocked
-          name
-          avatar {
-            large
-          }
+          ...NotifUser
         }
         thread {
           id
@@ -387,16 +198,7 @@ query GetNotifications(
         context
         createdAt
         media {
-          id
-          title {
-            userPreferred
-          }
-          coverImage {
-            medium
-            large
-            extraLarge
-          }
-          type
+          ...NotifMedia
         }
       }
       ... on MediaDataChangeNotification {
@@ -407,16 +209,7 @@ query GetNotifications(
         reason
         createdAt
         media {
-          id
-          title {
-            userPreferred
-          }
-          coverImage {
-            medium
-            large
-            extraLarge
-          }
-          type
+          ...NotifMedia
         }
       }
       ... on MediaMergeNotification {
@@ -428,16 +221,7 @@ query GetNotifications(
         reason
         createdAt
         media {
-          id
-          title {
-            userPreferred
-          }
-          coverImage {
-            medium
-            large
-            extraLarge
-          }
-          type
+          ...NotifMedia
         }
       }
       ... on MediaDeletionNotification {
@@ -449,5 +233,48 @@ query GetNotifications(
         createdAt
       }
     }
+  }
+}
+
+fragment NotifUser on User {
+  id
+  isBlocked
+  name
+  avatar {
+    large
+  }
+}
+
+fragment NotifMedia on Media {
+  id
+  title {
+    userPreferred
+  }
+  coverImage {
+    medium
+    large
+    extraLarge
+  }
+  type
+}
+
+fragment NotifActivity on ActivityUnion {
+  __typename
+  ... on TextActivity {
+    id
+    text(asHtml: true)
+  }
+  ... on ListActivity {
+    id
+    type
+    status
+    progress
+    media {
+      ...NotifMedia
+    }
+  }
+  ... on MessageActivity {
+    id
+    message(asHtml: true)
   }
 }

--- a/app/src/main/graphql/Notifications.graphql
+++ b/app/src/main/graphql/Notifications.graphql
@@ -2,7 +2,8 @@ query GetNotifications(
   $page: Int = 1,
   $perPage: Int = 20,
   $typeIn: [NotificationType] = null,
-  $resetCount: Boolean = true
+  # Default false: resetting the unread count is a deliberate act of the inbox screen only.
+  $resetCount: Boolean = false
 ) {
   Page(page: $page, perPage: $perPage) {
     pageInfo {

--- a/app/src/main/java/com/anisync/android/MainActivity.kt
+++ b/app/src/main/java/com/anisync/android/MainActivity.kt
@@ -193,6 +193,10 @@ class MainActivity : AppCompatActivity() {
                                 "PerfMetrics",
                                 "Notification scheduled in ${scheduleTime}ms via IO Thread"
                             )
+                        } else {
+                            // Disabled or logged out — stop the periodic poll instead of letting
+                            // it wake up every 15 minutes to find no usable accounts.
+                            notificationScheduler.cancel()
                         }
                     }
             }

--- a/app/src/main/java/com/anisync/android/data/NotificationPreferences.kt
+++ b/app/src/main/java/com/anisync/android/data/NotificationPreferences.kt
@@ -68,6 +68,10 @@ class NotificationPreferences @Inject constructor(
     private val _activityMessageEnabled = MutableStateFlow(prefs.getBoolean(KEY_ACTIVITY_MESSAGE_ENABLED, true))
     val activityMessageEnabled: StateFlow<Boolean> = _activityMessageEnabled.asStateFlow()
 
+    // Activity - new followers
+    private val _followsEnabled = MutableStateFlow(prefs.getBoolean(KEY_FOLLOWS_ENABLED, true))
+    val followsEnabled: StateFlow<Boolean> = _followsEnabled.asStateFlow()
+
     // Streaming availability delay (minutes) for "episode aired" notifications.
     // Lets users on streaming sites that post episodes after the official airing time
     // postpone the notification so it lines up with when the episode is actually watchable.
@@ -136,6 +140,11 @@ class NotificationPreferences @Inject constructor(
         prefs.edit().putBoolean(KEY_ACTIVITY_MESSAGE_ENABLED, enabled).apply()
     }
 
+    fun setFollowsEnabled(enabled: Boolean) {
+        _followsEnabled.value = enabled
+        prefs.edit().putBoolean(KEY_FOLLOWS_ENABLED, enabled).apply()
+    }
+
     fun setStreamingDelayMinutes(minutes: Int) {
         val clamped = minutes.coerceIn(MIN_STREAMING_DELAY_MINUTES, MAX_STREAMING_DELAY_MINUTES)
         _streamingDelayMinutes.value = clamped
@@ -158,6 +167,7 @@ class NotificationPreferences @Inject constructor(
         setActivityMentionEnabled(true)
         setActivityLikeEnabled(true)
         setActivityMessageEnabled(true)
+        setFollowsEnabled(true)
         setStreamingDelayMinutes(0)
     }
 
@@ -175,6 +185,7 @@ class NotificationPreferences @Inject constructor(
         private const val KEY_ACTIVITY_MENTION_ENABLED = "activity_mention_enabled"
         private const val KEY_ACTIVITY_LIKE_ENABLED = "activity_like_enabled"
         private const val KEY_ACTIVITY_MESSAGE_ENABLED = "activity_message_enabled"
+        private const val KEY_FOLLOWS_ENABLED = "follows_enabled"
         private const val KEY_STREAMING_DELAY_MINUTES = "streaming_delay_minutes"
         const val MIN_STREAMING_DELAY_MINUTES = 0
         const val MAX_STREAMING_DELAY_MINUTES = 180

--- a/app/src/main/java/com/anisync/android/data/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/NotificationRepositoryImpl.kt
@@ -14,6 +14,7 @@ import com.anisync.android.domain.ActivityReplyNotification
 import com.anisync.android.domain.ActivityReplySubscribedNotification
 import com.anisync.android.domain.AiringNotification
 import com.anisync.android.domain.AiringSchedule
+import com.anisync.android.domain.CoverImage
 import com.anisync.android.domain.FollowingNotification
 import com.anisync.android.domain.Media
 import com.anisync.android.domain.MediaDataChangeNotification
@@ -30,6 +31,11 @@ import com.anisync.android.domain.ThreadCommentReplyNotification
 import com.anisync.android.domain.ThreadCommentSubscribedNotification
 import com.anisync.android.domain.ThreadLikeNotification
 import com.anisync.android.domain.User
+import com.anisync.android.fragment.NotifActivity
+import com.anisync.android.fragment.NotifMedia
+import com.anisync.android.fragment.NotifUser
+import com.anisync.android.type.ActivityType
+import com.anisync.android.type.MediaType
 import com.anisync.android.type.NotificationType
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Optional
@@ -104,26 +110,34 @@ class NotificationRepositoryImpl @Inject constructor(
         }
     }
 
-    private fun snapshotFromUnion(
-        typename: String?,
-        textBody: String?,
-        listActivityType: com.anisync.android.type.ActivityType?,
-        listStatus: String?,
-        listProgress: String?,
-        listMedia: Media?,
-        messageBody: String?
-    ): ActivitySnapshot {
-        // Prefer the activity's own type field — AniList serves it directly on
-        // ListActivity (ANIME_LIST / MANGA_LIST). Fall back to media.type only
-        // when the activity type field is absent (e.g. older cache entries).
-        val kind = when (typename) {
-            "TextActivity" -> ActivityKind.TEXT
-            "MessageActivity" -> ActivityKind.MESSAGE
-            "ListActivity" -> when (listActivityType) {
-                com.anisync.android.type.ActivityType.ANIME_LIST -> ActivityKind.ANIME_LIST
-                com.anisync.android.type.ActivityType.MANGA_LIST -> ActivityKind.MANGA_LIST
-                else -> when (listMedia?.type) {
-                    com.anisync.android.type.MediaType.MANGA -> ActivityKind.MANGA_LIST
+    private fun NotifUser.toDomain(): User = User(
+        id = id,
+        name = name,
+        avatarUrl = avatar?.large
+    )
+
+    private fun NotifMedia.toDomain(): Media = Media(
+        id = id,
+        title = title?.userPreferred ?: "Unknown",
+        coverUrl = coverImage?.large,
+        cover = CoverImage.of(coverImage?.medium, coverImage?.large, coverImage?.extraLarge),
+        type = type ?: MediaType.ANIME
+    )
+
+    /**
+     * Prefer the activity's own type field — AniList serves it directly on
+     * ListActivity (ANIME_LIST / MANGA_LIST). Fall back to media.type only
+     * when the activity type field is absent (e.g. older cache entries).
+     */
+    private fun NotifActivity.toSnapshot(): ActivitySnapshot {
+        val kind = when {
+            onTextActivity != null -> ActivityKind.TEXT
+            onMessageActivity != null -> ActivityKind.MESSAGE
+            onListActivity != null -> when (onListActivity.type) {
+                ActivityType.ANIME_LIST -> ActivityKind.ANIME_LIST
+                ActivityType.MANGA_LIST -> ActivityKind.MANGA_LIST
+                else -> when (onListActivity.media?.notifMedia?.type) {
+                    MediaType.MANGA -> ActivityKind.MANGA_LIST
                     else -> ActivityKind.ANIME_LIST
                 }
             }
@@ -131,440 +145,227 @@ class NotificationRepositoryImpl @Inject constructor(
         }
         return ActivitySnapshot(
             kind = kind,
-            text = textBody,
-            message = messageBody,
-            listStatus = listStatus,
-            listProgress = listProgress,
-            listMedia = listMedia
+            text = onTextActivity?.text,
+            message = onMessageActivity?.message,
+            listStatus = onListActivity?.status,
+            listProgress = onListActivity?.progress,
+            listMedia = onListActivity?.media?.notifMedia?.toDomain()
         )
     }
 
-    @Suppress("CyclomaticComplexMethod", "LongMethod")
     /**
      * True when this notification was triggered by a user the viewer has blocked on AniList, so it
      * can be hidden (issue #76). Driven by the per-actor `User.isBlocked` flag; media/airing
      * notifications have no actor and are never blocked.
      */
     private fun GetNotificationsQuery.Notification.actorIsBlocked(): Boolean =
-        onFollowingNotification?.user?.isBlocked == true ||
-            onActivityLikeNotification?.user?.isBlocked == true ||
-            onActivityReplyNotification?.user?.isBlocked == true ||
-            onActivityReplySubscribedNotification?.user?.isBlocked == true ||
-            onActivityReplyLikeNotification?.user?.isBlocked == true ||
-            onActivityMentionNotification?.user?.isBlocked == true ||
-            onActivityMessageNotification?.user?.isBlocked == true ||
-            onThreadCommentReplyNotification?.user?.isBlocked == true ||
-            onThreadCommentSubscribedNotification?.user?.isBlocked == true ||
-            onThreadCommentMentionNotification?.user?.isBlocked == true ||
-            onThreadLikeNotification?.user?.isBlocked == true ||
-            onThreadCommentLikeNotification?.user?.isBlocked == true
+        onFollowingNotification?.user?.notifUser?.isBlocked == true ||
+            onActivityLikeNotification?.user?.notifUser?.isBlocked == true ||
+            onActivityReplyNotification?.user?.notifUser?.isBlocked == true ||
+            onActivityReplySubscribedNotification?.user?.notifUser?.isBlocked == true ||
+            onActivityReplyLikeNotification?.user?.notifUser?.isBlocked == true ||
+            onActivityMentionNotification?.user?.notifUser?.isBlocked == true ||
+            onActivityMessageNotification?.user?.notifUser?.isBlocked == true ||
+            onThreadCommentReplyNotification?.user?.notifUser?.isBlocked == true ||
+            onThreadCommentSubscribedNotification?.user?.notifUser?.isBlocked == true ||
+            onThreadCommentMentionNotification?.user?.notifUser?.isBlocked == true ||
+            onThreadLikeNotification?.user?.notifUser?.isBlocked == true ||
+            onThreadCommentLikeNotification?.user?.notifUser?.isBlocked == true
 
+    @Suppress("CyclomaticComplexMethod")
     private fun mapNotification(notification: GetNotificationsQuery.Notification): Notification? {
-        return when {
-            notification.onAiringNotification != null -> {
-                val data = notification.onAiringNotification!!
-                AiringNotification(
-                    id = data.id ?: 0,
-                    type = data.type ?: NotificationType.AIRING,
-                    createdAt = data.createdAt ?: 0,
-                    episode = data.episode ?: 0,
-                    contexts = data.contexts?.filterNotNull() ?: emptyList(),
-                    media = data.media?.let { media ->
-                        Media(
-                            id = media.id ?: 0,
-                            title = media.title?.userPreferred ?: "Unknown",
-                            coverUrl = media.coverImage?.large,
-                            cover = com.anisync.android.domain.CoverImage.of(media.coverImage?.medium, media.coverImage?.large, media.coverImage?.extraLarge),
-                            type = media.type ?: com.anisync.android.type.MediaType.ANIME
-                        )
-                    }
-                )
-            }
-            notification.onFollowingNotification != null -> {
-                val data = notification.onFollowingNotification!!
-                FollowingNotification(
-                    id = data.id ?: 0,
-                    type = data.type ?: NotificationType.FOLLOWING,
-                    createdAt = data.createdAt ?: 0,
-                    context = data.context ?: "",
-                    user = data.user?.let { user ->
-                        User(
-                            id = user.id ?: 0,
-                            name = user.name ?: "Unknown",
-                            avatarUrl = user.avatar?.large
-                        )
-                    }
-                )
-            }
-            notification.onActivityLikeNotification != null -> {
-                val data = notification.onActivityLikeNotification!!
-                ActivityLikeNotification(
-                    id = data.id ?: 0,
-                    type = data.type ?: NotificationType.ACTIVITY_LIKE,
-                    createdAt = data.createdAt ?: 0,
-                    context = data.context ?: "",
-                    activityId = data.activityId,
-                    user = data.user?.let { user ->
-                        User(
-                            id = user.id ?: 0,
-                            name = user.name ?: "Unknown",
-                            avatarUrl = user.avatar?.large
-                        )
-                    },
-                    activity = data.activity?.let { a ->
-                        snapshotFromUnion(
-                            typename = a.__typename,
-                            textBody = a.onTextActivity?.text,
-                            listActivityType = a.onListActivity?.type,
-                            listStatus = a.onListActivity?.status,
-                            listProgress = a.onListActivity?.progress,
-                            listMedia = a.onListActivity?.media?.let { m ->
-                                Media(
-                                    id = m.id ?: 0,
-                                    title = m.title?.userPreferred ?: "Unknown",
-                                    coverUrl = m.coverImage?.large,
-                                    cover = com.anisync.android.domain.CoverImage.of(m.coverImage?.medium, m.coverImage?.large, m.coverImage?.extraLarge),
-                                    type = m.type ?: com.anisync.android.type.MediaType.ANIME
-                                )
-                            },
-                            messageBody = a.onMessageActivity?.message
-                        )
-                    }
-                )
-            }
-            notification.onActivityReplyNotification != null -> {
-                val data = notification.onActivityReplyNotification!!
-                ActivityReplyNotification(
-                    id = data.id ?: 0,
-                    type = data.type ?: NotificationType.ACTIVITY_REPLY,
-                    createdAt = data.createdAt ?: 0,
-                    context = data.context ?: "",
-                    activityId = data.activityId,
-                    user = data.user?.let { user ->
-                        User(
-                            id = user.id ?: 0,
-                            name = user.name ?: "Unknown",
-                            avatarUrl = user.avatar?.large
-                        )
-                    },
-                    activity = data.activity?.let { a ->
-                        snapshotFromUnion(
-                            typename = a.__typename,
-                            textBody = a.onTextActivity?.text,
-                            listActivityType = a.onListActivity?.type,
-                            listStatus = a.onListActivity?.status,
-                            listProgress = a.onListActivity?.progress,
-                            listMedia = a.onListActivity?.media?.let { m ->
-                                Media(
-                                    id = m.id ?: 0,
-                                    title = m.title?.userPreferred ?: "Unknown",
-                                    coverUrl = m.coverImage?.large,
-                                    cover = com.anisync.android.domain.CoverImage.of(m.coverImage?.medium, m.coverImage?.large, m.coverImage?.extraLarge),
-                                    type = m.type ?: com.anisync.android.type.MediaType.ANIME
-                                )
-                            },
-                            messageBody = a.onMessageActivity?.message
-                        )
-                    }
-                )
-            }
-            notification.onActivityReplySubscribedNotification != null -> {
-                val data = notification.onActivityReplySubscribedNotification!!
-                ActivityReplySubscribedNotification(
-                    id = data.id ?: 0,
-                    type = data.type ?: NotificationType.ACTIVITY_REPLY_SUBSCRIBED,
-                    createdAt = data.createdAt ?: 0,
-                    context = data.context ?: "",
-                    activityId = data.activityId,
-                    user = data.user?.let { user ->
-                        User(
-                            id = user.id ?: 0,
-                            name = user.name ?: "Unknown",
-                            avatarUrl = user.avatar?.large
-                        )
-                    },
-                    activity = data.activity?.let { a ->
-                        snapshotFromUnion(
-                            typename = a.__typename,
-                            textBody = a.onTextActivity?.text,
-                            listActivityType = a.onListActivity?.type,
-                            listStatus = a.onListActivity?.status,
-                            listProgress = a.onListActivity?.progress,
-                            listMedia = a.onListActivity?.media?.let { m ->
-                                Media(
-                                    id = m.id ?: 0,
-                                    title = m.title?.userPreferred ?: "Unknown",
-                                    coverUrl = m.coverImage?.large,
-                                    cover = com.anisync.android.domain.CoverImage.of(m.coverImage?.medium, m.coverImage?.large, m.coverImage?.extraLarge),
-                                    type = m.type ?: com.anisync.android.type.MediaType.ANIME
-                                )
-                            },
-                            messageBody = a.onMessageActivity?.message
-                        )
-                    }
-                )
-            }
-            notification.onActivityReplyLikeNotification != null -> {
-                val data = notification.onActivityReplyLikeNotification!!
-                ActivityReplyLikeNotification(
-                    id = data.id ?: 0,
-                    type = data.type ?: NotificationType.ACTIVITY_REPLY_LIKE,
-                    createdAt = data.createdAt ?: 0,
-                    context = data.context ?: "",
-                    activityId = data.activityId,
-                    user = data.user?.let { user ->
-                        User(
-                            id = user.id ?: 0,
-                            name = user.name ?: "Unknown",
-                            avatarUrl = user.avatar?.large
-                        )
-                    },
-                    activity = data.activity?.let { a ->
-                        snapshotFromUnion(
-                            typename = a.__typename,
-                            textBody = a.onTextActivity?.text,
-                            listActivityType = a.onListActivity?.type,
-                            listStatus = a.onListActivity?.status,
-                            listProgress = a.onListActivity?.progress,
-                            listMedia = a.onListActivity?.media?.let { m ->
-                                Media(
-                                    id = m.id ?: 0,
-                                    title = m.title?.userPreferred ?: "Unknown",
-                                    coverUrl = m.coverImage?.large,
-                                    cover = com.anisync.android.domain.CoverImage.of(m.coverImage?.medium, m.coverImage?.large, m.coverImage?.extraLarge),
-                                    type = m.type ?: com.anisync.android.type.MediaType.ANIME
-                                )
-                            },
-                            messageBody = a.onMessageActivity?.message
-                        )
-                    }
-                )
-            }
-            notification.onActivityMentionNotification != null -> {
-                val data = notification.onActivityMentionNotification!!
-                ActivityMentionNotification(
-                    id = data.id ?: 0,
-                    type = data.type ?: NotificationType.ACTIVITY_MENTION,
-                    createdAt = data.createdAt ?: 0,
-                    context = data.context ?: "",
-                    activityId = data.activityId,
-                    user = data.user?.let { user ->
-                        User(
-                            id = user.id ?: 0,
-                            name = user.name ?: "Unknown",
-                            avatarUrl = user.avatar?.large
-                        )
-                    },
-                    activity = data.activity?.let { a ->
-                        snapshotFromUnion(
-                            typename = a.__typename,
-                            textBody = a.onTextActivity?.text,
-                            listActivityType = a.onListActivity?.type,
-                            listStatus = a.onListActivity?.status,
-                            listProgress = a.onListActivity?.progress,
-                            listMedia = a.onListActivity?.media?.let { m ->
-                                Media(
-                                    id = m.id ?: 0,
-                                    title = m.title?.userPreferred ?: "Unknown",
-                                    coverUrl = m.coverImage?.large,
-                                    cover = com.anisync.android.domain.CoverImage.of(m.coverImage?.medium, m.coverImage?.large, m.coverImage?.extraLarge),
-                                    type = m.type ?: com.anisync.android.type.MediaType.ANIME
-                                )
-                            },
-                            messageBody = a.onMessageActivity?.message
-                        )
-                    }
-                )
-            }
-            notification.onActivityMessageNotification != null -> {
-                val data = notification.onActivityMessageNotification!!
-                ActivityMessageNotification(
-                    id = data.id ?: 0,
-                    type = data.type ?: NotificationType.ACTIVITY_MESSAGE,
-                    createdAt = data.createdAt ?: 0,
-                    context = data.context ?: "",
-                    activityId = data.activityId,
-                    user = data.user?.let { user ->
-                        User(
-                            id = user.id ?: 0,
-                            name = user.name ?: "Unknown",
-                            avatarUrl = user.avatar?.large
-                        )
-                    },
-                    messagePreview = data.message?.message
-                )
-            }
-            notification.onThreadCommentReplyNotification != null -> {
-                val data = notification.onThreadCommentReplyNotification!!
-                ThreadCommentReplyNotification(
-                    id = data.id ?: 0,
-                    type = data.type ?: NotificationType.THREAD_COMMENT_REPLY,
-                    createdAt = data.createdAt ?: 0,
-                    context = data.context ?: "",
-                    user = data.user?.let { user ->
-                        User(
-                            id = user.id ?: 0,
-                            name = user.name ?: "Unknown",
-                            avatarUrl = user.avatar?.large
-                        )
-                    },
-                    threadId = data.thread?.id ?: 0,
-                    threadTitle = data.thread?.title ?: "",
-                    commentId = data.comment?.id,
-                    commentPreview = data.comment?.comment
-                )
-            }
-            notification.onThreadCommentSubscribedNotification != null -> {
-                val data = notification.onThreadCommentSubscribedNotification!!
-                ThreadCommentSubscribedNotification(
-                    id = data.id ?: 0,
-                    type = data.type ?: NotificationType.THREAD_SUBSCRIBED,
-                    createdAt = data.createdAt ?: 0,
-                    context = data.context ?: "",
-                    user = data.user?.let { user ->
-                        User(
-                            id = user.id ?: 0,
-                            name = user.name ?: "Unknown",
-                            avatarUrl = user.avatar?.large
-                        )
-                    },
-                    threadId = data.thread?.id ?: 0,
-                    threadTitle = data.thread?.title ?: "",
-                    commentId = data.comment?.id,
-                    commentPreview = data.comment?.comment
-                )
-            }
-            notification.onThreadCommentMentionNotification != null -> {
-                val data = notification.onThreadCommentMentionNotification!!
-                ThreadCommentMentionNotification(
-                    id = data.id ?: 0,
-                    type = data.type ?: NotificationType.THREAD_COMMENT_MENTION,
-                    createdAt = data.createdAt ?: 0,
-                    context = data.context ?: "",
-                    user = data.user?.let { user ->
-                        User(
-                            id = user.id ?: 0,
-                            name = user.name ?: "Unknown",
-                            avatarUrl = user.avatar?.large
-                        )
-                    },
-                    threadId = data.thread?.id ?: 0,
-                    threadTitle = data.thread?.title ?: "",
-                    commentId = data.comment?.id,
-                    commentPreview = data.comment?.comment
-                )
-            }
-            notification.onThreadLikeNotification != null -> {
-                val data = notification.onThreadLikeNotification!!
-                ThreadLikeNotification(
-                    id = data.id ?: 0,
-                    type = data.type ?: NotificationType.THREAD_LIKE,
-                    createdAt = data.createdAt ?: 0,
-                    context = data.context ?: "",
-                    user = data.user?.let { user ->
-                        User(
-                            id = user.id ?: 0,
-                            name = user.name ?: "Unknown",
-                            avatarUrl = user.avatar?.large
-                        )
-                    },
-                    threadId = data.thread?.id ?: 0,
-                    threadTitle = data.thread?.title ?: ""
-                )
-            }
-            notification.onThreadCommentLikeNotification != null -> {
-                val data = notification.onThreadCommentLikeNotification!!
-                ThreadCommentLikeNotification(
-                    id = data.id ?: 0,
-                    type = data.type ?: NotificationType.THREAD_COMMENT_LIKE,
-                    createdAt = data.createdAt ?: 0,
-                    context = data.context ?: "",
-                    user = data.user?.let { user ->
-                        User(
-                            id = user.id ?: 0,
-                            name = user.name ?: "Unknown",
-                            avatarUrl = user.avatar?.large
-                        )
-                    },
-                    threadId = data.thread?.id ?: 0,
-                    threadTitle = data.thread?.title ?: "",
-                    commentId = data.comment?.id,
-                    commentPreview = data.comment?.comment
-                )
-            }
-            notification.onRelatedMediaAdditionNotification != null -> {
-                val data = notification.onRelatedMediaAdditionNotification!!
-                RelatedMediaAdditionNotification(
-                    id = data.id,
-                    type = data.type ?: NotificationType.RELATED_MEDIA_ADDITION,
-                    createdAt = data.createdAt ?: 0,
-                    context = data.context ?: "",
-                    mediaId = data.mediaId,
-                    media = data.media?.let { media ->
-                        Media(
-                            id = media.id ?: 0,
-                            title = media.title?.userPreferred ?: "Unknown",
-                            coverUrl = media.coverImage?.large,
-                            cover = com.anisync.android.domain.CoverImage.of(media.coverImage?.medium, media.coverImage?.large, media.coverImage?.extraLarge),
-                            type = media.type ?: com.anisync.android.type.MediaType.ANIME
-                        )
-                    }
-                )
-            }
-            notification.onMediaDataChangeNotification != null -> {
-                val data = notification.onMediaDataChangeNotification!!
-                MediaDataChangeNotification(
-                    id = data.id,
-                    type = data.type ?: NotificationType.MEDIA_DATA_CHANGE,
-                    createdAt = data.createdAt ?: 0,
-                    context = data.context ?: "",
-                    reason = data.reason ?: "",
-                    mediaId = data.mediaId,
-                    media = data.media?.let { media ->
-                        Media(
-                            id = media.id ?: 0,
-                            title = media.title?.userPreferred ?: "Unknown",
-                            coverUrl = media.coverImage?.large,
-                            cover = com.anisync.android.domain.CoverImage.of(media.coverImage?.medium, media.coverImage?.large, media.coverImage?.extraLarge),
-                            type = media.type ?: com.anisync.android.type.MediaType.ANIME
-                        )
-                    }
-                )
-            }
-            notification.onMediaMergeNotification != null -> {
-                val data = notification.onMediaMergeNotification!!
-                MediaMergeNotification(
-                    id = data.id,
-                    type = data.type ?: NotificationType.MEDIA_MERGE,
-                    createdAt = data.createdAt ?: 0,
-                    context = data.context ?: "",
-                    reason = data.reason ?: "",
-                    mediaId = data.mediaId,
-                    deletedMediaTitles = data.deletedMediaTitles?.filterNotNull() ?: emptyList(),
-                    media = data.media?.let { media ->
-                        Media(
-                            id = media.id ?: 0,
-                            title = media.title?.userPreferred ?: "Unknown",
-                            coverUrl = media.coverImage?.large,
-                            cover = com.anisync.android.domain.CoverImage.of(media.coverImage?.medium, media.coverImage?.large, media.coverImage?.extraLarge),
-                            type = media.type ?: com.anisync.android.type.MediaType.ANIME
-                        )
-                    }
-                )
-            }
-            notification.onMediaDeletionNotification != null -> {
-                val data = notification.onMediaDeletionNotification!!
-                MediaDeletionNotification(
-                    id = data.id,
-                    type = data.type ?: NotificationType.MEDIA_DELETION,
-                    createdAt = data.createdAt ?: 0,
-                    context = data.context ?: "",
-                    reason = data.reason ?: "",
-                    deletedMediaTitle = data.deletedMediaTitle ?: ""
-                )
-            }
-            else -> null
+        notification.onAiringNotification?.let { data ->
+            return AiringNotification(
+                id = data.id,
+                type = data.type ?: NotificationType.AIRING,
+                createdAt = data.createdAt ?: 0,
+                episode = data.episode,
+                contexts = data.contexts?.filterNotNull() ?: emptyList(),
+                media = data.media?.notifMedia?.toDomain()
+            )
         }
+        notification.onFollowingNotification?.let { data ->
+            return FollowingNotification(
+                id = data.id,
+                type = data.type ?: NotificationType.FOLLOWING,
+                createdAt = data.createdAt ?: 0,
+                context = data.context ?: "",
+                user = data.user?.notifUser?.toDomain()
+            )
+        }
+        notification.onActivityLikeNotification?.let { data ->
+            return ActivityLikeNotification(
+                id = data.id,
+                type = data.type ?: NotificationType.ACTIVITY_LIKE,
+                createdAt = data.createdAt ?: 0,
+                context = data.context ?: "",
+                activityId = data.activityId,
+                user = data.user?.notifUser?.toDomain(),
+                activity = data.activity?.notifActivity?.toSnapshot()
+            )
+        }
+        notification.onActivityReplyNotification?.let { data ->
+            return ActivityReplyNotification(
+                id = data.id,
+                type = data.type ?: NotificationType.ACTIVITY_REPLY,
+                createdAt = data.createdAt ?: 0,
+                context = data.context ?: "",
+                activityId = data.activityId,
+                user = data.user?.notifUser?.toDomain(),
+                activity = data.activity?.notifActivity?.toSnapshot()
+            )
+        }
+        notification.onActivityReplySubscribedNotification?.let { data ->
+            return ActivityReplySubscribedNotification(
+                id = data.id,
+                type = data.type ?: NotificationType.ACTIVITY_REPLY_SUBSCRIBED,
+                createdAt = data.createdAt ?: 0,
+                context = data.context ?: "",
+                activityId = data.activityId,
+                user = data.user?.notifUser?.toDomain(),
+                activity = data.activity?.notifActivity?.toSnapshot()
+            )
+        }
+        notification.onActivityReplyLikeNotification?.let { data ->
+            return ActivityReplyLikeNotification(
+                id = data.id,
+                type = data.type ?: NotificationType.ACTIVITY_REPLY_LIKE,
+                createdAt = data.createdAt ?: 0,
+                context = data.context ?: "",
+                activityId = data.activityId,
+                user = data.user?.notifUser?.toDomain(),
+                activity = data.activity?.notifActivity?.toSnapshot()
+            )
+        }
+        notification.onActivityMentionNotification?.let { data ->
+            return ActivityMentionNotification(
+                id = data.id,
+                type = data.type ?: NotificationType.ACTIVITY_MENTION,
+                createdAt = data.createdAt ?: 0,
+                context = data.context ?: "",
+                activityId = data.activityId,
+                user = data.user?.notifUser?.toDomain(),
+                activity = data.activity?.notifActivity?.toSnapshot()
+            )
+        }
+        notification.onActivityMessageNotification?.let { data ->
+            return ActivityMessageNotification(
+                id = data.id,
+                type = data.type ?: NotificationType.ACTIVITY_MESSAGE,
+                createdAt = data.createdAt ?: 0,
+                context = data.context ?: "",
+                activityId = data.activityId,
+                user = data.user?.notifUser?.toDomain(),
+                messagePreview = data.message?.message
+            )
+        }
+        notification.onThreadCommentReplyNotification?.let { data ->
+            return ThreadCommentReplyNotification(
+                id = data.id,
+                type = data.type ?: NotificationType.THREAD_COMMENT_REPLY,
+                createdAt = data.createdAt ?: 0,
+                context = data.context ?: "",
+                user = data.user?.notifUser?.toDomain(),
+                threadId = data.thread?.id ?: 0,
+                threadTitle = data.thread?.title ?: "",
+                commentId = data.comment?.id,
+                commentPreview = data.comment?.comment
+            )
+        }
+        notification.onThreadCommentSubscribedNotification?.let { data ->
+            return ThreadCommentSubscribedNotification(
+                id = data.id,
+                type = data.type ?: NotificationType.THREAD_SUBSCRIBED,
+                createdAt = data.createdAt ?: 0,
+                context = data.context ?: "",
+                user = data.user?.notifUser?.toDomain(),
+                threadId = data.thread?.id ?: 0,
+                threadTitle = data.thread?.title ?: "",
+                commentId = data.comment?.id,
+                commentPreview = data.comment?.comment
+            )
+        }
+        notification.onThreadCommentMentionNotification?.let { data ->
+            return ThreadCommentMentionNotification(
+                id = data.id,
+                type = data.type ?: NotificationType.THREAD_COMMENT_MENTION,
+                createdAt = data.createdAt ?: 0,
+                context = data.context ?: "",
+                user = data.user?.notifUser?.toDomain(),
+                threadId = data.thread?.id ?: 0,
+                threadTitle = data.thread?.title ?: "",
+                commentId = data.comment?.id,
+                commentPreview = data.comment?.comment
+            )
+        }
+        notification.onThreadLikeNotification?.let { data ->
+            return ThreadLikeNotification(
+                id = data.id,
+                type = data.type ?: NotificationType.THREAD_LIKE,
+                createdAt = data.createdAt ?: 0,
+                context = data.context ?: "",
+                user = data.user?.notifUser?.toDomain(),
+                threadId = data.thread?.id ?: 0,
+                threadTitle = data.thread?.title ?: ""
+            )
+        }
+        notification.onThreadCommentLikeNotification?.let { data ->
+            return ThreadCommentLikeNotification(
+                id = data.id,
+                type = data.type ?: NotificationType.THREAD_COMMENT_LIKE,
+                createdAt = data.createdAt ?: 0,
+                context = data.context ?: "",
+                user = data.user?.notifUser?.toDomain(),
+                threadId = data.thread?.id ?: 0,
+                threadTitle = data.thread?.title ?: "",
+                commentId = data.comment?.id,
+                commentPreview = data.comment?.comment
+            )
+        }
+        notification.onRelatedMediaAdditionNotification?.let { data ->
+            return RelatedMediaAdditionNotification(
+                id = data.id,
+                type = data.type ?: NotificationType.RELATED_MEDIA_ADDITION,
+                createdAt = data.createdAt ?: 0,
+                context = data.context ?: "",
+                mediaId = data.mediaId,
+                media = data.media?.notifMedia?.toDomain()
+            )
+        }
+        notification.onMediaDataChangeNotification?.let { data ->
+            return MediaDataChangeNotification(
+                id = data.id,
+                type = data.type ?: NotificationType.MEDIA_DATA_CHANGE,
+                createdAt = data.createdAt ?: 0,
+                context = data.context ?: "",
+                reason = data.reason ?: "",
+                mediaId = data.mediaId,
+                media = data.media?.notifMedia?.toDomain()
+            )
+        }
+        notification.onMediaMergeNotification?.let { data ->
+            return MediaMergeNotification(
+                id = data.id,
+                type = data.type ?: NotificationType.MEDIA_MERGE,
+                createdAt = data.createdAt ?: 0,
+                context = data.context ?: "",
+                reason = data.reason ?: "",
+                mediaId = data.mediaId,
+                deletedMediaTitles = data.deletedMediaTitles?.filterNotNull() ?: emptyList(),
+                media = data.media?.notifMedia?.toDomain()
+            )
+        }
+        notification.onMediaDeletionNotification?.let { data ->
+            return MediaDeletionNotification(
+                id = data.id,
+                type = data.type ?: NotificationType.MEDIA_DELETION,
+                createdAt = data.createdAt ?: 0,
+                context = data.context ?: "",
+                reason = data.reason ?: "",
+                deletedMediaTitle = data.deletedMediaTitle ?: ""
+            )
+        }
+        return null
     }
 
     override suspend fun getFirstEpisodeAirings(mediaIds: List<Int>): Result<List<AiringSchedule>> {
@@ -599,8 +400,8 @@ class NotificationRepositoryImpl @Inject constructor(
                             mediaId = it.mediaId ?: 0,
                             mediaTitle = it.media?.title?.userPreferred ?: "Unknown",
                             mediaCoverUrl = it.media?.coverImage?.large,
-                            mediaCover = com.anisync.android.domain.CoverImage.of(it.media?.coverImage?.medium, it.media?.coverImage?.large, it.media?.coverImage?.extraLarge),
-                            mediaType = it.media?.type ?: com.anisync.android.type.MediaType.ANIME
+                            mediaCover = CoverImage.of(it.media?.coverImage?.medium, it.media?.coverImage?.large, it.media?.coverImage?.extraLarge),
+                            mediaType = it.media?.type ?: MediaType.ANIME
                         )
                     } else {
                         null
@@ -643,8 +444,8 @@ class NotificationRepositoryImpl @Inject constructor(
                             mediaId = it.mediaId ?: 0,
                             mediaTitle = it.media?.title?.userPreferred ?: "Unknown",
                             mediaCoverUrl = it.media?.coverImage?.large,
-                            mediaCover = com.anisync.android.domain.CoverImage.of(it.media?.coverImage?.medium, it.media?.coverImage?.large, it.media?.coverImage?.extraLarge),
-                            mediaType = it.media?.type ?: com.anisync.android.type.MediaType.ANIME
+                            mediaCover = CoverImage.of(it.media?.coverImage?.medium, it.media?.coverImage?.large, it.media?.coverImage?.extraLarge),
+                            mediaType = it.media?.type ?: MediaType.ANIME
                         )
                     } else {
                         null

--- a/app/src/main/java/com/anisync/android/data/repository/PreferencesRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/repository/PreferencesRepositoryImpl.kt
@@ -88,6 +88,19 @@ class PreferencesRepositoryImpl @Inject constructor(
                 .putStringSet(k, validIds.map { it.toString() }.toSet())
                 .apply()
         }
+
+        // Prune the advance_/imminent_ dedup keys of airings that left the upcoming window too.
+        // They're never consulted again once the airing is out of the window, and without this the
+        // set only shrinks via the size cap, which evicts arbitrary entries (StringSet is unordered)
+        // and can re-fire alerts whose key got dropped.
+        val keysKey = key(KEY_NOTIFICATION_KEYS, accountId)
+        val notificationKeys = prefs.getStringSet(keysKey, emptySet()) ?: emptySet()
+        val validKeys = notificationKeys.filterTo(mutableSetOf()) { entry ->
+            entry.substringAfterLast('_').toIntOrNull() in currentValidIds
+        }
+        if (validKeys.size != notificationKeys.size) {
+            prefs.edit().putStringSet(keysKey, validKeys).apply()
+        }
     }
 
     override suspend fun hasNotificationsEverRun(accountId: Int): Boolean = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/anisync/android/domain/Notification.kt
+++ b/app/src/main/java/com/anisync/android/domain/Notification.kt
@@ -32,6 +32,19 @@ data class FollowingNotification(
  */
 enum class ActivityKind { TEXT, ANIME_LIST, MANGA_LIST, MESSAGE, UNKNOWN }
 
+/** Noun phrase for the activity subtype, shared by the inbox cards and system notifications. */
+fun ActivityKind?.noun(): String = when (this) {
+    ActivityKind.TEXT -> "status update"
+    ActivityKind.ANIME_LIST -> "anime list update"
+    ActivityKind.MANGA_LIST -> "manga list update"
+    ActivityKind.MESSAGE -> "message"
+    ActivityKind.UNKNOWN, null -> "post"
+}
+
+/** [noun] with the right indefinite article ("an anime list update", "a post"). */
+fun ActivityKind?.indefiniteNoun(): String =
+    noun().let { if (it.first() in "aeiou") "an $it" else "a $it" }
+
 data class ActivitySnapshot(
     val kind: ActivityKind,
     val text: String? = null,        // TextActivity body

--- a/app/src/main/java/com/anisync/android/presentation/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/notifications/NotificationsViewModel.kt
@@ -2,6 +2,7 @@ package com.anisync.android.presentation.notifications
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.anisync.android.data.NotificationBadgeStore
 import com.anisync.android.domain.GetNotificationsUseCase
 import com.anisync.android.domain.Notification
 import com.anisync.android.domain.NotificationFilter
@@ -19,7 +20,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class NotificationsViewModel @Inject constructor(
-    private val getNotifications: GetNotificationsUseCase
+    private val getNotifications: GetNotificationsUseCase,
+    private val badgeStore: NotificationBadgeStore
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(NotificationsUiState())
@@ -38,6 +40,10 @@ class NotificationsViewModel @Inject constructor(
     private val snapshots = mutableMapOf<NotificationFilter, FilterSnapshot>()
 
     init {
+        // Clear the unread badge on any entry into the inbox (profile bell, deep link, system
+        // notification tap) — not just the profile path. The ALL first-page load below asks the
+        // server to reset its count too, so the next badge refresh agrees.
+        badgeStore.clearOptimistically()
         load(reset = true, isInitial = true)
     }
 
@@ -79,13 +85,13 @@ class NotificationsViewModel @Inject constructor(
                     entries = cached.entries,
                     hasNextPage = cached.hasNextPage,
                     isLoading = false,
-                    isRefreshing = true,
+                    isRefreshing = false,
                     isPaginating = false,
                     errorMessage = null
                 )
             }
-            // Silent background refresh; UI shows cached data immediately.
-            load(reset = true, isInitial = false, refreshing = true)
+            // Silent background refresh; UI shows cached data immediately, no spinner.
+            load(reset = true, isInitial = false, quiet = true)
         } else {
             nextPage = 1
             _uiState.update {
@@ -104,17 +110,19 @@ class NotificationsViewModel @Inject constructor(
         }
     }
 
-    private fun load(reset: Boolean, isInitial: Boolean, refreshing: Boolean = false) {
+    private fun load(reset: Boolean, isInitial: Boolean, refreshing: Boolean = false, quiet: Boolean = false) {
         loadJob?.cancel()
         if (reset) nextPage = 1
 
-        _uiState.update {
-            it.copy(
-                isLoading = isInitial,
-                isRefreshing = refreshing,
-                isPaginating = !isInitial && !refreshing,
-                errorMessage = null
-            )
+        if (!quiet) {
+            _uiState.update {
+                it.copy(
+                    isLoading = isInitial,
+                    isRefreshing = refreshing,
+                    isPaginating = !isInitial && !refreshing,
+                    errorMessage = null
+                )
+            }
         }
 
         val filter = _uiState.value.filter

--- a/app/src/main/java/com/anisync/android/presentation/notifications/components/NotificationGroupCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/notifications/components/NotificationGroupCard.kt
@@ -21,6 +21,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.MergeType
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PlayCircleOutline
 import androidx.compose.material3.Card
@@ -29,7 +31,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -83,9 +89,16 @@ fun NotificationGroupCard(
     selectedTarget: NotificationTarget? = null
 ) {
     val payload = entry.toPayload()
+    // Moderation notes (data change / merge / deletion reasons) can be long; the card expands in
+    // place instead of navigating, and the cover thumb keeps the media-details click.
+    var expanded by rememberSaveable(entry.key) { mutableStateOf(false) }
     Card(
         onClick = {
-            payload.handleClick(onMediaClick, onUserClick, onActivityClick, onThreadClick)
+            if (payload.expandableNote) {
+                expanded = !expanded
+            } else {
+                payload.handleClick(onMediaClick, onUserClick, onActivityClick, onThreadClick)
+            }
         },
         modifier = modifier
             .fillMaxWidth()
@@ -104,6 +117,7 @@ fun NotificationGroupCard(
             MediaCardBody(
                 entry = entry,
                 payload = payload,
+                expanded = expanded,
                 onMediaClick = onMediaClick
             )
         } else {
@@ -111,6 +125,7 @@ fun NotificationGroupCard(
             SocialCardBody(
                 entry = entry,
                 payload = payload,
+                expanded = expanded,
                 onMediaClick = onMediaClick,
                 onUserClick = onUserClick
             )
@@ -118,10 +133,22 @@ fun NotificationGroupCard(
     }
 }
 
+/** Chevron shown on expandable-note cards next to the timestamp. */
+@Composable
+private fun ExpandChevron(expanded: Boolean) {
+    Icon(
+        imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.size(18.dp)
+    )
+}
+
 @Composable
 private fun MediaCardBody(
     entry: NotificationEntry,
     payload: GroupPayload,
+    expanded: Boolean,
     onMediaClick: (Int) -> Unit
 ) {
     Row(
@@ -141,14 +168,20 @@ private fun MediaCardBody(
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )
-            SubtitleSlots(payload = payload)
+            SubtitleSlots(payload = payload, expanded = expanded)
         }
         Spacer(modifier = Modifier.width(8.dp))
-        Text(
-            text = formatRelative(entry.representative.createdAt.toLong()),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
+        Column(horizontalAlignment = Alignment.End) {
+            Text(
+                text = formatRelative(entry.representative.createdAt.toLong()),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            if (payload.expandableNote) {
+                Spacer(modifier = Modifier.height(4.dp))
+                ExpandChevron(expanded)
+            }
+        }
     }
 }
 
@@ -156,6 +189,7 @@ private fun MediaCardBody(
 private fun SocialCardBody(
     entry: NotificationEntry,
     payload: GroupPayload,
+    expanded: Boolean,
     onMediaClick: (Int) -> Unit,
     onUserClick: (String) -> Unit
 ) {
@@ -173,6 +207,10 @@ private fun SocialCardBody(
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+            if (payload.expandableNote) {
+                Spacer(modifier = Modifier.width(6.dp))
+                ExpandChevron(expanded)
+            }
         }
 
         Spacer(modifier = Modifier.height(12.dp))
@@ -185,7 +223,7 @@ private fun SocialCardBody(
             overflow = TextOverflow.Ellipsis
         )
 
-        SubtitleSlots(payload = payload)
+        SubtitleSlots(payload = payload, expanded = expanded)
     }
 }
 
@@ -197,13 +235,14 @@ private fun SocialCardBody(
  * stays compact and predictable.
  */
 @Composable
-private fun SubtitleSlots(payload: GroupPayload) {
+private fun SubtitleSlots(payload: GroupPayload, expanded: Boolean = false) {
     val plain = payload.subtitlePlain
     val bodyExcerpt = payload.subtitleHtml
         ?.takeIf { it.isNotBlank() }
         ?.let { remember(it) { htmlToPlainExcerpt(it) } }
         ?.takeIf { it.isNotBlank() }
     if (plain == null && bodyExcerpt == null) return
+    val maxLines = if (expanded) Int.MAX_VALUE else 2
 
     if (plain != null) {
         Spacer(modifier = Modifier.height(6.dp))
@@ -211,7 +250,7 @@ private fun SubtitleSlots(payload: GroupPayload) {
             text = plain,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 2,
+            maxLines = maxLines,
             overflow = TextOverflow.Ellipsis
         )
     }
@@ -222,7 +261,7 @@ private fun SubtitleSlots(payload: GroupPayload) {
             text = bodyExcerpt,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 2,
+            maxLines = maxLines,
             overflow = TextOverflow.Ellipsis
         )
     }
@@ -342,7 +381,9 @@ private data class GroupPayload(
     val mediaId: Int? = null,
     val threadId: Int? = null,
     val threadCommentId: Int? = null,
-    val userName: String? = null
+    val userName: String? = null,
+    /** Card click expands the note in place instead of navigating (moderation reasons). */
+    val expandableNote: Boolean = false
 ) {
     fun handleClick(
         onMediaClick: (Int) -> Unit,
@@ -478,26 +519,31 @@ private fun NotificationEntry.toPayload(): GroupPayload {
         )
         is MediaDataChangeNotification -> GroupPayload(
             headline = rep.media?.title ?: "A title on your list",
-            subtitlePlain = rep.reason.ifBlank { rep.context.ifBlank { "had data updated" } },
+            subtitlePlain = rep.context.trim().ifBlank { "had data updated" },
+            // Moderation note rides the body slot so the card can expand to show all of it.
+            subtitleHtml = rep.reason.takeIf { it.isNotBlank() },
             leadingMediaCover = rep.media?.coverUrl,
             fallbackIcon = Icons.Default.Edit,
-            mediaId = rep.mediaId
+            mediaId = rep.mediaId,
+            expandableNote = rep.reason.isNotBlank()
         )
         is MediaMergeNotification -> {
             val merged = rep.deletedMediaTitles.joinToString(", ").ifBlank { "Entries" }
             val target = rep.media?.title ?: "another entry"
             GroupPayload(
                 headline = "$merged merged into $target",
-                subtitlePlain = rep.reason.ifBlank { null },
+                subtitleHtml = rep.reason.takeIf { it.isNotBlank() },
                 leadingMediaCover = rep.media?.coverUrl,
                 fallbackIcon = Icons.AutoMirrored.Filled.MergeType,
-                mediaId = rep.mediaId
+                mediaId = rep.mediaId,
+                expandableNote = rep.reason.isNotBlank()
             )
         }
         is MediaDeletionNotification -> GroupPayload(
             headline = "${rep.deletedMediaTitle} was removed from the site",
-            subtitlePlain = rep.reason.ifBlank { null },
-            fallbackIcon = Icons.Default.Delete
+            subtitleHtml = rep.reason.takeIf { it.isNotBlank() },
+            fallbackIcon = Icons.Default.Delete,
+            expandableNote = rep.reason.isNotBlank()
         )
         is UnknownNotification -> GroupPayload(headline = "New notification")
     }

--- a/app/src/main/java/com/anisync/android/presentation/notifications/components/NotificationGroupCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/notifications/components/NotificationGroupCard.kt
@@ -63,6 +63,8 @@ import com.anisync.android.domain.ThreadCommentSubscribedNotification
 import com.anisync.android.domain.ThreadLikeNotification
 import com.anisync.android.domain.UnknownNotification
 import com.anisync.android.domain.User
+import com.anisync.android.domain.indefiniteNoun
+import com.anisync.android.domain.noun
 import com.anisync.android.presentation.notifications.NotificationEntry
 import com.anisync.android.presentation.notifications.NotificationTarget
 import com.anisync.android.presentation.util.selectedPaneItem
@@ -230,10 +232,14 @@ private fun SubtitleSlots(payload: GroupPayload) {
  * Strips AniList rich-text HTML to a plain text excerpt. Drops embedded
  * images, videos and AniList link cards — those would overflow the card
  * and add visual noise. Whitespace is collapsed so a short multi-paragraph
- * comment reads as a single tidy line.
+ * comment reads as a single tidy line. Spoiler spans are removed entirely:
+ * `.text()` would otherwise print their hidden content in the preview.
  */
-private fun htmlToPlainExcerpt(html: String): String =
-    Jsoup.parse(html).text().trim()
+private fun htmlToPlainExcerpt(html: String): String {
+    val document = Jsoup.parse(html)
+    document.select("span.markdown_spoiler").remove()
+    return document.text().trim()
+}
 
 @Composable
 private fun NotificationLeading(
@@ -571,16 +577,10 @@ private fun combineActors(actors: List<User>, verb: String): String {
  * AniList serves a generic "activity" string for all three subtypes, but the
  * activity union itself tells us whether the post is a text status, a list
  * update, or a DM — surface that distinction directly in the headline.
+ * "a" as the possessive picks the right indefinite article ("an anime list update").
  */
-private fun activityNoun(activity: ActivitySnapshot?, possessive: String): String {
-    return when (activity?.kind) {
-        ActivityKind.TEXT -> "$possessive status update"
-        ActivityKind.ANIME_LIST -> "$possessive anime list update"
-        ActivityKind.MANGA_LIST -> "$possessive manga list update"
-        ActivityKind.MESSAGE -> "$possessive message"
-        ActivityKind.UNKNOWN, null -> "$possessive post"
-    }
-}
+private fun activityNoun(activity: ActivitySnapshot?, possessive: String): String =
+    if (possessive == "a") activity?.kind.indefiniteNoun() else "$possessive ${activity?.kind.noun()}"
 
 /**
  * Splits an activity snapshot into the two subtitle slots — list activities

--- a/app/src/main/java/com/anisync/android/presentation/notifications/components/NotificationGroupCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/notifications/components/NotificationGroupCard.kt
@@ -1,5 +1,6 @@
 package com.anisync.android.presentation.notifications.components
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -102,6 +103,7 @@ fun NotificationGroupCard(
         },
         modifier = modifier
             .fillMaxWidth()
+            .animateContentSize()
             .selectedPaneItem(payload.isSelectedBy(selectedTarget), MaterialTheme.shapes.large),
         shape = MaterialTheme.shapes.large,
         colors = CardDefaults.cardColors(
@@ -133,15 +135,26 @@ fun NotificationGroupCard(
     }
 }
 
-/** Chevron shown on expandable-note cards next to the timestamp. */
+/** Explicit expand/collapse affordance under an expandable note — the whole card toggles it. */
 @Composable
-private fun ExpandChevron(expanded: Boolean) {
-    Icon(
-        imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-        contentDescription = null,
-        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.size(18.dp)
-    )
+private fun ExpandAffordance(expanded: Boolean) {
+    Row(
+        modifier = Modifier.padding(top = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(18.dp)
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = if (expanded) "Show less" else "Show more",
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary
+        )
+    }
 }
 
 @Composable
@@ -169,19 +182,16 @@ private fun MediaCardBody(
                 overflow = TextOverflow.Ellipsis
             )
             SubtitleSlots(payload = payload, expanded = expanded)
-        }
-        Spacer(modifier = Modifier.width(8.dp))
-        Column(horizontalAlignment = Alignment.End) {
-            Text(
-                text = formatRelative(entry.representative.createdAt.toLong()),
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
             if (payload.expandableNote) {
-                Spacer(modifier = Modifier.height(4.dp))
-                ExpandChevron(expanded)
+                ExpandAffordance(expanded)
             }
         }
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = formatRelative(entry.representative.createdAt.toLong()),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }
 
@@ -207,10 +217,6 @@ private fun SocialCardBody(
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            if (payload.expandableNote) {
-                Spacer(modifier = Modifier.width(6.dp))
-                ExpandChevron(expanded)
-            }
         }
 
         Spacer(modifier = Modifier.height(12.dp))
@@ -224,6 +230,9 @@ private fun SocialCardBody(
         )
 
         SubtitleSlots(payload = payload, expanded = expanded)
+        if (payload.expandableNote) {
+            ExpandAffordance(expanded)
+        }
     }
 }
 

--- a/app/src/main/java/com/anisync/android/presentation/settings/NotificationsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/NotificationsScreen.kt
@@ -77,6 +77,7 @@ fun NotificationsScreen(
     val activityMentionEnabled = uiState.activityMentionEnabled
     val activityLikeEnabled = uiState.activityLikeEnabled
     val activityMessageEnabled = uiState.activityMessageEnabled
+    val followsEnabled = uiState.followsEnabled
     val streamingDelayMinutes = uiState.streamingDelayMinutes
 
     var hasSystemPermission by rememberSaveable { mutableStateOf(true) }
@@ -287,6 +288,14 @@ fun NotificationsScreen(
                     checked = activityMessageEnabled,
                     enabled = isNotificationsEnabled,
                     onCheckedChange = { viewModel.onAction(SettingsAction.SetActivityMessageEnabled(it)) }
+                )
+                SettingsDivider()
+                SwitchSettingsItem(
+                    title = stringResource(R.string.notification_follows),
+                    subtitle = stringResource(R.string.notification_follows_desc),
+                    checked = followsEnabled,
+                    enabled = isNotificationsEnabled,
+                    onCheckedChange = { viewModel.onAction(SettingsAction.SetFollowsEnabled(it)) }
                 )
             }
         }

--- a/app/src/main/java/com/anisync/android/presentation/settings/SettingsUiState.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/SettingsUiState.kt
@@ -48,6 +48,7 @@ sealed interface SettingsAction {
     data class SetActivityMentionEnabled(val enabled: Boolean) : SettingsAction
     data class SetActivityLikeEnabled(val enabled: Boolean) : SettingsAction
     data class SetActivityMessageEnabled(val enabled: Boolean) : SettingsAction
+    data class SetFollowsEnabled(val enabled: Boolean) : SettingsAction
     data class SetStreamingDelayMinutes(val minutes: Int) : SettingsAction
 
     data class SetAutoUpdateEnabled(val enabled: Boolean) : SettingsAction
@@ -147,6 +148,7 @@ data class SettingsUiState(
     val activityMentionEnabled: Boolean = true,
     val activityLikeEnabled: Boolean = true,
     val activityMessageEnabled: Boolean = true,
+    val followsEnabled: Boolean = true,
     val streamingDelayMinutes: Int = 0,
 
     // Storage

--- a/app/src/main/java/com/anisync/android/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/settings/SettingsViewModel.kt
@@ -137,9 +137,10 @@ class SettingsViewModel @Inject constructor(
                 notificationPreferences.activityReplyEnabled,
                 notificationPreferences.activityMentionEnabled,
                 notificationPreferences.activityLikeEnabled,
-                notificationPreferences.activityMessageEnabled
-            ) { reply, mention, like, message ->
-                listOf<Any>(reply, mention, like, message)
+                notificationPreferences.activityMessageEnabled,
+                notificationPreferences.followsEnabled
+            ) { reply, mention, like, message, follows ->
+                listOf<Any>(reply, mention, like, message, follows)
             }
         ) { airing, forum, activity ->
             airing + forum + activity
@@ -185,6 +186,7 @@ class SettingsViewModel @Inject constructor(
             activityMentionEnabled = notifications[11] as Boolean,
             activityLikeEnabled = notifications[12] as Boolean,
             activityMessageEnabled = notifications[13] as Boolean,
+            followsEnabled = notifications[14] as Boolean,
             isAutoUpdateEnabled = updatesAndNav.autoUpdate,
             isPrereleaseAllowed = updatesAndNav.allowPrerelease,
             navBarStyle = updatesAndNav.navBarStyle,
@@ -288,6 +290,10 @@ class SettingsViewModel @Inject constructor(
             )
 
             is SettingsAction.SetActivityMessageEnabled -> notificationPreferences.setActivityMessageEnabled(
+                action.enabled
+            )
+
+            is SettingsAction.SetFollowsEnabled -> notificationPreferences.setFollowsEnabled(
                 action.enabled
             )
 

--- a/app/src/main/java/com/anisync/android/worker/AddToWatchingReceiver.kt
+++ b/app/src/main/java/com/anisync/android/worker/AddToWatchingReceiver.kt
@@ -34,6 +34,7 @@ class AddToWatchingReceiver : BroadcastReceiver() {
         const val ACTION_ADD_TO_WATCHING = "com.anisync.android.ACTION_ADD_TO_WATCHING"
         const val EXTRA_MEDIA_ID = "extra_media_id"
         const val EXTRA_NOTIFICATION_ID = "extra_notification_id"
+        const val EXTRA_NOTIFICATION_TAG = "extra_notification_tag"
         const val EXTRA_MEDIA_TITLE = "extra_media_title"
         private const val TAG = "AddToWatchingReceiver"
     }
@@ -43,6 +44,8 @@ class AddToWatchingReceiver : BroadcastReceiver() {
 
         val mediaId = intent.getIntExtra(EXTRA_MEDIA_ID, -1)
         val notificationId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
+        // The worker posts under a per-account tag; cancelling without it never matches.
+        val notificationTag = intent.getStringExtra(EXTRA_NOTIFICATION_TAG)
         val mediaTitle = intent.getStringExtra(EXTRA_MEDIA_TITLE) ?: "Anime"
 
         if (mediaId == -1) {
@@ -53,7 +56,7 @@ class AddToWatchingReceiver : BroadcastReceiver() {
         // Dismiss the notification immediately
         val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         if (notificationId != -1) {
-            notificationManager.cancel(notificationId)
+            notificationManager.cancel(notificationTag, notificationId)
         }
 
         // Use goAsync() to extend the BroadcastReceiver's lifecycle for the coroutine

--- a/app/src/main/java/com/anisync/android/worker/NotificationChannels.kt
+++ b/app/src/main/java/com/anisync/android/worker/NotificationChannels.kt
@@ -1,6 +1,7 @@
 package com.anisync.android.worker
 
 import android.app.NotificationChannel
+import android.app.NotificationChannelGroup
 import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
@@ -20,132 +21,68 @@ object NotificationChannels {
     const val ACTIVITY_MENTION_CHANNEL_ID = "activity_mention_notifications"
     const val ACTIVITY_LIKE_CHANNEL_ID = "activity_like_notifications"
     const val ACTIVITY_MESSAGE_CHANNEL_ID = "activity_message_notifications"
+    const val FOLLOW_CHANNEL_ID = "follow_notifications"
+
+    private const val GROUP_AIRING_ID = "group_airing"
+    private const val GROUP_FORUM_ID = "group_forum"
+    private const val GROUP_ACTIVITY_ID = "group_activity"
+    private const val GROUP_OTHER_ID = "group_other"
+
+    private data class ChannelSpec(
+        val id: String,
+        val nameRes: Int,
+        val descriptionRes: Int,
+        val groupId: String,
+    )
 
     fun createChannels(context: Context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-            val airingChannel = NotificationChannel(
-                AIRING_CHANNEL_ID,
-                context.getString(R.string.notification_channel_watching),
-                NotificationManager.IMPORTANCE_DEFAULT
-            ).apply {
-                description = context.getString(R.string.notification_channel_watching_desc)
-            }
-
-            val planningChannel = NotificationChannel(
-                PLANNING_CHANNEL_ID,
-                context.getString(R.string.notification_channel_planning),
-                NotificationManager.IMPORTANCE_DEFAULT
-            ).apply {
-                description = context.getString(R.string.notification_channel_planning_desc)
-            }
-
-            val upcomingChannel = NotificationChannel(
-                UPCOMING_CHANNEL_ID,
-                context.getString(R.string.notification_channel_upcoming),
-                NotificationManager.IMPORTANCE_DEFAULT
-            ).apply {
-                description = context.getString(R.string.notification_channel_upcoming_desc)
-            }
-
-            val threadCommentReplyChannel = NotificationChannel(
-                THREAD_COMMENT_REPLY_CHANNEL_ID,
-                context.getString(R.string.notification_channel_thread_comment_reply),
-                NotificationManager.IMPORTANCE_DEFAULT
-            ).apply {
-                description = context.getString(R.string.notification_channel_thread_comment_reply_desc)
-            }
-
-            val threadSubscribedChannel = NotificationChannel(
-                THREAD_SUBSCRIBED_CHANNEL_ID,
-                context.getString(R.string.notification_channel_thread_subscribed),
-                NotificationManager.IMPORTANCE_DEFAULT
-            ).apply {
-                description = context.getString(R.string.notification_channel_thread_subscribed_desc)
-            }
-
-            val threadCommentMentionChannel = NotificationChannel(
-                THREAD_COMMENT_MENTION_CHANNEL_ID,
-                context.getString(R.string.notification_channel_thread_comment_mention),
-                NotificationManager.IMPORTANCE_DEFAULT
-            ).apply {
-                description = context.getString(R.string.notification_channel_thread_comment_mention_desc)
-            }
-
-            val threadLikeChannel = NotificationChannel(
-                THREAD_LIKE_CHANNEL_ID,
-                context.getString(R.string.notification_channel_thread_like),
-                NotificationManager.IMPORTANCE_DEFAULT
-            ).apply {
-                description = context.getString(R.string.notification_channel_thread_like_desc)
-            }
-
-            val threadCommentLikeChannel = NotificationChannel(
-                THREAD_COMMENT_LIKE_CHANNEL_ID,
-                context.getString(R.string.notification_channel_thread_comment_like),
-                NotificationManager.IMPORTANCE_DEFAULT
-            ).apply {
-                description = context.getString(R.string.notification_channel_thread_comment_like_desc)
-            }
-
-            val updateChannel = NotificationChannel(
-                UPDATE_CHANNEL_ID,
-                context.getString(R.string.update_notification_channel_name),
-                NotificationManager.IMPORTANCE_DEFAULT
-            ).apply {
-                description = context.getString(R.string.update_notification_channel_desc)
-            }
-
-            val activityReplyChannel = NotificationChannel(
-                ACTIVITY_REPLY_CHANNEL_ID,
-                context.getString(R.string.notification_channel_activity_reply),
-                NotificationManager.IMPORTANCE_DEFAULT
-            ).apply {
-                description = context.getString(R.string.notification_channel_activity_reply_desc)
-            }
-
-            val activityMentionChannel = NotificationChannel(
-                ACTIVITY_MENTION_CHANNEL_ID,
-                context.getString(R.string.notification_channel_activity_mention),
-                NotificationManager.IMPORTANCE_DEFAULT
-            ).apply {
-                description = context.getString(R.string.notification_channel_activity_mention_desc)
-            }
-
-            val activityLikeChannel = NotificationChannel(
-                ACTIVITY_LIKE_CHANNEL_ID,
-                context.getString(R.string.notification_channel_activity_like),
-                NotificationManager.IMPORTANCE_DEFAULT
-            ).apply {
-                description = context.getString(R.string.notification_channel_activity_like_desc)
-            }
-
-            val activityMessageChannel = NotificationChannel(
-                ACTIVITY_MESSAGE_CHANNEL_ID,
-                context.getString(R.string.notification_channel_activity_message),
-                NotificationManager.IMPORTANCE_DEFAULT
-            ).apply {
-                description = context.getString(R.string.notification_channel_activity_message_desc)
-            }
-
-            notificationManager.createNotificationChannels(
-                listOf(
-                    airingChannel,
-                    planningChannel,
-                    upcomingChannel,
-                    threadCommentReplyChannel,
-                    threadSubscribedChannel,
-                    threadCommentMentionChannel,
-                    threadLikeChannel,
-                    threadCommentLikeChannel,
-                    updateChannel,
-                    activityReplyChannel,
-                    activityMentionChannel,
-                    activityLikeChannel,
-                    activityMessageChannel
-                )
+        notificationManager.createNotificationChannelGroups(
+            listOf(
+                NotificationChannelGroup(GROUP_AIRING_ID, context.getString(R.string.notification_group_airing)),
+                NotificationChannelGroup(GROUP_FORUM_ID, context.getString(R.string.notification_group_forum)),
+                NotificationChannelGroup(GROUP_ACTIVITY_ID, context.getString(R.string.notification_group_activity)),
+                NotificationChannelGroup(GROUP_OTHER_ID, context.getString(R.string.notification_group_other)),
             )
+        )
+
+        val specs = listOf(
+            ChannelSpec(AIRING_CHANNEL_ID, R.string.notification_channel_watching, R.string.notification_channel_watching_desc, GROUP_AIRING_ID),
+            ChannelSpec(PLANNING_CHANNEL_ID, R.string.notification_channel_planning, R.string.notification_channel_planning_desc, GROUP_AIRING_ID),
+            ChannelSpec(UPCOMING_CHANNEL_ID, R.string.notification_channel_upcoming, R.string.notification_channel_upcoming_desc, GROUP_AIRING_ID),
+            ChannelSpec(THREAD_COMMENT_REPLY_CHANNEL_ID, R.string.notification_channel_thread_comment_reply, R.string.notification_channel_thread_comment_reply_desc, GROUP_FORUM_ID),
+            ChannelSpec(THREAD_SUBSCRIBED_CHANNEL_ID, R.string.notification_channel_thread_subscribed, R.string.notification_channel_thread_subscribed_desc, GROUP_FORUM_ID),
+            ChannelSpec(THREAD_COMMENT_MENTION_CHANNEL_ID, R.string.notification_channel_thread_comment_mention, R.string.notification_channel_thread_comment_mention_desc, GROUP_FORUM_ID),
+            ChannelSpec(THREAD_LIKE_CHANNEL_ID, R.string.notification_channel_thread_like, R.string.notification_channel_thread_like_desc, GROUP_FORUM_ID),
+            ChannelSpec(THREAD_COMMENT_LIKE_CHANNEL_ID, R.string.notification_channel_thread_comment_like, R.string.notification_channel_thread_comment_like_desc, GROUP_FORUM_ID),
+            ChannelSpec(ACTIVITY_REPLY_CHANNEL_ID, R.string.notification_channel_activity_reply, R.string.notification_channel_activity_reply_desc, GROUP_ACTIVITY_ID),
+            ChannelSpec(ACTIVITY_MENTION_CHANNEL_ID, R.string.notification_channel_activity_mention, R.string.notification_channel_activity_mention_desc, GROUP_ACTIVITY_ID),
+            ChannelSpec(ACTIVITY_LIKE_CHANNEL_ID, R.string.notification_channel_activity_like, R.string.notification_channel_activity_like_desc, GROUP_ACTIVITY_ID),
+            ChannelSpec(ACTIVITY_MESSAGE_CHANNEL_ID, R.string.notification_channel_activity_message, R.string.notification_channel_activity_message_desc, GROUP_ACTIVITY_ID),
+            ChannelSpec(FOLLOW_CHANNEL_ID, R.string.notification_follows, R.string.notification_follows_desc, GROUP_ACTIVITY_ID),
+            ChannelSpec(UPDATE_CHANNEL_ID, R.string.update_notification_channel_name, R.string.update_notification_channel_desc, GROUP_OTHER_ID),
+        )
+
+        val channels = specs.map { spec ->
+            // A channel's group is frozen at creation, so channels from versions before the groups
+            // existed sit ungrouped ("Other" bucket in system settings) forever. Delete those once;
+            // recreating under the same id revives them inside their group.
+            val existing = notificationManager.getNotificationChannel(spec.id)
+            if (existing != null && existing.group == null) {
+                notificationManager.deleteNotificationChannel(spec.id)
+            }
+            NotificationChannel(
+                spec.id,
+                context.getString(spec.nameRes),
+                NotificationManager.IMPORTANCE_DEFAULT
+            ).apply {
+                description = context.getString(spec.descriptionRes)
+                group = spec.groupId
+            }
         }
+
+        notificationManager.createNotificationChannels(channels)
     }
 }

--- a/app/src/main/java/com/anisync/android/worker/NotificationDebugService.kt
+++ b/app/src/main/java/com/anisync/android/worker/NotificationDebugService.kt
@@ -57,14 +57,14 @@ class NotificationDebugService @Inject constructor(
 
     /**
      * Send a test "Watching" notification.
-     * Simulates: "Episode X has aired!" for a show in the watching list.
+     * Simulates: "Episode X has aired" for a show in the watching list.
      */
     fun sendTestWatchingNotification() {
         scope.launch {
             val notificationId = DEBUG_WATCHING_ID
             val title = SAMPLE_TITLE
             val episode = (1..24).random()
-            val content = "Episode $episode has aired!"
+            val content = "Episode $episode has aired"
 
             val intent = Intent(Intent.ACTION_VIEW, Uri.parse("anisync://notifications"))
             val pendingIntent = PendingIntent.getActivity(
@@ -80,7 +80,6 @@ class NotificationDebugService @Inject constructor(
                 .setSmallIcon(R.drawable.ic_notification)
                 .setContentTitle(title)
                 .setContentText(content)
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .setAutoCancel(true)
                 .setGroup(GROUP_KEY_AIRING)
                 .setContentIntent(pendingIntent)
@@ -96,12 +95,12 @@ class NotificationDebugService @Inject constructor(
 
     /**
      * Send a test "Planning" notification.
-     * Simulates: "Episode 1 is now available!" for a show in the planning list.
+     * Simulates: "Episode 1 is now available" for a show in the planning list.
      */
     fun sendTestPlanningNotification() {
         scope.launch {
             val notificationId = DEBUG_PLANNING_ID
-            val title = "$SAMPLE_TITLE has started!"
+            val title = SAMPLE_TITLE
             val content = "Episode 1 is now available"
 
             val intent = Intent(Intent.ACTION_VIEW, Uri.parse("anisync://details/$SAMPLE_MEDIA_ID"))
@@ -132,7 +131,6 @@ class NotificationDebugService @Inject constructor(
                 .setSmallIcon(R.drawable.ic_notification)
                 .setContentTitle(title)
                 .setContentText(content)
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .setAutoCancel(true)
                 .setGroup(GROUP_KEY_PLANNING)
                 .setContentIntent(pendingIntent)
@@ -158,8 +156,8 @@ class NotificationDebugService @Inject constructor(
     fun sendTestAdvanceNotification() {
         scope.launch {
             val notificationId = DEBUG_ADVANCE_ID
-            val title = "📅 Premiere Alert: $SAMPLE_TITLE"
-            
+            val title = SAMPLE_TITLE
+
             // Simulate airing time as tomorrow at a random afternoon hour
             val calendar = Calendar.getInstance().apply {
                 add(Calendar.DAY_OF_YEAR, 1)
@@ -186,7 +184,6 @@ class NotificationDebugService @Inject constructor(
                 .setSmallIcon(R.drawable.ic_notification)
                 .setContentTitle(title)
                 .setContentText(content)
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .setAutoCancel(true)
                 .setGroup(GROUP_KEY_PLANNING)
                 .setContentIntent(pendingIntent)
@@ -202,18 +199,18 @@ class NotificationDebugService @Inject constructor(
 
     /**
      * Send a test "Imminent" notification (2h or less before premiere).
-     * Simulates: "Episode 1 is airing in 2 hours!"
+     * Simulates: "Episode 1 airs in about 2 hours"
      */
     fun sendTestImminentNotification() {
         scope.launch {
             val notificationId = DEBUG_IMMINENT_ID
-            val title = "🔔 Starting Soon: $SAMPLE_TITLE"
-            
+            val title = SAMPLE_TITLE
+
             val hoursUntil = (0..2).random()
             val content = when (hoursUntil) {
-                0 -> "Episode 1 is airing in less than an hour!"
-                1 -> "Episode 1 is airing in about an hour!"
-                else -> "Episode 1 is airing in $hoursUntil hours!"
+                0 -> "Episode 1 airs in less than an hour"
+                1 -> "Episode 1 airs in about an hour"
+                else -> "Episode 1 airs in about $hoursUntil hours"
             }
 
             val intent = Intent(Intent.ACTION_VIEW, Uri.parse("anisync://details/$SAMPLE_MEDIA_ID"))
@@ -230,7 +227,6 @@ class NotificationDebugService @Inject constructor(
                 .setSmallIcon(R.drawable.ic_notification)
                 .setContentTitle(title)
                 .setContentText(content)
-                .setPriority(NotificationCompat.PRIORITY_HIGH)
                 .setAutoCancel(true)
                 .setGroup(GROUP_KEY_PLANNING)
                 .setContentIntent(pendingIntent)

--- a/app/src/main/java/com/anisync/android/worker/NotificationScheduler.kt
+++ b/app/src/main/java/com/anisync/android/worker/NotificationScheduler.kt
@@ -1,6 +1,7 @@
 package com.anisync.android.worker
 
 import android.content.Context
+import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
@@ -29,6 +30,9 @@ class NotificationScheduler @Inject constructor(
 
         val workRequest = PeriodicWorkRequestBuilder<NotificationWorker>(REPEAT_INTERVAL_MINUTES, TimeUnit.MINUTES)
             .setInitialDelay(REPEAT_INTERVAL_MINUTES, TimeUnit.MINUTES)
+            // The worker retries on AniList rate limits; wait out the limit window instead of
+            // hammering again seconds later (default backoff starts at 30s).
+            .setBackoffCriteria(BackoffPolicy.LINEAR, 5, TimeUnit.MINUTES)
             .setConstraints(constraints)
             .build()
 

--- a/app/src/main/java/com/anisync/android/worker/NotificationWorker.kt
+++ b/app/src/main/java/com/anisync/android/worker/NotificationWorker.kt
@@ -37,6 +37,9 @@ import com.anisync.android.domain.ThreadCommentMentionNotification
 import com.anisync.android.domain.ThreadCommentReplyNotification
 import com.anisync.android.domain.ThreadCommentSubscribedNotification
 import com.anisync.android.domain.ThreadLikeNotification
+import com.anisync.android.domain.User
+import com.anisync.android.domain.indefiniteNoun
+import com.anisync.android.domain.noun
 import com.anisync.android.type.MediaType
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -65,6 +68,7 @@ class NotificationWorker @AssistedInject constructor(
     companion object {
         private const val TAG = "NotificationWorker"
         private const val MAX_NOTIFICATION_PAGES = 3
+        private const val PAGE_SIZE = 20
 
         // Two-tier upcoming notification system
         private const val ADVANCE_NOTICE_HOURS = 12 // First notification: "Episode 1 airs tomorrow at X"
@@ -93,6 +97,7 @@ class NotificationWorker @AssistedInject constructor(
         val activeId = accountStore.activeAccount.value?.id
         val showLabel = accounts.size > 1
 
+        val watchingEnabled = notificationPreferences.watchingEnabled.value
         val anySocialEnabled = notificationPreferences.threadCommentReplyEnabled.value ||
             notificationPreferences.threadSubscribedEnabled.value ||
             notificationPreferences.threadCommentMentionEnabled.value ||
@@ -108,34 +113,52 @@ class NotificationWorker @AssistedInject constructor(
             val isActive = account.id == activeId
             try {
                 if (!preferencesRepository.hasNotificationsEverRun(ctx.id)) {
-                    // First time we see this account — establish baselines silently.
-                    performBaselineSync(ctx, isActive)
-                    preferencesRepository.markNotificationsHaveRun(ctx.id)
-                    Log.d(TAG, "Baseline sync done for ${ctx.name}")
+                    // First time we see this account — establish baselines silently. Only mark the
+                    // baseline done when it fully succeeded, otherwise a failed first fetch would
+                    // flood the user with that account's entire history on the next run.
+                    if (performBaselineSync(ctx, isActive)) {
+                        preferencesRepository.markNotificationsHaveRun(ctx.id)
+                        Log.d(TAG, "Baseline sync done for ${ctx.name}")
+                    } else {
+                        Log.w(TAG, "Baseline sync incomplete for ${ctx.name} — will retry next run")
+                    }
                     continue
                 }
 
-                // AniList feed (airing + social) — works for any account via its token.
-                if (notificationPreferences.watchingEnabled.value) {
-                    val planningMediaIds = if (isActive && notificationPreferences.planningEnabled.value) {
-                        libraryDao.getByType(ctx.id, MediaType.ANIME)
-                            .filter { it.status == LibraryStatus.PLANNING }
-                            .map { it.mediaId }
-                            .toSet()
-                    } else {
-                        emptySet()
+                // AniList feed (airing + social) — both checks read the same feed, so fetch the
+                // pages once per account and share the result.
+                if (watchingEnabled || anySocialEnabled) {
+                    val airingWatermark = preferencesRepository.getLastNotifiedId(ctx.id)
+                    val socialWatermark = preferencesRepository.getLastSocialNotifiedId(ctx.id)
+                    val stopBelowId = minOf(
+                        if (watchingEnabled) airingWatermark else Int.MAX_VALUE,
+                        if (anySocialEnabled) socialWatermark else Int.MAX_VALUE
+                    )
+                    val recent = fetchRecentNotifications(ctx, stopBelowId)
+
+                    if (watchingEnabled) {
+                        val planningMediaIds = if (isActive && notificationPreferences.planningEnabled.value) {
+                            libraryDao.getByType(ctx.id, MediaType.ANIME)
+                                .filter { it.status == LibraryStatus.PLANNING }
+                                .map { it.mediaId }
+                                .toSet()
+                        } else {
+                            emptySet()
+                        }
+                        notifyNewAiring(ctx, recent, airingWatermark, planningMediaIds)
                     }
-                    checkWatchingListNotifications(ctx, planningMediaIds)
-                }
-                if (anySocialEnabled) {
-                    checkSocialNotifications(ctx)
+                    if (anySocialEnabled) {
+                        notifyNewSocial(ctx, recent, socialWatermark)
+                    }
                 }
 
                 // Planning / upcoming "Episode 1" alerts depend on the locally-cached library,
-                // so they only run for the active account.
+                // so they only run for the active account. The "has started" check must run first:
+                // it consumes the upcoming-notified markers that checkUpcomingPlanningEpisodes
+                // prunes once an episode leaves the upcoming window.
                 if (isActive) {
-                    if (notificationPreferences.upcomingEnabled.value) checkUpcomingPlanningEpisodes(ctx)
                     if (notificationPreferences.planningEnabled.value) checkPlanningFirstEpisodes(ctx)
+                    if (notificationPreferences.upcomingEnabled.value) checkUpcomingPlanningEpisodes(ctx)
                 }
             } catch (e: ApiError.RateLimited) {
                 // Back off the whole worker; per-account dedup makes the retry idempotent.
@@ -155,182 +178,169 @@ class NotificationWorker @AssistedInject constructor(
     }
 
     /**
+     * safeApiCall folds ApiErrors into Result.Error, so rate-limit/auth conditions never reach
+     * doWork() as exceptions on their own — resurface the two it reacts to (retry / mark expired).
+     */
+    private fun DomainResult.Error.rethrowWorkerSignals() {
+        when (val e = exception) {
+            is ApiError.RateLimited, is ApiError.Unauthorized -> throw e
+            else -> Unit
+        }
+    }
+
+    /**
      * On an account's first run, fetch current state and set baselines WITHOUT notifying, so the
      * user isn't spammed with that account's historical notifications. Planning/upcoming baseline
      * runs only for the active account (it uses the locally-cached library).
+     *
+     * @return true when every baseline fetch succeeded.
      */
-    private suspend fun performBaselineSync(ctx: AcctCtx, isActive: Boolean) {
-        val repoResult = notificationRepository.getNotifications(1, ctx.token)
-        if (repoResult is DomainResult.Success) {
-            val allNotifications = repoResult.data
-            val latestAiringId = allNotifications
-                .filterIsInstance<AiringNotification>()
-                .maxOfOrNull { it.id } ?: 0
-            if (latestAiringId > 0) preferencesRepository.setLastNotifiedId(ctx.id, latestAiringId)
-            val latestSocialId = allNotifications
-                .filter { isSocialNotification(it) }
-                .maxOfOrNull { it.id } ?: 0
-            if (latestSocialId > 0) preferencesRepository.setLastSocialNotifiedId(ctx.id, latestSocialId)
+    private suspend fun performBaselineSync(ctx: AcctCtx, isActive: Boolean): Boolean {
+        var complete = true
+
+        when (val repoResult = notificationRepository.getNotifications(1, ctx.token)) {
+            is DomainResult.Success -> {
+                val allNotifications = repoResult.data
+                val latestAiringId = allNotifications
+                    .filterIsInstance<AiringNotification>()
+                    .maxOfOrNull { it.id } ?: 0
+                if (latestAiringId > 0) preferencesRepository.setLastNotifiedId(ctx.id, latestAiringId)
+                val latestSocialId = allNotifications
+                    .filter { isSocialNotification(it) }
+                    .maxOfOrNull { it.id } ?: 0
+                if (latestSocialId > 0) preferencesRepository.setLastSocialNotifiedId(ctx.id, latestSocialId)
+            }
+            is DomainResult.Error -> {
+                repoResult.rethrowWorkerSignals()
+                complete = false
+            }
         }
 
-        if (!isActive) return
+        if (!isActive) return complete
 
         val planningEntries = libraryDao.getByType(ctx.id, MediaType.ANIME)
             .filter { it.status == LibraryStatus.PLANNING }
         val planningMediaIds = planningEntries.map { it.mediaId }
 
-        val airedResult = notificationRepository.getFirstEpisodeAirings(planningMediaIds)
-        if (airedResult is DomainResult.Success) {
-            for (airing in airedResult.data) {
-                preferencesRepository.markPlanningMediaAsNotified(ctx.id, airing.mediaId)
-            }
-        }
-        val upcomingResult = notificationRepository.getUpcomingFirstEpisodes(planningMediaIds, ADVANCE_NOTICE_HOURS)
-        if (upcomingResult is DomainResult.Success) {
-            for (airing in upcomingResult.data) {
-                preferencesRepository.markUpcomingAiringNotified(ctx.id, airing.id)
-            }
-        }
-    }
-
-    private suspend fun checkWatchingListNotifications(ctx: AcctCtx, planningMediaIds: Set<Int>) {
-        val allNewAiring = mutableListOf<AiringNotification>()
-        val lastNotifiedId = preferencesRepository.getLastNotifiedId(ctx.id)
-        var currentPage = 1
-        var hasMore = true
-
-        while (hasMore && currentPage <= MAX_NOTIFICATION_PAGES) {
-            val repoResult = notificationRepository.getNotifications(currentPage, ctx.token)
-
-            when (repoResult) {
-                is DomainResult.Success -> {
-                    val notifications = repoResult.data
-
-                    val newOnThisPage = notifications
-                        .filterIsInstance<AiringNotification>()
-                        .filter { it.id > lastNotifiedId }
-                        // Skip Episode 1 for Planning items (handled by checkPlanningFirstEpisodes)
-                        .filter { notification ->
-                            val isEpisode1ForPlanning = notification.episode == 1 &&
-                                notification.media?.id in planningMediaIds
-                            !isEpisode1ForPlanning
-                        }
-
-                    val allAiringOnPage = notifications.filterIsInstance<AiringNotification>()
-                    val hasOlderAiring = allAiringOnPage.any { it.id <= lastNotifiedId }
-
-                    if (newOnThisPage.isEmpty() && hasOlderAiring) {
-                        hasMore = false
-                    } else if (newOnThisPage.isEmpty() && allAiringOnPage.isEmpty()) {
-                        currentPage++
-                        if (notifications.size < 20) hasMore = false
-                    } else {
-                        allNewAiring.addAll(newOnThisPage)
-                        currentPage++
-                        if (notifications.size < 20) hasMore = false
-                    }
-                }
-                is DomainResult.Error -> {
-                    Log.e(TAG, "Failed to fetch notifications page $currentPage for ${ctx.name}: ${repoResult.message}", repoResult.exception)
-                    hasMore = false
+        when (val airedResult = notificationRepository.getFirstEpisodeAirings(planningMediaIds)) {
+            is DomainResult.Success -> {
+                for (airing in airedResult.data) {
+                    preferencesRepository.markPlanningMediaAsNotified(ctx.id, airing.mediaId)
                 }
             }
-        }
-
-        if (allNewAiring.isNotEmpty()) {
-            val sortedAiring = allNewAiring.sortedBy { it.id }
-
-            // Apply the user-configured streaming delay (defer episodes not yet "due").
-            val delaySeconds = notificationPreferences.streamingDelayMinutes.value * 60L
-            val nowSeconds = System.currentTimeMillis() / 1000
-            val cutoff = if (delaySeconds > 0L) {
-                sortedAiring.firstOrNull { (nowSeconds - it.createdAt) < delaySeconds }?.id
-                    ?: Int.MAX_VALUE
-            } else {
-                Int.MAX_VALUE
-            }
-            val toEmit = sortedAiring.filter { it.id < cutoff }
-
-            for (notification in toEmit) {
-                showNotification(notification, ctx)
-            }
-            if (toEmit.size >= 3) {
-                showSummaryNotification(toEmit, ctx)
-            }
-            if (toEmit.isNotEmpty()) {
-                preferencesRepository.setLastNotifiedId(ctx.id, toEmit.maxOf { it.id })
+            is DomainResult.Error -> {
+                airedResult.rethrowWorkerSignals()
+                complete = false
             }
         }
+        when (val upcomingResult = notificationRepository.getUpcomingFirstEpisodes(planningMediaIds, ADVANCE_NOTICE_HOURS)) {
+            is DomainResult.Success -> {
+                for (airing in upcomingResult.data) {
+                    preferencesRepository.markUpcomingAiringNotified(ctx.id, airing.id)
+                }
+            }
+            is DomainResult.Error -> {
+                upcomingResult.rethrowWorkerSignals()
+                complete = false
+            }
+        }
+        return complete
     }
 
     /**
-     * Check for new social/forum notifications (thread replies, mentions, likes, subscriptions).
-     * Each type is gated behind its own preference toggle.
+     * Pulls the newest notification pages once per account. Stops as soon as a page reaches ids
+     * at/below [stopBelowId] (every consumer's watermark is covered), the feed runs short, or the
+     * page cap is hit.
      */
-    private suspend fun checkSocialNotifications(ctx: AcctCtx) {
-        val lastSocialId = preferencesRepository.getLastSocialNotifiedId(ctx.id)
-        val allNewSocial = mutableListOf<Notification>()
-        var currentPage = 1
-        var hasMore = true
-
-        while (hasMore && currentPage <= MAX_NOTIFICATION_PAGES) {
-            val repoResult = notificationRepository.getNotifications(currentPage, ctx.token)
-
-            when (repoResult) {
+    private suspend fun fetchRecentNotifications(ctx: AcctCtx, stopBelowId: Int): List<Notification> {
+        val fetched = mutableListOf<Notification>()
+        var page = 1
+        while (page <= MAX_NOTIFICATION_PAGES) {
+            when (val result = notificationRepository.getNotifications(page, ctx.token)) {
                 is DomainResult.Success -> {
-                    val notifications = repoResult.data
-
-                    val socialOnPage = notifications.filter { notification ->
-                        notification.id > lastSocialId && isSocialNotification(notification)
-                    }
-
-                    val olderSocialExists = notifications.any { notification ->
-                        notification.id <= lastSocialId && isSocialNotification(notification)
-                    }
-
-                    if (socialOnPage.isEmpty() && olderSocialExists) {
-                        hasMore = false
-                    } else if (socialOnPage.isEmpty()) {
-                        currentPage++
-                        if (notifications.size < 20) hasMore = false
-                    } else {
-                        allNewSocial.addAll(socialOnPage)
-                        currentPage++
-                        if (notifications.size < 20) hasMore = false
+                    fetched += result.data
+                    if (result.data.size < PAGE_SIZE || result.data.any { it.id <= stopBelowId }) {
+                        return fetched
                     }
                 }
                 is DomainResult.Error -> {
-                    Log.e(TAG, "Failed to fetch social notifications page $currentPage for ${ctx.name}: ${repoResult.message}", repoResult.exception)
-                    hasMore = false
+                    result.rethrowWorkerSignals()
+                    Log.e(TAG, "Failed to fetch notifications page $page for ${ctx.name}: ${result.message}", result.exception)
+                    return fetched
                 }
+            }
+            page++
+        }
+        return fetched
+    }
+
+    private suspend fun notifyNewAiring(
+        ctx: AcctCtx,
+        recent: List<Notification>,
+        lastNotifiedId: Int,
+        planningMediaIds: Set<Int>
+    ) {
+        val newAiring = recent
+            .filterIsInstance<AiringNotification>()
+            .filter { it.id > lastNotifiedId }
+            // Skip Episode 1 for Planning items (handled by checkPlanningFirstEpisodes)
+            .filterNot { it.episode == 1 && it.media?.id in planningMediaIds }
+            .sortedBy { it.id }
+        if (newAiring.isEmpty()) return
+
+        // Apply the user-configured streaming delay (defer episodes not yet "due").
+        val delaySeconds = notificationPreferences.streamingDelayMinutes.value * 60L
+        val nowSeconds = System.currentTimeMillis() / 1000
+        val cutoff = if (delaySeconds > 0L) {
+            newAiring.firstOrNull { (nowSeconds - it.createdAt) < delaySeconds }?.id
+                ?: Int.MAX_VALUE
+        } else {
+            Int.MAX_VALUE
+        }
+        val toEmit = newAiring.filter { it.id < cutoff }
+        if (toEmit.isEmpty()) return
+
+        for (notification in toEmit) {
+            showAiringNotification(notification, ctx)
+        }
+        if (toEmit.size >= 3) {
+            showSummaryNotification(toEmit, ctx)
+        }
+        preferencesRepository.setLastNotifiedId(ctx.id, toEmit.maxOf { it.id })
+    }
+
+    /**
+     * Surface new social/forum notifications (thread replies, mentions, likes, subscriptions).
+     * Each type is gated behind its own preference toggle; the watermark still advances past
+     * disabled types so re-enabling them doesn't replay history.
+     */
+    private suspend fun notifyNewSocial(ctx: AcctCtx, recent: List<Notification>, lastSocialId: Int) {
+        val newSocial = recent
+            .filter { it.id > lastSocialId && isSocialNotification(it) }
+            .sortedBy { it.id }
+        if (newSocial.isEmpty()) return
+
+        for (notification in newSocial) {
+            val shouldNotify = when (notification) {
+                is ThreadCommentReplyNotification -> notificationPreferences.threadCommentReplyEnabled.value
+                is ThreadCommentSubscribedNotification -> notificationPreferences.threadSubscribedEnabled.value
+                is ThreadCommentMentionNotification -> notificationPreferences.threadCommentMentionEnabled.value
+                is ThreadLikeNotification -> notificationPreferences.threadLikeEnabled.value
+                is ThreadCommentLikeNotification -> notificationPreferences.threadCommentLikeEnabled.value
+                is ActivityReplyNotification,
+                is ActivityReplySubscribedNotification -> notificationPreferences.activityReplyEnabled.value
+                is ActivityMentionNotification -> notificationPreferences.activityMentionEnabled.value
+                is ActivityLikeNotification,
+                is ActivityReplyLikeNotification -> notificationPreferences.activityLikeEnabled.value
+                is ActivityMessageNotification -> notificationPreferences.activityMessageEnabled.value
+                else -> false
+            }
+            if (shouldNotify) {
+                showSocialNotification(notification, ctx)
             }
         }
 
-        if (allNewSocial.isNotEmpty()) {
-            val sorted = allNewSocial.sortedBy { it.id }
-
-            for (notification in sorted) {
-                val shouldNotify = when (notification) {
-                    is ThreadCommentReplyNotification -> notificationPreferences.threadCommentReplyEnabled.value
-                    is ThreadCommentSubscribedNotification -> notificationPreferences.threadSubscribedEnabled.value
-                    is ThreadCommentMentionNotification -> notificationPreferences.threadCommentMentionEnabled.value
-                    is ThreadLikeNotification -> notificationPreferences.threadLikeEnabled.value
-                    is ThreadCommentLikeNotification -> notificationPreferences.threadCommentLikeEnabled.value
-                    is ActivityReplyNotification,
-                    is ActivityReplySubscribedNotification -> notificationPreferences.activityReplyEnabled.value
-                    is ActivityMentionNotification -> notificationPreferences.activityMentionEnabled.value
-                    is ActivityLikeNotification,
-                    is ActivityReplyLikeNotification -> notificationPreferences.activityLikeEnabled.value
-                    is ActivityMessageNotification -> notificationPreferences.activityMessageEnabled.value
-                    else -> false
-                }
-                if (shouldNotify) {
-                    showSocialNotification(notification, ctx)
-                }
-            }
-
-            preferencesRepository.setLastSocialNotifiedId(ctx.id, sorted.maxOf { it.id })
-        }
+        preferencesRepository.setLastSocialNotifiedId(ctx.id, newSocial.maxOf { it.id })
     }
 
     private fun isSocialNotification(notification: Notification): Boolean {
@@ -347,115 +357,88 @@ class NotificationWorker @AssistedInject constructor(
             notification is ActivityMessageNotification
     }
 
+    /** ` in "Thread title"` suffix, or nothing when the title is blank. */
+    private fun inThread(title: String): String =
+        title.takeIf { it.isNotBlank() }?.let { " in \"$it\"" }.orEmpty()
+
     /**
-     * Display a social/forum notification using the appropriate channel.
+     * Display a social/forum notification. Copy follows the messaging convention:
+     * title = who, text = what they did.
      */
     private suspend fun showSocialNotification(notification: Notification, ctx: AcctCtx) {
         val data = when (notification) {
-            is ThreadCommentReplyNotification -> {
-                val userName = notification.user?.name ?: "Someone"
-                SocialNotificationData(
-                    title = "💬 Reply on \"${notification.threadTitle}\"",
-                    content = "$userName ${notification.context}",
-                    channelId = NotificationChannels.THREAD_COMMENT_REPLY_CHANNEL_ID,
-                    threadId = notification.threadId,
-                    commentId = notification.commentId
-                )
-            }
-            is ThreadCommentSubscribedNotification -> {
-                val userName = notification.user?.name ?: "Someone"
-                SocialNotificationData(
-                    title = "🔔 Update on \"${notification.threadTitle}\"",
-                    content = "$userName ${notification.context}",
-                    channelId = NotificationChannels.THREAD_SUBSCRIBED_CHANNEL_ID,
-                    threadId = notification.threadId,
-                    commentId = notification.commentId
-                )
-            }
-            is ThreadCommentMentionNotification -> {
-                val userName = notification.user?.name ?: "Someone"
-                SocialNotificationData(
-                    title = "📢 Mentioned in \"${notification.threadTitle}\"",
-                    content = "$userName ${notification.context}",
-                    channelId = NotificationChannels.THREAD_COMMENT_MENTION_CHANNEL_ID,
-                    threadId = notification.threadId,
-                    commentId = notification.commentId
-                )
-            }
-            is ThreadLikeNotification -> {
-                val userName = notification.user?.name ?: "Someone"
-                SocialNotificationData(
-                    title = "❤️ Thread liked",
-                    content = "$userName liked your thread \"${notification.threadTitle}\"",
-                    channelId = NotificationChannels.THREAD_LIKE_CHANNEL_ID,
-                    threadId = notification.threadId,
-                    commentId = null
-                )
-            }
-            is ThreadCommentLikeNotification -> {
-                val userName = notification.user?.name ?: "Someone"
-                SocialNotificationData(
-                    title = "❤️ Comment liked",
-                    content = "$userName liked your comment in \"${notification.threadTitle}\"",
-                    channelId = NotificationChannels.THREAD_COMMENT_LIKE_CHANNEL_ID,
-                    threadId = notification.threadId,
-                    commentId = notification.commentId
-                )
-            }
-            is ActivityReplyNotification -> {
-                val userName = notification.user?.name ?: "Someone"
-                SocialNotificationData(
-                    title = "💬 Activity reply",
-                    content = "$userName ${notification.context}",
-                    channelId = NotificationChannels.ACTIVITY_REPLY_CHANNEL_ID,
-                    activityId = notification.activityId
-                )
-            }
-            is ActivityReplySubscribedNotification -> {
-                val userName = notification.user?.name ?: "Someone"
-                SocialNotificationData(
-                    title = "🔔 Activity update",
-                    content = "$userName ${notification.context}",
-                    channelId = NotificationChannels.ACTIVITY_REPLY_CHANNEL_ID,
-                    activityId = notification.activityId
-                )
-            }
-            is ActivityMentionNotification -> {
-                val userName = notification.user?.name ?: "Someone"
-                SocialNotificationData(
-                    title = "📢 Mentioned in activity",
-                    content = "$userName ${notification.context}",
-                    channelId = NotificationChannels.ACTIVITY_MENTION_CHANNEL_ID,
-                    activityId = notification.activityId
-                )
-            }
-            is ActivityLikeNotification -> {
-                val userName = notification.user?.name ?: "Someone"
-                SocialNotificationData(
-                    title = "❤️ Activity liked",
-                    content = "$userName ${notification.context}",
-                    channelId = NotificationChannels.ACTIVITY_LIKE_CHANNEL_ID,
-                    activityId = notification.activityId
-                )
-            }
-            is ActivityReplyLikeNotification -> {
-                val userName = notification.user?.name ?: "Someone"
-                SocialNotificationData(
-                    title = "❤️ Reply liked",
-                    content = "$userName ${notification.context}",
-                    channelId = NotificationChannels.ACTIVITY_LIKE_CHANNEL_ID,
-                    activityId = notification.activityId
-                )
-            }
-            is ActivityMessageNotification -> {
-                val userName = notification.user?.name ?: "Someone"
-                SocialNotificationData(
-                    title = "✉️ New message",
-                    content = "$userName ${notification.context}",
-                    channelId = NotificationChannels.ACTIVITY_MESSAGE_CHANNEL_ID,
-                    activityId = notification.activityId
-                )
-            }
+            is ThreadCommentReplyNotification -> SocialNotificationData(
+                user = notification.user,
+                content = "Replied to your comment${inThread(notification.threadTitle)}",
+                channelId = NotificationChannels.THREAD_COMMENT_REPLY_CHANNEL_ID,
+                threadId = notification.threadId,
+                commentId = notification.commentId
+            )
+            is ThreadCommentSubscribedNotification -> SocialNotificationData(
+                user = notification.user,
+                content = notification.threadTitle.takeIf { it.isNotBlank() }
+                    ?.let { "Commented in \"$it\"" } ?: "Commented in a thread you're subscribed to",
+                channelId = NotificationChannels.THREAD_SUBSCRIBED_CHANNEL_ID,
+                threadId = notification.threadId,
+                commentId = notification.commentId
+            )
+            is ThreadCommentMentionNotification -> SocialNotificationData(
+                user = notification.user,
+                content = "Mentioned you in a comment${inThread(notification.threadTitle)}",
+                channelId = NotificationChannels.THREAD_COMMENT_MENTION_CHANNEL_ID,
+                threadId = notification.threadId,
+                commentId = notification.commentId
+            )
+            is ThreadLikeNotification -> SocialNotificationData(
+                user = notification.user,
+                content = "Liked your thread" +
+                    notification.threadTitle.takeIf { it.isNotBlank() }?.let { " \"$it\"" }.orEmpty(),
+                channelId = NotificationChannels.THREAD_LIKE_CHANNEL_ID,
+                threadId = notification.threadId
+            )
+            is ThreadCommentLikeNotification -> SocialNotificationData(
+                user = notification.user,
+                content = "Liked your comment${inThread(notification.threadTitle)}",
+                channelId = NotificationChannels.THREAD_COMMENT_LIKE_CHANNEL_ID,
+                threadId = notification.threadId,
+                commentId = notification.commentId
+            )
+            is ActivityReplyNotification -> SocialNotificationData(
+                user = notification.user,
+                content = "Replied to your ${notification.activity?.kind.noun()}",
+                channelId = NotificationChannels.ACTIVITY_REPLY_CHANNEL_ID,
+                activityId = notification.activityId
+            )
+            is ActivityReplySubscribedNotification -> SocialNotificationData(
+                user = notification.user,
+                content = "Replied to a post you're subscribed to",
+                channelId = NotificationChannels.ACTIVITY_REPLY_CHANNEL_ID,
+                activityId = notification.activityId
+            )
+            is ActivityMentionNotification -> SocialNotificationData(
+                user = notification.user,
+                content = "Mentioned you in ${notification.activity?.kind.indefiniteNoun()}",
+                channelId = NotificationChannels.ACTIVITY_MENTION_CHANNEL_ID,
+                activityId = notification.activityId
+            )
+            is ActivityLikeNotification -> SocialNotificationData(
+                user = notification.user,
+                content = "Liked your ${notification.activity?.kind.noun()}",
+                channelId = NotificationChannels.ACTIVITY_LIKE_CHANNEL_ID,
+                activityId = notification.activityId
+            )
+            is ActivityReplyLikeNotification -> SocialNotificationData(
+                user = notification.user,
+                content = "Liked your reply",
+                channelId = NotificationChannels.ACTIVITY_LIKE_CHANNEL_ID,
+                activityId = notification.activityId
+            )
+            is ActivityMessageNotification -> SocialNotificationData(
+                user = notification.user,
+                content = "Sent you a message",
+                channelId = NotificationChannels.ACTIVITY_MESSAGE_CHANNEL_ID,
+                activityId = notification.activityId
+            )
             else -> return
         }
 
@@ -467,26 +450,12 @@ class NotificationWorker @AssistedInject constructor(
             else -> "anisync://notifications"
         }
 
-        val largeIcon: Bitmap? = when (notification) {
-            is ThreadCommentReplyNotification -> notification.user?.avatarUrl
-            is ThreadCommentSubscribedNotification -> notification.user?.avatarUrl
-            is ThreadCommentMentionNotification -> notification.user?.avatarUrl
-            is ThreadLikeNotification -> notification.user?.avatarUrl
-            is ThreadCommentLikeNotification -> notification.user?.avatarUrl
-            is ActivityReplyNotification -> notification.user?.avatarUrl
-            is ActivityReplySubscribedNotification -> notification.user?.avatarUrl
-            is ActivityMentionNotification -> notification.user?.avatarUrl
-            is ActivityLikeNotification -> notification.user?.avatarUrl
-            is ActivityReplyLikeNotification -> notification.user?.avatarUrl
-            is ActivityMessageNotification -> notification.user?.avatarUrl
-            else -> null
-        }?.let { loadImage(it) }
+        val largeIcon: Bitmap? = data.user?.avatarUrl?.let { loadImage(it) }
 
         val builder = NotificationCompat.Builder(applicationContext, data.channelId)
-            .setSmallIcon(getApplicationIcon())
-            .setContentTitle(data.title)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle(data.user?.name ?: "Someone")
             .setContentText(data.content)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
             .setWhen(notification.createdAt.toLong() * 1000L)
             .setShowWhen(true)
@@ -499,7 +468,7 @@ class NotificationWorker @AssistedInject constructor(
     }
 
     private data class SocialNotificationData(
-        val title: String,
+        val user: User?,
         val content: String,
         val channelId: String,
         val threadId: Int? = null,
@@ -519,35 +488,38 @@ class NotificationWorker @AssistedInject constructor(
         val mediaIds = planningEntries.map { it.mediaId }
         val currentTimeSeconds = System.currentTimeMillis() / 1000
 
-        val result = notificationRepository.getUpcomingFirstEpisodes(mediaIds, ADVANCE_NOTICE_HOURS)
-        if (result is DomainResult.Success) {
-            val upcomingAirings = result.data
-            val currentAiringIds = upcomingAirings.map { it.id }.toSet()
-            preferencesRepository.cleanupOldUpcomingAirings(ctx.id, currentAiringIds)
+        when (val result = notificationRepository.getUpcomingFirstEpisodes(mediaIds, ADVANCE_NOTICE_HOURS)) {
+            is DomainResult.Success -> {
+                val upcomingAirings = result.data
+                val currentAiringIds = upcomingAirings.map { it.id }.toSet()
+                preferencesRepository.cleanupOldUpcomingAirings(ctx.id, currentAiringIds)
 
-            for (airing in upcomingAirings) {
-                val hoursUntil = ((airing.airingAt - currentTimeSeconds) / 3600).toInt()
-                when {
-                    hoursUntil <= IMMINENT_NOTICE_HOURS -> {
-                        val imminentKey = "imminent_${airing.id}"
-                        if (!preferencesRepository.hasNotifiedWithKey(ctx.id, imminentKey)) {
-                            showImminentEpisodeNotification(airing, hoursUntil, ctx)
-                            preferencesRepository.markNotifiedWithKey(ctx.id, imminentKey)
-                            preferencesRepository.markUpcomingAiringNotified(ctx.id, airing.id)
+                for (airing in upcomingAirings) {
+                    val hoursUntil = ((airing.airingAt - currentTimeSeconds) / 3600).toInt()
+                    when {
+                        hoursUntil <= IMMINENT_NOTICE_HOURS -> {
+                            val imminentKey = "imminent_${airing.id}"
+                            if (!preferencesRepository.hasNotifiedWithKey(ctx.id, imminentKey)) {
+                                showImminentEpisodeNotification(airing, hoursUntil, ctx)
+                                preferencesRepository.markNotifiedWithKey(ctx.id, imminentKey)
+                                preferencesRepository.markUpcomingAiringNotified(ctx.id, airing.id)
+                            }
                         }
-                    }
-                    hoursUntil <= ADVANCE_NOTICE_HOURS -> {
-                        val advanceKey = "advance_${airing.id}"
-                        if (!preferencesRepository.hasNotifiedWithKey(ctx.id, advanceKey)) {
-                            showAdvanceEpisodeNotification(airing, ctx)
-                            preferencesRepository.markNotifiedWithKey(ctx.id, advanceKey)
-                            preferencesRepository.markUpcomingAiringNotified(ctx.id, airing.id)
+                        hoursUntil <= ADVANCE_NOTICE_HOURS -> {
+                            val advanceKey = "advance_${airing.id}"
+                            if (!preferencesRepository.hasNotifiedWithKey(ctx.id, advanceKey)) {
+                                showAdvanceEpisodeNotification(airing, ctx)
+                                preferencesRepository.markNotifiedWithKey(ctx.id, advanceKey)
+                                preferencesRepository.markUpcomingAiringNotified(ctx.id, airing.id)
+                            }
                         }
                     }
                 }
             }
-        } else if (result is DomainResult.Error) {
-            Log.e(TAG, "Failed to fetch upcoming episodes: ${result.message}", result.exception)
+            is DomainResult.Error -> {
+                result.rethrowWorkerSignals()
+                Log.e(TAG, "Failed to fetch upcoming episodes: ${result.message}", result.exception)
+            }
         }
     }
 
@@ -565,35 +537,38 @@ class NotificationWorker @AssistedInject constructor(
         if (unnotifiedIds.isEmpty()) return
 
         val upcomingNotifiedAiringIds = preferencesRepository.getNotifiedUpcomingAiringIds(ctx.id)
-        val result = notificationRepository.getFirstEpisodeAirings(unnotifiedIds)
 
-        if (result is DomainResult.Success) {
-            for (airing in result.data) {
-                if (airing.id in upcomingNotifiedAiringIds) {
+        when (val result = notificationRepository.getFirstEpisodeAirings(unnotifiedIds)) {
+            is DomainResult.Success -> {
+                for (airing in result.data) {
+                    if (airing.id in upcomingNotifiedAiringIds) {
+                        // Already told the user this premiere was coming — don't repeat it.
+                        preferencesRepository.markPlanningMediaAsNotified(ctx.id, airing.mediaId)
+                        continue
+                    }
+                    showPlanningFirstEpisodeNotification(airing, ctx)
                     preferencesRepository.markPlanningMediaAsNotified(ctx.id, airing.mediaId)
-                    continue
                 }
-                showPlanningFirstEpisodeNotification(airing, ctx)
-                preferencesRepository.markPlanningMediaAsNotified(ctx.id, airing.mediaId)
             }
-        } else if (result is DomainResult.Error) {
-            Log.e(TAG, "Failed to fetch planning first episodes: ${result.message}", result.exception)
+            is DomainResult.Error -> {
+                result.rethrowWorkerSignals()
+                Log.e(TAG, "Failed to fetch planning first episodes: ${result.message}", result.exception)
+            }
         }
     }
 
-    private suspend fun showNotification(notification: AiringNotification, ctx: AcctCtx) {
+    private suspend fun showAiringNotification(notification: AiringNotification, ctx: AcctCtx) {
         val notificationId = AIRING_NOTIFICATION_BASE_ID + notification.id
         val media = notification.media
-        val title = media?.title ?: "New Episode"
-        val content = "Episode ${notification.episode} has aired!"
+        val title = media?.title ?: "New episode"
+        val content = "Episode ${notification.episode} has aired"
 
         val largeIcon: Bitmap? = media?.coverUrl?.let { loadImage(it) }
 
         val builder = NotificationCompat.Builder(applicationContext, NotificationChannels.AIRING_CHANNEL_ID)
-            .setSmallIcon(getApplicationIcon())
+            .setSmallIcon(R.drawable.ic_notification)
             .setContentTitle(title)
             .setContentText(content)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
             // Stamp with the airing moment (AniList createdAt) so it's consistent across devices
             // regardless of when each device's worker polled.
@@ -610,7 +585,7 @@ class NotificationWorker @AssistedInject constructor(
 
     private suspend fun showAdvanceEpisodeNotification(airing: AiringSchedule, ctx: AcctCtx) {
         val notificationId = UPCOMING_ADVANCE_NOTIFICATION_BASE_ID + airing.id
-        val title = "📅 Premiere Alert: ${airing.mediaTitle}"
+        val title = airing.mediaTitle
 
         val airingDate = java.util.Date(airing.airingAt * 1000)
         val timeFormat = DateFormat.getTimeFormat(applicationContext)
@@ -634,10 +609,9 @@ class NotificationWorker @AssistedInject constructor(
         val largeIcon: Bitmap? = airing.mediaCoverUrl?.let { loadImage(it) }
 
         val builder = NotificationCompat.Builder(applicationContext, NotificationChannels.UPCOMING_CHANNEL_ID)
-            .setSmallIcon(getApplicationIcon())
+            .setSmallIcon(R.drawable.ic_notification)
             .setContentTitle(title)
             .setContentText(content)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
             .setGroup(groupKey(GROUP_KEY_PLANNING, ctx))
             .setContentIntent(deepLinkIntent("anisync://details/${airing.mediaId}", ctx, notificationId))
@@ -650,21 +624,20 @@ class NotificationWorker @AssistedInject constructor(
 
     private suspend fun showImminentEpisodeNotification(airing: AiringSchedule, hoursUntil: Int, ctx: AcctCtx) {
         val notificationId = UPCOMING_IMMINENT_NOTIFICATION_BASE_ID + airing.id
-        val title = "🔔 Starting Soon: ${airing.mediaTitle}"
+        val title = airing.mediaTitle
 
         val content = when {
-            hoursUntil < 1 -> "Episode 1 is airing in less than an hour!"
-            hoursUntil == 1 -> "Episode 1 is airing in about an hour!"
-            else -> "Episode 1 is airing in $hoursUntil hours!"
+            hoursUntil < 1 -> "Episode 1 airs in less than an hour"
+            hoursUntil == 1 -> "Episode 1 airs in about an hour"
+            else -> "Episode 1 airs in about $hoursUntil hours"
         }
 
         val largeIcon: Bitmap? = airing.mediaCoverUrl?.let { loadImage(it) }
 
         val builder = NotificationCompat.Builder(applicationContext, NotificationChannels.UPCOMING_CHANNEL_ID)
-            .setSmallIcon(getApplicationIcon())
+            .setSmallIcon(R.drawable.ic_notification)
             .setContentTitle(title)
             .setContentText(content)
-            .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setAutoCancel(true)
             .setGroup(groupKey(GROUP_KEY_PLANNING, ctx))
             .setContentIntent(deepLinkIntent("anisync://details/${airing.mediaId}", ctx, notificationId))
@@ -677,7 +650,7 @@ class NotificationWorker @AssistedInject constructor(
 
     private suspend fun showPlanningFirstEpisodeNotification(airing: AiringSchedule, ctx: AcctCtx) {
         val notificationId = PLANNING_NOTIFICATION_BASE_ID + airing.mediaId
-        val title = "${airing.mediaTitle} has started!"
+        val title = airing.mediaTitle
         val content = "Episode 1 is now available"
 
         // "Add to Watching" action button
@@ -685,6 +658,7 @@ class NotificationWorker @AssistedInject constructor(
             action = AddToWatchingReceiver.ACTION_ADD_TO_WATCHING
             putExtra(AddToWatchingReceiver.EXTRA_MEDIA_ID, airing.mediaId)
             putExtra(AddToWatchingReceiver.EXTRA_NOTIFICATION_ID, notificationId)
+            putExtra(AddToWatchingReceiver.EXTRA_NOTIFICATION_TAG, notificationTag(ctx))
             putExtra(AddToWatchingReceiver.EXTRA_MEDIA_TITLE, airing.mediaTitle)
         }
         val addToWatchingPendingIntent = PendingIntent.getBroadcast(
@@ -697,10 +671,9 @@ class NotificationWorker @AssistedInject constructor(
         val largeIcon: Bitmap? = airing.mediaCoverUrl?.let { loadImage(it) }
 
         val builder = NotificationCompat.Builder(applicationContext, NotificationChannels.PLANNING_CHANNEL_ID)
-            .setSmallIcon(getApplicationIcon())
+            .setSmallIcon(R.drawable.ic_notification)
             .setContentTitle(title)
             .setContentText(content)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
             .setWhen(airing.airingAt * 1000L)
             .setShowWhen(true)
@@ -718,22 +691,24 @@ class NotificationWorker @AssistedInject constructor(
     }
 
     private fun showSummaryNotification(notifications: List<AiringNotification>, ctx: AcctCtx) {
+        val summaryTitle = "${notifications.size} new episodes aired"
         val inboxStyle = NotificationCompat.InboxStyle()
-            .setBigContentTitle("${notifications.size} new episodes aired")
+            .setBigContentTitle(summaryTitle)
             .setSummaryText(if (ctx.showLabel) ctx.name else "AniSync")
 
         for (notification in notifications) {
             val title = notification.media?.title ?: "Anime"
-            inboxStyle.addLine("Ep ${notification.episode}: $title")
+            inboxStyle.addLine("$title — Episode ${notification.episode}")
         }
 
         val builder = NotificationCompat.Builder(applicationContext, NotificationChannels.AIRING_CHANNEL_ID)
-            .setSmallIcon(getApplicationIcon())
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle(summaryTitle)
             .setStyle(inboxStyle)
             .setGroup(groupKey(GROUP_KEY_AIRING, ctx))
             .setGroupSummary(true)
             .setAutoCancel(true)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(deepLinkIntent("anisync://notifications", ctx, SUMMARY_ID))
 
         post(ctx, SUMMARY_ID, builder)
     }
@@ -755,6 +730,8 @@ class NotificationWorker @AssistedInject constructor(
         )
     }
 
+    private fun notificationTag(ctx: AcctCtx) = "acct_${ctx.id}"
+
     /**
      * Posts under a per-account tag so the same AniList notification id from two accounts can't
      * overwrite each other in the tray, and labels the account when more than one is signed in.
@@ -762,7 +739,7 @@ class NotificationWorker @AssistedInject constructor(
     private fun post(ctx: AcctCtx, id: Int, builder: NotificationCompat.Builder) {
         if (ctx.showLabel) builder.setSubText(ctx.name)
         val nm = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        nm.notify("acct_${ctx.id}", id, builder.build())
+        nm.notify(notificationTag(ctx), id, builder.build())
     }
 
     private suspend fun loadImage(url: String): Bitmap? {
@@ -778,9 +755,5 @@ class NotificationWorker @AssistedInject constructor(
         } else {
             null
         }
-    }
-
-    private fun getApplicationIcon(): Int {
-        return R.drawable.ic_notification
     }
 }

--- a/app/src/main/java/com/anisync/android/worker/NotificationWorker.kt
+++ b/app/src/main/java/com/anisync/android/worker/NotificationWorker.kt
@@ -28,6 +28,7 @@ import com.anisync.android.domain.ActivityReplyNotification
 import com.anisync.android.domain.ActivityReplySubscribedNotification
 import com.anisync.android.domain.AiringNotification
 import com.anisync.android.domain.AiringSchedule
+import com.anisync.android.domain.FollowingNotification
 import com.anisync.android.domain.LibraryStatus
 import com.anisync.android.domain.Notification
 import com.anisync.android.domain.NotificationRepository
@@ -76,15 +77,19 @@ class NotificationWorker @AssistedInject constructor(
 
         private const val GROUP_KEY_AIRING = "com.anisync.android.AIRING_GROUP"
         private const val GROUP_KEY_PLANNING = "com.anisync.android.PLANNING_GROUP"
-        private const val SUMMARY_ID = 0
-        private const val AIRING_NOTIFICATION_BASE_ID = 1000
-        private const val PLANNING_NOTIFICATION_BASE_ID = 100000
-        private const val UPCOMING_ADVANCE_NOTIFICATION_BASE_ID = 200000  // 12h notice
-        private const val UPCOMING_IMMINENT_NOTIFICATION_BASE_ID = 300000 // 2h notice
-        private const val SOCIAL_NOTIFICATION_BASE_ID = 400000
-
         private const val GROUP_KEY_SOCIAL = "com.anisync.android.SOCIAL_GROUP"
+
+        // Tray slot = (tag "acct_<accountId>_<category>", id stable per target). A newer event for
+        // the same target replaces its stale tray entry instead of piling up next to it.
+        private const val CATEGORY_AIRING = "airing"
+        private const val CATEGORY_PLANNING = "planning"
+        private const val CATEGORY_UPCOMING = "upcoming"
+        private const val CATEGORY_SOCIAL_SUMMARY = "social"
+        private const val SUMMARY_ID = 0
     }
+
+    /** The tray slot a social notification lands in; events sharing a slot collapse to one entry. */
+    private data class SocialSlot(val category: String, val id: Int)
 
     override suspend fun doWork(): androidx.work.ListenableWorker.Result {
         // Poll every signed-in account that still has a (non-expired) token.
@@ -106,7 +111,8 @@ class NotificationWorker @AssistedInject constructor(
             notificationPreferences.activityReplyEnabled.value ||
             notificationPreferences.activityMentionEnabled.value ||
             notificationPreferences.activityLikeEnabled.value ||
-            notificationPreferences.activityMessageEnabled.value
+            notificationPreferences.activityMessageEnabled.value ||
+            notificationPreferences.followsEnabled.value
 
         for (account in accounts) {
             val ctx = AcctCtx(account.id, account.token, account.name, showLabel)
@@ -310,9 +316,10 @@ class NotificationWorker @AssistedInject constructor(
     }
 
     /**
-     * Surface new social/forum notifications (thread replies, mentions, likes, subscriptions).
-     * Each type is gated behind its own preference toggle; the watermark still advances past
-     * disabled types so re-enabling them doesn't replay history.
+     * Surface new social/forum notifications (thread replies, mentions, likes, subscriptions,
+     * messages, follows). Each type is gated behind its own preference toggle; the watermark still
+     * advances past disabled types so re-enabling them doesn't replay history. Events aimed at the
+     * same target collapse into one tray entry per [SocialSlot].
      */
     private suspend fun notifyNewSocial(ctx: AcctCtx, recent: List<Notification>, lastSocialId: Int) {
         val newSocial = recent
@@ -320,25 +327,12 @@ class NotificationWorker @AssistedInject constructor(
             .sortedBy { it.id }
         if (newSocial.isEmpty()) return
 
-        for (notification in newSocial) {
-            val shouldNotify = when (notification) {
-                is ThreadCommentReplyNotification -> notificationPreferences.threadCommentReplyEnabled.value
-                is ThreadCommentSubscribedNotification -> notificationPreferences.threadSubscribedEnabled.value
-                is ThreadCommentMentionNotification -> notificationPreferences.threadCommentMentionEnabled.value
-                is ThreadLikeNotification -> notificationPreferences.threadLikeEnabled.value
-                is ThreadCommentLikeNotification -> notificationPreferences.threadCommentLikeEnabled.value
-                is ActivityReplyNotification,
-                is ActivityReplySubscribedNotification -> notificationPreferences.activityReplyEnabled.value
-                is ActivityMentionNotification -> notificationPreferences.activityMentionEnabled.value
-                is ActivityLikeNotification,
-                is ActivityReplyLikeNotification -> notificationPreferences.activityLikeEnabled.value
-                is ActivityMessageNotification -> notificationPreferences.activityMessageEnabled.value
-                else -> false
-            }
-            if (shouldNotify) {
-                showSocialNotification(notification, ctx)
-            }
+        val enabled = newSocial.filter { isTypeEnabled(it) }
+        val bySlot = enabled.groupBy { socialSlot(it) }
+        for ((slot, members) in bySlot) {
+            if (slot != null) showSocialNotification(slot, members, ctx)
         }
+        if (bySlot.isNotEmpty()) maybePostSocialSummary(ctx)
 
         preferencesRepository.setLastSocialNotifiedId(ctx.id, newSocial.maxOf { it.id })
     }
@@ -354,7 +348,64 @@ class NotificationWorker @AssistedInject constructor(
             notification is ActivityMentionNotification ||
             notification is ActivityLikeNotification ||
             notification is ActivityReplyLikeNotification ||
-            notification is ActivityMessageNotification
+            notification is ActivityMessageNotification ||
+            notification is FollowingNotification
+    }
+
+    private fun isTypeEnabled(notification: Notification): Boolean = when (notification) {
+        is ThreadCommentReplyNotification -> notificationPreferences.threadCommentReplyEnabled.value
+        is ThreadCommentSubscribedNotification -> notificationPreferences.threadSubscribedEnabled.value
+        is ThreadCommentMentionNotification -> notificationPreferences.threadCommentMentionEnabled.value
+        is ThreadLikeNotification -> notificationPreferences.threadLikeEnabled.value
+        is ThreadCommentLikeNotification -> notificationPreferences.threadCommentLikeEnabled.value
+        is ActivityReplyNotification,
+        is ActivityReplySubscribedNotification -> notificationPreferences.activityReplyEnabled.value
+        is ActivityMentionNotification -> notificationPreferences.activityMentionEnabled.value
+        is ActivityLikeNotification,
+        is ActivityReplyLikeNotification -> notificationPreferences.activityLikeEnabled.value
+        is ActivityMessageNotification -> notificationPreferences.activityMessageEnabled.value
+        is FollowingNotification -> notificationPreferences.followsEnabled.value
+        else -> false
+    }
+
+    private fun socialSlot(notification: Notification): SocialSlot? = when (notification) {
+        is ThreadCommentReplyNotification -> SocialSlot("thread_reply", notification.threadId)
+        is ThreadCommentSubscribedNotification -> SocialSlot("thread_sub", notification.threadId)
+        is ThreadCommentMentionNotification -> SocialSlot("thread_mention", notification.threadId)
+        is ThreadLikeNotification -> SocialSlot("thread_like", notification.threadId)
+        is ThreadCommentLikeNotification -> SocialSlot("comment_like", notification.commentId ?: notification.threadId)
+        is ActivityReplyNotification -> SocialSlot("act_reply", notification.activityId ?: notification.id)
+        is ActivityReplySubscribedNotification -> SocialSlot("act_reply", notification.activityId ?: notification.id)
+        is ActivityMentionNotification -> SocialSlot("act_mention", notification.activityId ?: notification.id)
+        is ActivityLikeNotification -> SocialSlot("act_like", notification.activityId ?: notification.id)
+        is ActivityReplyLikeNotification -> SocialSlot("reply_like", notification.activityId ?: notification.id)
+        is ActivityMessageNotification -> SocialSlot("message", notification.user?.id ?: notification.id)
+        is FollowingNotification -> SocialSlot("follow", notification.user?.id ?: notification.id)
+        else -> null
+    }
+
+    private fun socialActor(notification: Notification): User? = when (notification) {
+        is ThreadCommentReplyNotification -> notification.user
+        is ThreadCommentSubscribedNotification -> notification.user
+        is ThreadCommentMentionNotification -> notification.user
+        is ThreadLikeNotification -> notification.user
+        is ThreadCommentLikeNotification -> notification.user
+        is ActivityReplyNotification -> notification.user
+        is ActivityReplySubscribedNotification -> notification.user
+        is ActivityMentionNotification -> notification.user
+        is ActivityLikeNotification -> notification.user
+        is ActivityReplyLikeNotification -> notification.user
+        is ActivityMessageNotification -> notification.user
+        is FollowingNotification -> notification.user
+        else -> null
+    }
+
+    /** "Hameru", "Hameru and Bob", "Hameru and 2 others" — newest actor first. */
+    private fun actorsLabel(actors: List<User>): String = when (actors.size) {
+        0 -> "Someone"
+        1 -> actors[0].name
+        2 -> "${actors[0].name} and ${actors[1].name}"
+        else -> "${actors[0].name} and ${actors.size - 1} others"
     }
 
     /** ` in "Thread title"` suffix, or nothing when the title is blank. */
@@ -362,119 +413,150 @@ class NotificationWorker @AssistedInject constructor(
         title.takeIf { it.isNotBlank() }?.let { " in \"$it\"" }.orEmpty()
 
     /**
-     * Display a social/forum notification. Copy follows the messaging convention:
-     * title = who, text = what they did.
+     * Display one tray entry for all [members] that landed in the same [slot]. Copy follows the
+     * messaging convention: title = who, text = what they did; multiple events for the same target
+     * combine actors and switch to a counted phrase.
      */
-    private suspend fun showSocialNotification(notification: Notification, ctx: AcctCtx) {
-        val data = when (notification) {
+    private suspend fun showSocialNotification(slot: SocialSlot, members: List<Notification>, ctx: AcctCtx) {
+        val rep = members.last()
+        val count = members.size
+        val actors = members.asReversed().mapNotNull(::socialActor).distinctBy { it.id }
+
+        val data = when (rep) {
             is ThreadCommentReplyNotification -> SocialNotificationData(
-                user = notification.user,
-                content = "Replied to your comment${inThread(notification.threadTitle)}",
+                content = if (count > 1) "$count new replies${inThread(rep.threadTitle)}"
+                else "Replied to your comment${inThread(rep.threadTitle)}",
                 channelId = NotificationChannels.THREAD_COMMENT_REPLY_CHANNEL_ID,
-                threadId = notification.threadId,
-                commentId = notification.commentId
+                threadId = rep.threadId,
+                commentId = rep.commentId
             )
             is ThreadCommentSubscribedNotification -> SocialNotificationData(
-                user = notification.user,
-                content = notification.threadTitle.takeIf { it.isNotBlank() }
-                    ?.let { "Commented in \"$it\"" } ?: "Commented in a thread you're subscribed to",
+                content = when {
+                    count > 1 -> "$count new comments${inThread(rep.threadTitle)}"
+                    rep.threadTitle.isNotBlank() -> "Commented in \"${rep.threadTitle}\""
+                    else -> "Commented in a thread you're subscribed to"
+                },
                 channelId = NotificationChannels.THREAD_SUBSCRIBED_CHANNEL_ID,
-                threadId = notification.threadId,
-                commentId = notification.commentId
+                threadId = rep.threadId,
+                commentId = rep.commentId
             )
             is ThreadCommentMentionNotification -> SocialNotificationData(
-                user = notification.user,
-                content = "Mentioned you in a comment${inThread(notification.threadTitle)}",
+                content = "Mentioned you in a comment${inThread(rep.threadTitle)}",
                 channelId = NotificationChannels.THREAD_COMMENT_MENTION_CHANNEL_ID,
-                threadId = notification.threadId,
-                commentId = notification.commentId
+                threadId = rep.threadId,
+                commentId = rep.commentId
             )
             is ThreadLikeNotification -> SocialNotificationData(
-                user = notification.user,
                 content = "Liked your thread" +
-                    notification.threadTitle.takeIf { it.isNotBlank() }?.let { " \"$it\"" }.orEmpty(),
+                    rep.threadTitle.takeIf { it.isNotBlank() }?.let { " \"$it\"" }.orEmpty(),
                 channelId = NotificationChannels.THREAD_LIKE_CHANNEL_ID,
-                threadId = notification.threadId
+                threadId = rep.threadId
             )
             is ThreadCommentLikeNotification -> SocialNotificationData(
-                user = notification.user,
-                content = "Liked your comment${inThread(notification.threadTitle)}",
+                content = "Liked your comment${inThread(rep.threadTitle)}",
                 channelId = NotificationChannels.THREAD_COMMENT_LIKE_CHANNEL_ID,
-                threadId = notification.threadId,
-                commentId = notification.commentId
+                threadId = rep.threadId,
+                commentId = rep.commentId
             )
             is ActivityReplyNotification -> SocialNotificationData(
-                user = notification.user,
-                content = "Replied to your ${notification.activity?.kind.noun()}",
+                content = if (count > 1) "$count new replies to your ${rep.activity?.kind.noun()}"
+                else "Replied to your ${rep.activity?.kind.noun()}",
                 channelId = NotificationChannels.ACTIVITY_REPLY_CHANNEL_ID,
-                activityId = notification.activityId
+                activityId = rep.activityId
             )
             is ActivityReplySubscribedNotification -> SocialNotificationData(
-                user = notification.user,
-                content = "Replied to a post you're subscribed to",
+                content = if (count > 1) "$count new replies to a post you're subscribed to"
+                else "Replied to a post you're subscribed to",
                 channelId = NotificationChannels.ACTIVITY_REPLY_CHANNEL_ID,
-                activityId = notification.activityId
+                activityId = rep.activityId
             )
             is ActivityMentionNotification -> SocialNotificationData(
-                user = notification.user,
-                content = "Mentioned you in ${notification.activity?.kind.indefiniteNoun()}",
+                content = "Mentioned you in ${rep.activity?.kind.indefiniteNoun()}",
                 channelId = NotificationChannels.ACTIVITY_MENTION_CHANNEL_ID,
-                activityId = notification.activityId
+                activityId = rep.activityId
             )
             is ActivityLikeNotification -> SocialNotificationData(
-                user = notification.user,
-                content = "Liked your ${notification.activity?.kind.noun()}",
+                content = "Liked your ${rep.activity?.kind.noun()}",
                 channelId = NotificationChannels.ACTIVITY_LIKE_CHANNEL_ID,
-                activityId = notification.activityId
+                activityId = rep.activityId
             )
             is ActivityReplyLikeNotification -> SocialNotificationData(
-                user = notification.user,
                 content = "Liked your reply",
                 channelId = NotificationChannels.ACTIVITY_LIKE_CHANNEL_ID,
-                activityId = notification.activityId
+                activityId = rep.activityId
             )
             is ActivityMessageNotification -> SocialNotificationData(
-                user = notification.user,
-                content = "Sent you a message",
+                content = if (count > 1) "$count new messages" else "Sent you a message",
                 channelId = NotificationChannels.ACTIVITY_MESSAGE_CHANNEL_ID,
-                activityId = notification.activityId
+                activityId = rep.activityId
+            )
+            is FollowingNotification -> SocialNotificationData(
+                content = "Started following you",
+                channelId = NotificationChannels.FOLLOW_CHANNEL_ID,
+                userName = rep.user?.name
             )
             else -> return
         }
 
-        val notificationId = SOCIAL_NOTIFICATION_BASE_ID + notification.id
         val deepLinkUri = when {
             data.activityId != null -> "anisync://activity/${data.activityId}"
             data.commentId != null -> "anisync://forum/thread/${data.threadId}?commentId=${data.commentId}"
             data.threadId != null -> "anisync://forum/thread/${data.threadId}"
+            data.userName != null -> "anisync://user/${Uri.encode(data.userName)}"
             else -> "anisync://notifications"
         }
 
-        val largeIcon: Bitmap? = data.user?.avatarUrl?.let { loadImage(it) }
+        val largeIcon: Bitmap? = actors.firstOrNull()?.avatarUrl?.let { loadImage(it) }
 
         val builder = NotificationCompat.Builder(applicationContext, data.channelId)
             .setSmallIcon(R.drawable.ic_notification)
-            .setContentTitle(data.user?.name ?: "Someone")
+            .setContentTitle(actorsLabel(actors))
             .setContentText(data.content)
             .setAutoCancel(true)
-            .setWhen(notification.createdAt.toLong() * 1000L)
+            .setWhen(rep.createdAt.toLong() * 1000L)
             .setShowWhen(true)
             .setGroup(groupKey(GROUP_KEY_SOCIAL, ctx))
-            .setContentIntent(deepLinkIntent(deepLinkUri, ctx, notificationId))
+            .setContentIntent(deepLinkIntent(deepLinkUri, ctx, slot.id))
 
         if (largeIcon != null) builder.setLargeIcon(largeIcon)
 
-        post(ctx, notificationId, builder)
+        post(ctx, slot.category, slot.id, builder)
     }
 
     private data class SocialNotificationData(
-        val user: User?,
         val content: String,
         val channelId: String,
         val threadId: Int? = null,
         val commentId: Int? = null,
-        val activityId: Int? = null
+        val activityId: Int? = null,
+        val userName: String? = null
     )
+
+    /**
+     * Group summary so social notifications bundle in the tray. Only needed once two or more are
+     * actually showing; the system expands/collapses the stack and drops the summary with the
+     * last child.
+     */
+    private fun maybePostSocialSummary(ctx: AcctCtx) {
+        val nm = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val group = groupKey(GROUP_KEY_SOCIAL, ctx)
+        val activeInGroup = nm.activeNotifications.count { sbn ->
+            sbn.notification.group == group &&
+                (sbn.notification.flags and android.app.Notification.FLAG_GROUP_SUMMARY) == 0
+        }
+        if (activeInGroup < 2) return
+
+        val builder = NotificationCompat.Builder(applicationContext, NotificationChannels.ACTIVITY_REPLY_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle("New activity")
+            .setContentText("$activeInGroup notifications")
+            .setGroup(group)
+            .setGroupSummary(true)
+            .setAutoCancel(true)
+            .setContentIntent(deepLinkIntent("anisync://notifications", ctx, SUMMARY_ID))
+
+        post(ctx, CATEGORY_SOCIAL_SUMMARY, SUMMARY_ID, builder)
+    }
 
     /**
      * Check for upcoming Episode 1 airings for Planning list items (active account only).
@@ -558,7 +640,7 @@ class NotificationWorker @AssistedInject constructor(
     }
 
     private suspend fun showAiringNotification(notification: AiringNotification, ctx: AcctCtx) {
-        val notificationId = AIRING_NOTIFICATION_BASE_ID + notification.id
+        val notificationId = notification.id
         val media = notification.media
         val title = media?.title ?: "New episode"
         val content = "Episode ${notification.episode} has aired"
@@ -580,11 +662,12 @@ class NotificationWorker @AssistedInject constructor(
 
         if (largeIcon != null) builder.setLargeIcon(largeIcon)
 
-        post(ctx, notificationId, builder)
+        post(ctx, CATEGORY_AIRING, notificationId, builder)
     }
 
     private suspend fun showAdvanceEpisodeNotification(airing: AiringSchedule, ctx: AcctCtx) {
-        val notificationId = UPCOMING_ADVANCE_NOTIFICATION_BASE_ID + airing.id
+        // Same slot as the imminent tier: "starting soon" replaces "airs tomorrow" in the tray.
+        val notificationId = airing.id
         val title = airing.mediaTitle
 
         val airingDate = java.util.Date(airing.airingAt * 1000)
@@ -618,12 +701,12 @@ class NotificationWorker @AssistedInject constructor(
 
         if (largeIcon != null) builder.setLargeIcon(largeIcon)
 
-        post(ctx, notificationId, builder)
+        post(ctx, CATEGORY_UPCOMING, notificationId, builder)
         Log.d(TAG, "Sent advance notification for ${airing.mediaTitle}: $content")
     }
 
     private suspend fun showImminentEpisodeNotification(airing: AiringSchedule, hoursUntil: Int, ctx: AcctCtx) {
-        val notificationId = UPCOMING_IMMINENT_NOTIFICATION_BASE_ID + airing.id
+        val notificationId = airing.id
         val title = airing.mediaTitle
 
         val content = when {
@@ -644,12 +727,12 @@ class NotificationWorker @AssistedInject constructor(
 
         if (largeIcon != null) builder.setLargeIcon(largeIcon)
 
-        post(ctx, notificationId, builder)
+        post(ctx, CATEGORY_UPCOMING, notificationId, builder)
         Log.d(TAG, "Sent imminent notification for ${airing.mediaTitle}: $content")
     }
 
     private suspend fun showPlanningFirstEpisodeNotification(airing: AiringSchedule, ctx: AcctCtx) {
-        val notificationId = PLANNING_NOTIFICATION_BASE_ID + airing.mediaId
+        val notificationId = airing.mediaId
         val title = airing.mediaTitle
         val content = "Episode 1 is now available"
 
@@ -658,7 +741,7 @@ class NotificationWorker @AssistedInject constructor(
             action = AddToWatchingReceiver.ACTION_ADD_TO_WATCHING
             putExtra(AddToWatchingReceiver.EXTRA_MEDIA_ID, airing.mediaId)
             putExtra(AddToWatchingReceiver.EXTRA_NOTIFICATION_ID, notificationId)
-            putExtra(AddToWatchingReceiver.EXTRA_NOTIFICATION_TAG, notificationTag(ctx))
+            putExtra(AddToWatchingReceiver.EXTRA_NOTIFICATION_TAG, notificationTag(ctx, CATEGORY_PLANNING))
             putExtra(AddToWatchingReceiver.EXTRA_MEDIA_TITLE, airing.mediaTitle)
         }
         val addToWatchingPendingIntent = PendingIntent.getBroadcast(
@@ -687,7 +770,7 @@ class NotificationWorker @AssistedInject constructor(
 
         if (largeIcon != null) builder.setLargeIcon(largeIcon)
 
-        post(ctx, notificationId, builder)
+        post(ctx, CATEGORY_PLANNING, notificationId, builder)
     }
 
     private fun showSummaryNotification(notifications: List<AiringNotification>, ctx: AcctCtx) {
@@ -710,7 +793,7 @@ class NotificationWorker @AssistedInject constructor(
             .setAutoCancel(true)
             .setContentIntent(deepLinkIntent("anisync://notifications", ctx, SUMMARY_ID))
 
-        post(ctx, SUMMARY_ID, builder)
+        post(ctx, CATEGORY_AIRING, SUMMARY_ID, builder)
     }
 
     // ── Multi-account notification helpers ──────────────────────────────────────────────
@@ -730,16 +813,18 @@ class NotificationWorker @AssistedInject constructor(
         )
     }
 
-    private fun notificationTag(ctx: AcctCtx) = "acct_${ctx.id}"
+    private fun notificationTag(ctx: AcctCtx, category: String) = "acct_${ctx.id}_$category"
 
     /**
-     * Posts under a per-account tag so the same AniList notification id from two accounts can't
-     * overwrite each other in the tray, and labels the account when more than one is signed in.
+     * Posts under a per-account, per-category tag: two accounts can't overwrite each other, and
+     * within an account the id only has to be unique per category (it's the target's own id, so
+     * a newer event for the same target replaces the stale entry). Labels the account when more
+     * than one is signed in.
      */
-    private fun post(ctx: AcctCtx, id: Int, builder: NotificationCompat.Builder) {
+    private fun post(ctx: AcctCtx, category: String, id: Int, builder: NotificationCompat.Builder) {
         if (ctx.showLabel) builder.setSubText(ctx.name)
         val nm = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        nm.notify(notificationTag(ctx), id, builder.build())
+        nm.notify(notificationTag(ctx, category), id, builder.build())
     }
 
     private suspend fun loadImage(url: String): Bitmap? {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -489,6 +489,9 @@
     <string name="notification_channel_watching_desc">حلقات جديدة للعروض التي تشاهدها</string>
     <string name="notification_group_airing">البث</string>
     <string name="notification_group_forum">المنتدى</string>
+    <string name="notification_group_other">أخرى</string>
+    <string name="notification_follows">متابعون جدد</string>
+    <string name="notification_follows_desc">عندما يبدأ شخص ما بمتابعتك</string>
     <string name="notification_thread_comment_like">إعجابات التعليقات</string>
     <string name="notification_thread_comment_like_desc">عندما يعجب أحدهم بتعليقك</string>
     <string name="notification_thread_comment_mention">الإشارات</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -489,6 +489,9 @@
     <string name="notification_channel_watching_desc">Neue Folgen für Serien, die du ansiehst</string>
     <string name="notification_group_airing">Austrahlung</string>
     <string name="notification_group_forum">Forum</string>
+    <string name="notification_group_other">Sonstiges</string>
+    <string name="notification_follows">Neue Follower</string>
+    <string name="notification_follows_desc">Wenn dir jemand folgt</string>
     <string name="notification_thread_comment_like">Kommentar-Likes</string>
     <string name="notification_thread_comment_like_desc">Wenn jemand deinen Kommentar liked</string>
     <string name="notification_thread_comment_mention">Erwähnungen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -246,6 +246,9 @@
     <string name="notification_thread_comment_like_desc">Cuando a alguien le gusta tu comentario</string>
     <string name="notification_group_airing">En emisión</string>
     <string name="notification_group_forum">Foro</string>
+    <string name="notification_group_other">Otros</string>
+    <string name="notification_follows">Nuevos seguidores</string>
+    <string name="notification_follows_desc">Cuando alguien empieza a seguirte</string>
     <string name="notification_group_activity">Actividad</string>
     <string name="notification_channel_watching">Lista de viendo</string>
     <string name="notification_channel_watching_desc">Nuevos episodios de los programas que estás viendo</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -199,6 +199,9 @@
     <string name="notification_thread_comment_like_desc">Quando alguém curte o seu comentário</string>
     <string name="notification_group_airing">Em exibição</string>
     <string name="notification_group_forum">Fórum</string>
+    <string name="notification_group_other">Outros</string>
+    <string name="notification_follows">Novos seguidores</string>
+    <string name="notification_follows_desc">Quando alguém começa a seguir você</string>
     <string name="notification_group_activity">Atividade</string>
     <string name="notification_channel_watching">Lista de Assistindo</string>
     <string name="notification_channel_watching_desc">Novos episódios para programas que você está assistindo</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -243,6 +243,9 @@
     <string name="notification_thread_comment_like_desc">Quando alguém curte o seu comentário</string>
     <string name="notification_group_airing">Em exibição</string>
     <string name="notification_group_forum">Fórum</string>
+    <string name="notification_group_other">Outros</string>
+    <string name="notification_follows">Novos seguidores</string>
+    <string name="notification_follows_desc">Quando alguém começa a seguir você</string>
     <string name="notification_group_activity">Atividade</string>
     <string name="notification_channel_watching">Lista de Vistos</string>
     <string name="notification_channel_watching_desc">Novos episódios para programas que está a ver</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -96,4 +96,7 @@
     <string name="notification_thread_comment_reply">Ответы на комментарий</string>
     <string name="notification_thread_comment_reply_desc">Когда кто-то ответил на Ваш комментарий</string>
     <string name="control_notifications">Уведомления</string>
+    <string name="notification_group_other">Прочее</string>
+    <string name="notification_follows">Новые подписчики</string>
+    <string name="notification_follows_desc">Когда кто-то подписывается на вас</string>
 </resources>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -282,6 +282,9 @@
     <string name="notification_thread_comment_like_desc">உங்கள் கருத்தை யாராவது விரும்பும்போது</string>
     <string name="notification_group_airing">ஒளிபரப்பு</string>
     <string name="notification_group_forum">மன்றம்</string>
+    <string name="notification_group_other">மற்றவை</string>
+    <string name="notification_follows">புதிய பின்தொடர்பவர்கள்</string>
+    <string name="notification_follows_desc">யாராவது உங்களைப் பின்தொடரத் தொடங்கும்போது</string>
     <string name="notification_group_activity">செய்கைப்பாடு</string>
     <string name="notification_channel_watching">பார்க்கும் பட்டியல்</string>
     <string name="notification_channel_watching_desc">நீங்கள் பார்க்கும் நிகழ்ச்சிகளுக்கான புதிய அத்தியாயங்கள்</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -318,6 +318,9 @@
     <string name="notification_group_airing">Airing</string>
     <string name="notification_group_forum">Forum</string>
     <string name="notification_group_activity">Activity</string>
+    <string name="notification_group_other">Other</string>
+    <string name="notification_follows">New Followers</string>
+    <string name="notification_follows_desc">When someone starts following you</string>
     <string name="notification_channel_watching">Watching List</string>
     <string name="notification_channel_watching_desc">New episodes for shows you\'re watching</string>
     <string name="notification_channel_planning">Planning List</string>


### PR DESCRIPTION
Reworks how notifications land in the tray and fills in a couple of missing kinds.

## What it does
- Tray entries stack per target instead of per event: a given media, activity or thread keeps one slot that updates, rather than piling up duplicates.
- Notification channels are grouped so the system notification settings read cleanly.
- Adds follower alerts.
- Long media notes expand in place, with a clearer affordance showing they can be opened.

## Notes
- Also repairs the notification worker's error handling and tidies the notification copy.