### PR TITLE
feat(library): show your score on list and grid cards

### DIFF
--- a/app/src/main/java/com/anisync/android/data/AppSettings.kt
+++ b/app/src/main/java/com/anisync/android/data/AppSettings.kt
@@ -377,6 +377,11 @@ class AppSettings @Inject constructor(
     )
     val gridColumnCount: StateFlow<Int> = _gridColumnCount.asStateFlow()
 
+    // Show the user's saved score on Library list/grid cards. Persisted like the other Library view
+    // options so the choice survives restarts.
+    private val _showScoreOnCards = MutableStateFlow(prefs.getBoolean(KEY_SHOW_SCORE_ON_CARDS, true))
+    val showScoreOnCards: StateFlow<Boolean> = _showScoreOnCards.asStateFlow()
+
     // Two-pane list/detail split, stored as the list pane's width fraction so a resized split
     // survives app restarts (M3 panes guidance). Only real split widths are written here; the
     // fully-collapsed state is a transient per-session toggle, not a width preference.
@@ -841,6 +846,12 @@ class AppSettings @Inject constructor(
         prefs.edit().putInt(KEY_GRID_COLUMN_COUNT, coerced).apply()
     }
 
+    /** Toggle the saved-score badge on Library list/grid cards. */
+    fun setShowScoreOnCards(show: Boolean) {
+        _showScoreOnCards.value = show
+        prefs.edit().putBoolean(KEY_SHOW_SCORE_ON_CARDS, show).apply()
+    }
+
     /** Persist the two-pane list/detail split as the list pane's width fraction (coerced to 0..1). */
     fun setPaneListFraction(fraction: Float) {
         val coerced = fraction.coerceIn(0f, 1f)
@@ -1120,6 +1131,7 @@ companion object {
         private const val KEY_LIBRARY_GRID_VIEW = "library_grid_view"
         private const val KEY_GRID_COLUMNS_AUTO = "grid_columns_auto"
         private const val KEY_GRID_COLUMN_COUNT = "grid_column_count"
+        private const val KEY_SHOW_SCORE_ON_CARDS = "show_score_on_cards"
         const val MIN_GRID_COLUMNS = 2
         const val MAX_GRID_COLUMNS = 8
         const val DEFAULT_GRID_COLUMNS = 3

--- a/app/src/main/java/com/anisync/android/presentation/components/LibraryMediaCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/components/LibraryMediaCard.kt
@@ -33,6 +33,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -72,6 +73,8 @@ import com.anisync.android.data.AppSettings
 import com.anisync.android.data.TitleLanguage
 import com.anisync.android.domain.LibraryEntry
 import com.anisync.android.domain.LibraryStatus
+import com.anisync.android.domain.ScoreFormat
+import com.anisync.android.domain.formatScore
 import com.anisync.android.presentation.util.AppMotion
 import com.anisync.android.presentation.util.LocalAppSettings
 import com.anisync.android.presentation.util.TransitionKeys
@@ -140,6 +143,8 @@ fun LibraryMediaCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     config: LibraryCardConfig = WatchingCardConfig,
+    showScore: Boolean = false,
+    scoreFormat: ScoreFormat = ScoreFormat.POINT_10_DECIMAL,
     onIncrement: (() -> Unit)? = null,
     onDecrement: (() -> Unit)? = null,
     onEdit: (() -> Unit)? = null,
@@ -296,6 +301,16 @@ fun LibraryMediaCard(
                         .align(Alignment.BottomStart)
                         .padding(12.dp)
                 )
+
+                if (showScore && (entry.score ?: 0.0) > 0.0) {
+                    ScorePosterBadge(
+                        score = entry.score,
+                        format = scoreFormat,
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(8.dp)
+                    )
+                }
             }
 
             // Content section
@@ -525,6 +540,40 @@ fun LibraryMediaCard(
                 }
             }
         }
+    }
+}
+
+/**
+ * Score badge overlaid on the poster's top corner. Uses its own dark scrim + white text because it
+ * sits on the cover image, not a surface (so [ScoreChip] doesn't fit). The leading star is dropped
+ * for POINT_5 / POINT_3, which already read as stars / smileys.
+ */
+@Composable
+private fun ScorePosterBadge(score: Double?, format: ScoreFormat, modifier: Modifier = Modifier) {
+    val showStar = format != ScoreFormat.POINT_5 && format != ScoreFormat.POINT_3
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color.Black.copy(alpha = 0.55f))
+            .padding(horizontal = 6.dp, vertical = 3.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        if (showStar) {
+            Icon(
+                imageVector = Icons.Default.Star,
+                contentDescription = null,
+                tint = Color(0xFFFFC107),
+                modifier = Modifier.size(11.dp)
+            )
+        }
+        Text(
+            text = formatScore(score, format),
+            style = MaterialTheme.typography.labelSmall,
+            color = Color.White,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1
+        )
     }
 }
 

--- a/app/src/main/java/com/anisync/android/presentation/library/LibraryScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/library/LibraryScreen.kt
@@ -668,6 +668,8 @@ fun LibraryScreen(
                                                 } else null,
                                                 onEdit = { handleEdit(entry) },
                                                 config = cardConfig,
+                                                showScore = uiState.showScoreOnCards,
+                                                scoreFormat = uiState.userScoreFormat,
                                                 sharedTransitionScope = sharedTransitionScope,
                                                 animatedVisibilityScope = animatedVisibilityScope,
                                                 titleLanguage = titleLanguage,
@@ -713,6 +715,8 @@ fun LibraryScreen(
                                                 } else null,
                                                 onEdit = { handleEdit(entry) },
                                                 config = cardConfig,
+                                                showScore = uiState.showScoreOnCards,
+                                                scoreFormat = uiState.userScoreFormat,
                                                 sharedTransitionScope = sharedTransitionScope,
                                                 animatedVisibilityScope = animatedVisibilityScope,
                                                 titleLanguage = titleLanguage,
@@ -864,9 +868,11 @@ fun LibraryScreen(
         isGridView = uiState.isGridView,
         autoColumns = LocalGridColumnsAuto.current,
         columnCount = LocalGridColumnCount.current,
+        showScore = uiState.showScoreOnCards,
         onSetGridView = { viewModel.onAction(LibraryAction.SetGridView(it)) },
         onSetAutoColumns = { appSettings.setGridColumnsAuto(it) },
         onSetColumnCount = { appSettings.setGridColumnCount(it) },
+        onSetShowScore = { appSettings.setShowScoreOnCards(it) },
         onDismiss = { showViewOptionsSheet = false }
     )
 

--- a/app/src/main/java/com/anisync/android/presentation/library/LibraryUiState.kt
+++ b/app/src/main/java/com/anisync/android/presentation/library/LibraryUiState.kt
@@ -34,6 +34,7 @@ data class LibraryUiState(
     /** The search category chip currently selected; [LIBRARY_ALL_TAB_ID] shows everything. */
     val activeSearchCategory: String = LIBRARY_ALL_TAB_ID,
     val showPrivateEntries: Boolean = true,
+    val showScoreOnCards: Boolean = true,
     val isGridView: Boolean = true,
     val initialTabId: String? = null,
     val isLoading: Boolean = true,

--- a/app/src/main/java/com/anisync/android/presentation/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/library/LibraryViewModel.kt
@@ -99,6 +99,10 @@ class LibraryViewModel @Inject constructor(
             _uiState.update { it.copy(userScoreFormat = format) }
         }.launchIn(viewModelScope)
 
+        appSettings.showScoreOnCards.onEach { show ->
+            _uiState.update { it.copy(showScoreOnCards = show) }
+        }.launchIn(viewModelScope)
+
         observeLibraryData()
     }
 

--- a/app/src/main/java/com/anisync/android/presentation/library/components/LibraryListCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/library/components/LibraryListCard.kt
@@ -61,7 +61,9 @@ import com.anisync.android.data.AppSettings
 import com.anisync.android.data.TitleLanguage
 import com.anisync.android.domain.LibraryEntry
 import com.anisync.android.domain.LibraryStatus
+import com.anisync.android.domain.ScoreFormat
 import com.anisync.android.presentation.components.CompletedCardConfig
+import com.anisync.android.presentation.components.ScoreChip
 import com.anisync.android.presentation.components.LibraryCardConfig
 import com.anisync.android.presentation.components.WatchingCardConfig
 import com.anisync.android.presentation.util.AppMotion
@@ -84,6 +86,8 @@ fun LibraryListCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     config: LibraryCardConfig = WatchingCardConfig,
+    showScore: Boolean = false,
+    scoreFormat: ScoreFormat = ScoreFormat.POINT_10_DECIMAL,
     onIncrement: (() -> Unit)? = null,
     onDecrement: (() -> Unit)? = null,
     onEdit: (() -> Unit)? = null,
@@ -242,12 +246,17 @@ fun LibraryListCard(
                 )
 
                 // Badges and Airing Info
-                if (config.showBehindBadge || config.showAiringInfo) {
+                val showScoreChip = showScore && (entry.score ?: 0.0) > 0.0
+                if (showScoreChip || config.showBehindBadge || config.showAiringInfo) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         modifier = Modifier.padding(top = 4.dp)
                     ) {
+                        if (showScoreChip) {
+                            ScoreChip(score = entry.score, format = scoreFormat)
+                        }
+
                         if (config.showBehindBadge && entry.status == LibraryStatus.CURRENT) {
                             val nextAiring = entry.nextAiringEpisode
                             val latest: Int? = if (nextAiring != null) nextAiring - 1 else total

--- a/app/src/main/java/com/anisync/android/presentation/library/components/LibraryViewOptionsSheet.kt
+++ b/app/src/main/java/com/anisync/android/presentation/library/components/LibraryViewOptionsSheet.kt
@@ -48,9 +48,11 @@ fun LibraryViewOptionsSheet(
     isGridView: Boolean,
     autoColumns: Boolean,
     columnCount: Int,
+    showScore: Boolean,
     onSetGridView: (Boolean) -> Unit,
     onSetAutoColumns: (Boolean) -> Unit,
     onSetColumnCount: (Int) -> Unit,
+    onSetShowScore: (Boolean) -> Unit,
     onDismiss: () -> Unit,
 ) {
     if (!visible) return
@@ -163,6 +165,28 @@ fun LibraryViewOptionsSheet(
                 steps = AppSettings.MAX_GRID_COLUMNS - AppSettings.MIN_GRID_COLUMNS - 1,
                 enabled = sliderEnabled
             )
+
+            Spacer(Modifier.height(16.dp))
+
+            // Score badge — applies to both layouts, so it's not gated on grid mode.
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.library_view_show_score),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Text(
+                        text = stringResource(R.string.library_view_show_score_desc),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = showScore,
+                    onCheckedChange = onSetShowScore
+                )
+            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -401,6 +401,8 @@
     <string name="library_view_automatic_desc">Fit the number of columns to the screen size</string>
     <string name="library_view_columns">Columns</string>
     <string name="library_view_columns_value">%1$d columns</string>
+    <string name="library_view_show_score">Show score</string>
+    <string name="library_view_show_score_desc">Show your rating on list and grid cards</string>
     <string name="list_detail_select_prompt">Select a title to see details</string>
     <string name="cover_quality_extra_large">Extra large</string>
     <string name="cover_quality_extra_large_desc">Maximum sharpness everywhere. Best on Wi-Fi.</string>

--- a/app/src/test/java/com/anisync/android/domain/ScoreFormatterTest.kt
+++ b/app/src/test/java/com/anisync/android/domain/ScoreFormatterTest.kt
@@ -1,0 +1,50 @@
+package com.anisync.android.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Locks the score-badge rendering across every AniList rating system. The raw [LibraryEntry.score]
+ * is returned in the account's own [ScoreFormat] scale (UserLibrary.graphql fetches `score` with no
+ * `format:` arg), so each format must read its value on its own scale.
+ */
+class ScoreFormatterTest {
+
+    @Test
+    fun `null and zero render as no score for every format`() {
+        for (format in ScoreFormat.entries) {
+            assertEquals("No score", formatScore(null, format))
+            assertEquals("No score", formatScore(0.0, format))
+        }
+    }
+
+    @Test
+    fun `point 100 renders the integer on the 0-100 scale`() {
+        assertEquals("87", formatScore(87.0, ScoreFormat.POINT_100))
+        assertEquals("100", formatScore(100.0, ScoreFormat.POINT_100))
+    }
+
+    @Test
+    fun `point 10 renders the integer on the 0-10 scale`() {
+        assertEquals("9", formatScore(9.0, ScoreFormat.POINT_10))
+    }
+
+    @Test
+    fun `point 10 decimal keeps one decimal place`() {
+        assertEquals("7.5", formatScore(7.5, ScoreFormat.POINT_10_DECIMAL))
+        assertEquals("8.0", formatScore(8.0, ScoreFormat.POINT_10_DECIMAL))
+    }
+
+    @Test
+    fun `point 5 renders filled stars on the 0-5 scale`() {
+        assertEquals("★★★", formatScore(3.0, ScoreFormat.POINT_5))
+        assertEquals("★★★★★", formatScore(5.0, ScoreFormat.POINT_5))
+    }
+
+    @Test
+    fun `point 3 renders smileys on the 1-3 scale`() {
+        assertEquals(":(", formatScore(1.0, ScoreFormat.POINT_3))
+        assertEquals(":|", formatScore(2.0, ScoreFormat.POINT_3))
+        assertEquals(":)", formatScore(3.0, ScoreFormat.POINT_3))
+    }
+}


### PR DESCRIPTION
Adds a "Show score" toggle to the Library view options that puts your own rating on each card.

## What it does
- A small badge in the poster corner on grid, a chip in the list layout.
- On by default, and remembered across restarts like the other view options.
- Renders in your account's score format (100-point, 10-point, decimal, 5-star or 3-smiley), and only shows when you've actually rated the title.

## Notes
- Verified on-device, with a unit test locking the score rendering across every rating system.