### PR TITLE
Customizable share cards

### DIFF
--- a/app/src/main/graphql/StaffDetails.graphql
+++ b/app/src/main/graphql/StaffDetails.graphql
@@ -30,13 +30,27 @@ query GetStaffDetails($id: Int!, $page: Int = 1, $staffMediaPage: Int = 1) {
         primaryOccupations
         yearsActive
         homeTown
-        characterMedia(page: $page, sort: [START_DATE_DESC], perPage: 25) {
+        # The characters connection (NOT characterMedia): sortable by the characters' own
+        # favourites, so "known for" surfaces the VA's most iconic roles. characterMedia can
+        # only sort by media, which is why the AniList site grid orders feel irrelevant here.
+        characters(page: $page, sort: [FAVOURITES_DESC], perPage: 25) {
             pageInfo {
                 hasNextPage
             }
             edges {
-                characterRole
+                role
                 node {
+                    id
+                    name {
+                        full
+                        native
+                        userPreferred
+                    }
+                    image {
+                        medium
+                    }
+                }
+                media {
                     id
                     title {
                         userPreferred
@@ -45,9 +59,9 @@ query GetStaffDetails($id: Int!, $page: Int = 1, $staffMediaPage: Int = 1) {
                         native
                     }
                     coverImage {
-                      medium
-                      large
-                      extraLarge
+                        medium
+                        large
+                        extraLarge
                     }
                     startDate {
                         year
@@ -58,17 +72,6 @@ query GetStaffDetails($id: Int!, $page: Int = 1, $staffMediaPage: Int = 1) {
                     favourites
                     mediaListEntry {
                         id
-                    }
-                }
-                characters {
-                    id
-                    name {
-                        full
-                        native
-                        userPreferred
-                    }
-                    image {
-                        medium
                     }
                 }
             }

--- a/app/src/main/java/com/anisync/android/data/DetailsRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/DetailsRepositoryImpl.kt
@@ -925,31 +925,25 @@ class DetailsRepositoryImpl @Inject constructor(
 
             val alternativeNames = staffData.name?.alternative?.filterNotNull() ?: emptyList()
 
-            val pageInfo = staffData.characterMedia?.pageInfo
+            val pageInfo = staffData.characters?.pageInfo
             val hasNextPage = pageInfo?.hasNextPage ?: false
 
-            val characterMap =
-                linkedMapOf<Int, MutableList<Pair<GetStaffDetailsQuery.Edge, GetStaffDetailsQuery.Character>>>()
-            staffData.characterMedia?.edges?.filterNotNull()?.forEach { edge ->
-                edge.characters?.filterNotNull()?.forEach { character ->
-                    val charId = character.id ?: return@forEach
-                    characterMap.getOrPut(charId) { mutableListOf() }.add(edge to character)
-                }
-            }
-
-            val voicedCharacters = characterMap.map { (charId, entries) ->
-                val firstChar = entries.first().second
+            // One edge per character, already server-ordered by the characters' own favourites
+            // (FAVOURITES_DESC); edge.media carries the roles, so no client-side regrouping.
+            val voicedCharacters = staffData.characters?.edges?.filterNotNull()?.mapNotNull { edge ->
+                val character = edge.node ?: return@mapNotNull null
+                val charId = character.id ?: return@mapNotNull null
                 VoicedCharacter(
                     characterId = charId,
-                    characterName = firstChar.name?.full ?: "Unknown",
-                    characterNameNative = firstChar.name?.native,
-                    characterNameUserPreferred = firstChar.name?.userPreferred
-                        ?: firstChar.name?.full ?: "Unknown",
-                    characterImageUrl = firstChar.image?.medium,
-                    mediaAppearances = entries.mapNotNull { (edge, _) ->
-                        val node = edge.node ?: return@mapNotNull null
+                    characterName = character.name?.full ?: "Unknown",
+                    characterNameNative = character.name?.native,
+                    characterNameUserPreferred = character.name?.userPreferred
+                        ?: character.name?.full ?: "Unknown",
+                    characterImageUrl = character.image?.medium,
+                    mediaAppearances = edge.media?.filterNotNull()?.mapNotNull { node ->
+                        val mediaId = node.id ?: return@mapNotNull null
                         CharacterMediaAppearance(
-                            mediaId = node.id ?: 0,
+                            mediaId = mediaId,
                             mediaTitle = node.title?.userPreferred ?: "Unknown",
                             mediaTitleRomaji = node.title?.romaji,
                             mediaTitleEnglish = node.title?.english,
@@ -957,15 +951,15 @@ class DetailsRepositoryImpl @Inject constructor(
                             coverUrl = node.coverImage?.large,
                             cover = com.anisync.android.domain.CoverImage.of(node.coverImage?.medium, node.coverImage?.large, node.coverImage?.extraLarge),
                             startYear = node.startDate?.year,
-                            characterRole = edge.characterRole?.name,
+                            characterRole = edge.role?.name,
                             popularity = node.popularity,
                             averageScore = node.averageScore,
                             favourites = node.favourites,
                             isOnList = node.mediaListEntry?.id != null
                         )
-                    }
+                    }.orEmpty()
                 )
-            }
+            } ?: emptyList()
 
             val serverIsFav = staffData.isFavourite ?: false
             favouriteOverrideStore.clearIfMatches(FavouriteEntity.STAFF, id, serverIsFav)

--- a/app/src/main/java/com/anisync/android/domain/ScoreFormatter.kt
+++ b/app/src/main/java/com/anisync/android/domain/ScoreFormatter.kt
@@ -1,5 +1,7 @@
 package com.anisync.android.domain
 
+import kotlin.math.roundToInt
+
 enum class ScoreFormat {
     POINT_100,      // 0-100 integer
     POINT_10_DECIMAL, // 0-10 with 1 decimal (e.g., "7.5")
@@ -29,6 +31,26 @@ fun formatScore(score: Double?, format: ScoreFormat): String {
             score >= 2.0 -> ":|"
             score >= 1.0 -> ":("
             else -> "–"
+        }
+    }
+}
+
+/**
+ * Formats a 0–100 community **average** score into the viewer's chosen [format], so a share card's
+ * score badge reads in the same scale the user rates in (a POINT_5 user sees stars, not "8.3").
+ * Returns null when there's no score to show.
+ */
+fun formatCommunityScore(averageScore: Int?, format: ScoreFormat): String? {
+    if (averageScore == null || averageScore <= 0) return null
+    return when (format) {
+        ScoreFormat.POINT_100 -> averageScore.toString()
+        ScoreFormat.POINT_10 -> (averageScore / 10.0).roundToInt().toString()
+        ScoreFormat.POINT_10_DECIMAL -> formatOneDecimal(averageScore / 10.0)
+        ScoreFormat.POINT_5 -> STAR_STRINGS[(averageScore / 20.0).roundToInt().coerceIn(0, 5)]
+        ScoreFormat.POINT_3 -> when {
+            averageScore >= 67 -> ":)"
+            averageScore >= 34 -> ":|"
+            else -> ":("
         }
     }
 }

--- a/app/src/main/java/com/anisync/android/presentation/details/CharacterDetailsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/CharacterDetailsScreen.kt
@@ -223,7 +223,7 @@ fun CharacterDetailsScreen(
             (uiState as? CharacterDetailsUiState.Success)?.details?.let { details ->
                 ShareImageSheet(
                     onDismiss = { showShareSheet = false },
-                    caption = AniListUrls.characterUrl(details.id)
+                    link = AniListUrls.characterUrl(details.id)
                 ) {
                     CharacterShareCard(
                         details = details,

--- a/app/src/main/java/com/anisync/android/presentation/details/CharacterDetailsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/CharacterDetailsScreen.kt
@@ -80,7 +80,10 @@ import com.anisync.android.presentation.details.components.ExpandableBiography
 import com.anisync.android.presentation.details.components.FeaturedMediaItem
 import com.anisync.android.presentation.details.components.NameCard
 import com.anisync.android.presentation.details.components.VoiceActorCard
+import com.anisync.android.presentation.share.CharacterShareCard
+import com.anisync.android.presentation.share.ShareImageSheet
 import com.anisync.android.presentation.util.TransitionKeys
+import com.anisync.android.util.AniListUrls
 import com.anisync.android.util.getName
 import com.anisync.android.util.getTitle
 import kotlinx.coroutines.launch
@@ -99,7 +102,7 @@ fun CharacterDetailsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val titleLanguage by viewModel.titleLanguage.collectAsStateWithLifecycle()
-    val context = androidx.compose.ui.platform.LocalContext.current
+    var showShareSheet by rememberSaveable { mutableStateOf(false) }
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
@@ -145,7 +148,7 @@ fun CharacterDetailsScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = { viewModel.shareCharacter(context) }) {
+                    IconButton(onClick = { showShareSheet = true }) {
                         Icon(
                             imageVector = Icons.Default.Share,
                             contentDescription = stringResource(R.string.cd_share),
@@ -211,6 +214,20 @@ fun CharacterDetailsScreen(
                         message = state.message,
                         onRetry = viewModel::loadCharacterDetails,
                         onBackClick = onBackClick
+                    )
+                }
+            }
+        }
+
+        if (showShareSheet) {
+            (uiState as? CharacterDetailsUiState.Success)?.details?.let { details ->
+                ShareImageSheet(
+                    onDismiss = { showShareSheet = false },
+                    caption = AniListUrls.characterUrl(details.id)
+                ) {
+                    CharacterShareCard(
+                        details = details,
+                        displayName = details.getName(titleLanguage)
                     )
                 }
             }

--- a/app/src/main/java/com/anisync/android/presentation/details/CharacterDetailsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/CharacterDetailsViewModel.kt
@@ -111,10 +111,4 @@ class CharacterDetailsViewModel @Inject constructor(
             }
         }
     }
-
-    fun shareCharacter(context: android.content.Context) {
-        val details = (_uiState.value as? CharacterDetailsUiState.Success)?.details ?: return
-        val name = details.name
-        com.anisync.android.util.ShareUtils.shareCharacter(context, name, characterId)
-    }
 }

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
@@ -755,7 +755,7 @@ fun MediaDetailsScreen(
             (uiState as? DetailsUiState.Success)?.details?.let { details ->
                 ShareImageSheet(
                     onDismiss = { showShareImageSheet = false },
-                    caption = AniListUrls.mediaUrl(details.id, details.type),
+                    link = AniListUrls.mediaUrl(details.id, details.type),
                     seedColor = parseCoverColor(details.coverColor),
                     supportsPrivacy = true,
                     templates = listOf(ShareCardTemplate.STANDARD, ShareCardTemplate.HERO),

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
@@ -165,6 +165,7 @@ import com.anisync.android.presentation.util.rememberHapticFeedback
 import com.anisync.android.presentation.util.toIcon
 import com.anisync.android.presentation.util.toLabel
 import com.anisync.android.presentation.share.MediaShareCard
+import com.anisync.android.presentation.share.ShareCardTemplate
 import com.anisync.android.presentation.share.ShareImageSheet
 import com.anisync.android.presentation.share.parseCoverColor
 import com.anisync.android.util.AniListUrls
@@ -757,6 +758,7 @@ fun MediaDetailsScreen(
                     caption = AniListUrls.mediaUrl(details.id, details.type),
                     seedColor = parseCoverColor(details.coverColor),
                     supportsPrivacy = true,
+                    templates = listOf(ShareCardTemplate.STANDARD, ShareCardTemplate.HERO),
                 ) {
                     MediaShareCard(details = details, scoreFormat = userScoreFormat)
                 }

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
@@ -166,6 +166,7 @@ import com.anisync.android.presentation.util.toIcon
 import com.anisync.android.presentation.util.toLabel
 import com.anisync.android.presentation.share.MediaShareCard
 import com.anisync.android.presentation.share.ShareImageSheet
+import com.anisync.android.presentation.share.parseCoverColor
 import com.anisync.android.util.AniListUrls
 import com.anisync.android.util.getTitle
 
@@ -753,9 +754,12 @@ fun MediaDetailsScreen(
             (uiState as? DetailsUiState.Success)?.details?.let { details ->
                 ShareImageSheet(
                     onDismiss = { showShareImageSheet = false },
-                    caption = AniListUrls.mediaUrl(details.id, details.type)
+                    caption = AniListUrls.mediaUrl(details.id, details.type),
+                    seedColor = parseCoverColor(details.coverColor),
+                    backdropUrl = details.bannerUrl ?: details.coverUrl,
+                    supportsPrivacy = true,
                 ) {
-                    MediaShareCard(details = details)
+                    MediaShareCard(details = details, scoreFormat = userScoreFormat)
                 }
             }
         }

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
@@ -756,7 +756,6 @@ fun MediaDetailsScreen(
                     onDismiss = { showShareImageSheet = false },
                     caption = AniListUrls.mediaUrl(details.id, details.type),
                     seedColor = parseCoverColor(details.coverColor),
-                    backdropUrl = details.bannerUrl ?: details.coverUrl,
                     supportsPrivacy = true,
                 ) {
                     MediaShareCard(details = details, scoreFormat = userScoreFormat)

--- a/app/src/main/java/com/anisync/android/presentation/details/StaffDetailsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/StaffDetailsScreen.kt
@@ -65,6 +65,9 @@ import com.anisync.android.presentation.details.components.ExpandableBiography
 import com.anisync.android.presentation.details.components.FeaturedMediaItem
 import com.anisync.android.presentation.details.components.NameCard
 import com.anisync.android.presentation.details.components.VoicedCharacterItem
+import com.anisync.android.presentation.share.ShareImageSheet
+import com.anisync.android.presentation.share.StaffShareCard
+import com.anisync.android.util.AniListUrls
 import com.anisync.android.util.getTitle
 import com.anisync.android.presentation.util.TransitionKeys
 import com.anisync.android.util.getName
@@ -84,7 +87,7 @@ fun StaffDetailsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val titleLanguage by viewModel.titleLanguage.collectAsStateWithLifecycle()
-    val context = androidx.compose.ui.platform.LocalContext.current
+    var showShareSheet by rememberSaveable { mutableStateOf(false) }
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
@@ -130,7 +133,7 @@ fun StaffDetailsScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = { viewModel.shareStaff(context) }) {
+                    IconButton(onClick = { showShareSheet = true }) {
                         Icon(
                             imageVector = Icons.Default.Share,
                             contentDescription = stringResource(R.string.cd_share),
@@ -199,6 +202,20 @@ fun StaffDetailsScreen(
                         message = state.message,
                         onRetry = viewModel::loadStaffDetails,
                         onBackClick = onBackClick
+                    )
+                }
+            }
+        }
+
+        if (showShareSheet) {
+            (uiState as? StaffDetailsUiState.Success)?.details?.let { details ->
+                ShareImageSheet(
+                    onDismiss = { showShareSheet = false },
+                    caption = AniListUrls.staffUrl(details.id)
+                ) {
+                    StaffShareCard(
+                        details = details,
+                        displayName = details.getName(titleLanguage)
                     )
                 }
             }

--- a/app/src/main/java/com/anisync/android/presentation/details/StaffDetailsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/StaffDetailsScreen.kt
@@ -211,7 +211,7 @@ fun StaffDetailsScreen(
             (uiState as? StaffDetailsUiState.Success)?.details?.let { details ->
                 ShareImageSheet(
                     onDismiss = { showShareSheet = false },
-                    caption = AniListUrls.staffUrl(details.id)
+                    link = AniListUrls.staffUrl(details.id)
                 ) {
                     StaffShareCard(
                         details = details,

--- a/app/src/main/java/com/anisync/android/presentation/details/StaffDetailsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/StaffDetailsViewModel.kt
@@ -177,10 +177,4 @@ class StaffDetailsViewModel @Inject constructor(
             }
         }
     }
-
-    fun shareStaff(context: android.content.Context) {
-        val details = (_uiState.value as? StaffDetailsUiState.Success)?.details ?: return
-        val name = details.name
-        com.anisync.android.util.ShareUtils.shareStaff(context, name, staffId)
-    }
 }

--- a/app/src/main/java/com/anisync/android/presentation/library/components/LibraryViewOptionsSheet.kt
+++ b/app/src/main/java/com/anisync/android/presentation/library/components/LibraryViewOptionsSheet.kt
@@ -7,17 +7,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.GridView
 import androidx.compose.material.icons.outlined.ViewAgenda
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -30,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import com.anisync.android.R
 import com.anisync.android.data.AppSettings
 import com.anisync.android.presentation.components.AppModalBottomSheet
+import com.anisync.android.presentation.components.SegmentedTabGroup
 import kotlin.math.roundToInt
 
 /**
@@ -79,37 +75,17 @@ fun LibraryViewOptionsSheet(
 
             Spacer(Modifier.height(16.dp))
 
-            // List / Grid choice.
-            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                SegmentedButton(
-                    selected = !isGridView,
-                    onClick = { onSetGridView(false) },
-                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Outlined.ViewAgenda,
-                            contentDescription = null,
-                            modifier = Modifier.size(SegmentedButtonDefaults.IconSize)
-                        )
-                    }
-                ) {
-                    Text(stringResource(R.string.library_view_list))
-                }
-                SegmentedButton(
-                    selected = isGridView,
-                    onClick = { onSetGridView(true) },
-                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Outlined.GridView,
-                            contentDescription = null,
-                            modifier = Modifier.size(SegmentedButtonDefaults.IconSize)
-                        )
-                    }
-                ) {
-                    Text(stringResource(R.string.library_view_grid))
-                }
-            }
+            // List / Grid choice — the app's connected ToggleButton group (same as tab switchers).
+            SegmentedTabGroup(
+                options = listOf(false, true),
+                selected = isGridView,
+                onSelect = onSetGridView,
+                label = { grid ->
+                    stringResource(if (grid) R.string.library_view_grid else R.string.library_view_list)
+                },
+                icon = { grid -> if (grid) Icons.Outlined.GridView else Icons.Outlined.ViewAgenda },
+                fillEqually = true,
+            )
 
             Spacer(Modifier.height(24.dp))
 

--- a/app/src/main/java/com/anisync/android/presentation/profile/ProfileContent.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/ProfileContent.kt
@@ -253,8 +253,7 @@ fun ProfileContent(
         uiState.statsData?.let { stats ->
             ShareImageSheet(
                 onDismiss = { statsShareVisible = false },
-                caption = profileUrl,
-                backdropUrl = profile.bannerUrl
+                caption = profileUrl
             ) {
                 ProfileStatsShareCard(
                     profile = profile,
@@ -271,8 +270,7 @@ fun ProfileContent(
         if (entries.isNotEmpty()) {
             ShareImageSheet(
                 onDismiss = { favouritesShareVisible = false },
-                caption = profileUrl,
-                backdropUrl = profile.bannerUrl
+                caption = profileUrl
             ) {
                 FavouritesShareCard(
                     heading = stringResource(

--- a/app/src/main/java/com/anisync/android/presentation/profile/ProfileContent.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/ProfileContent.kt
@@ -70,6 +70,7 @@ import com.anisync.android.presentation.profile.sections.profileSocialTab
 import com.anisync.android.presentation.profile.sections.profileStatsTab
 import com.anisync.android.presentation.share.FavouritesShareCard
 import com.anisync.android.presentation.share.ProfileStatsShareCard
+import com.anisync.android.presentation.share.ShareCardTemplate
 import com.anisync.android.presentation.share.ShareImageSheet
 import com.anisync.android.type.MediaType
 import com.anisync.android.util.ShareUtils
@@ -253,7 +254,14 @@ fun ProfileContent(
         uiState.statsData?.let { stats ->
             ShareImageSheet(
                 onDismiss = { statsShareVisible = false },
-                caption = profileUrl
+                caption = profileUrl,
+                templates = listOf(ShareCardTemplate.STANDARD, ShareCardTemplate.HERO),
+                templateLabel = { tmpl ->
+                    stringResource(
+                        if (tmpl == ShareCardTemplate.STANDARD) R.string.share_template_stats
+                        else R.string.share_template_recap
+                    )
+                }
             ) {
                 ProfileStatsShareCard(
                     profile = profile,
@@ -270,7 +278,14 @@ fun ProfileContent(
         if (entries.isNotEmpty()) {
             ShareImageSheet(
                 onDismiss = { favouritesShareVisible = false },
-                caption = profileUrl
+                caption = profileUrl,
+                templates = listOf(ShareCardTemplate.STANDARD, ShareCardTemplate.HERO),
+                templateLabel = { tmpl ->
+                    stringResource(
+                        if (tmpl == ShareCardTemplate.STANDARD) R.string.share_template_grid
+                        else R.string.share_template_ranked
+                    )
+                }
             ) {
                 FavouritesShareCard(
                     heading = stringResource(

--- a/app/src/main/java/com/anisync/android/presentation/profile/ProfileContent.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/ProfileContent.kt
@@ -476,7 +476,10 @@ internal fun LazyListScope.profileSelectedTabContent(
             }
             if (showShareActions && favShareable) {
                 item(key = "favourites_share_action") {
-                    ShareTabAction(onClick = onShareFavourites)
+                    ShareTabAction(
+                        label = stringResource(R.string.share_favourites_card),
+                        onClick = onShareFavourites
+                    )
                 }
             }
             profileFavoritesTab(
@@ -507,7 +510,10 @@ internal fun LazyListScope.profileSelectedTabContent(
         ProfileTab.STATS -> {
             if (showShareActions && uiState.statsData != null) {
                 item(key = "stats_share_action") {
-                    ShareTabAction(onClick = onShareStats)
+                    ShareTabAction(
+                        label = stringResource(R.string.share_stats_card),
+                        onClick = onShareStats
+                    )
                 }
             }
             profileStatsTab(
@@ -522,9 +528,13 @@ internal fun LazyListScope.profileSelectedTabContent(
     }
 }
 
-/** Right-aligned "Share as image" affordance rendered above a shareable profile tab's content. */
+/** Right-aligned share affordance rendered above a shareable profile tab's content. */
 @Composable
-private fun ShareTabAction(onClick: () -> Unit, modifier: Modifier = Modifier) {
+private fun ShareTabAction(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -538,7 +548,7 @@ private fun ShareTabAction(onClick: () -> Unit, modifier: Modifier = Modifier) {
                 modifier = Modifier.size(18.dp)
             )
             Spacer(Modifier.width(8.dp))
-            Text(stringResource(R.string.share_as_image))
+            Text(label)
         }
     }
 }

--- a/app/src/main/java/com/anisync/android/presentation/profile/ProfileContent.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/ProfileContent.kt
@@ -253,7 +253,8 @@ fun ProfileContent(
         uiState.statsData?.let { stats ->
             ShareImageSheet(
                 onDismiss = { statsShareVisible = false },
-                caption = profileUrl
+                caption = profileUrl,
+                backdropUrl = profile.bannerUrl
             ) {
                 ProfileStatsShareCard(
                     profile = profile,
@@ -270,7 +271,8 @@ fun ProfileContent(
         if (entries.isNotEmpty()) {
             ShareImageSheet(
                 onDismiss = { favouritesShareVisible = false },
-                caption = profileUrl
+                caption = profileUrl,
+                backdropUrl = profile.bannerUrl
             ) {
                 FavouritesShareCard(
                     heading = stringResource(

--- a/app/src/main/java/com/anisync/android/presentation/profile/ProfileContent.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/ProfileContent.kt
@@ -254,7 +254,7 @@ fun ProfileContent(
         uiState.statsData?.let { stats ->
             ShareImageSheet(
                 onDismiss = { statsShareVisible = false },
-                caption = profileUrl,
+                link = profileUrl,
                 templates = listOf(ShareCardTemplate.STANDARD, ShareCardTemplate.HERO),
                 templateLabel = { tmpl ->
                     stringResource(
@@ -278,7 +278,7 @@ fun ProfileContent(
         if (entries.isNotEmpty()) {
             ShareImageSheet(
                 onDismiss = { favouritesShareVisible = false },
-                caption = profileUrl,
+                link = profileUrl,
                 templates = listOf(ShareCardTemplate.STANDARD, ShareCardTemplate.HERO),
                 templateLabel = { tmpl ->
                     stringResource(

--- a/app/src/main/java/com/anisync/android/presentation/review/ReviewDetailScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/review/ReviewDetailScreen.kt
@@ -136,7 +136,7 @@ fun ReviewDetailScreen(
                 if (showShareImage) {
                     ShareImageSheet(
                         onDismiss = { showShareImage = false },
-                        caption = "https://anilist.co/review/$reviewId"
+                        link = "https://anilist.co/review/$reviewId"
                     ) {
                         ReviewShareCard(review = review)
                     }

--- a/app/src/main/java/com/anisync/android/presentation/review/ReviewDetailScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/review/ReviewDetailScreen.kt
@@ -136,8 +136,7 @@ fun ReviewDetailScreen(
                 if (showShareImage) {
                     ShareImageSheet(
                         onDismiss = { showShareImage = false },
-                        caption = "https://anilist.co/review/$reviewId",
-                        backdropUrl = review.mediaBannerUrl ?: review.mediaCoverUrl
+                        caption = "https://anilist.co/review/$reviewId"
                     ) {
                         ReviewShareCard(review = review)
                     }

--- a/app/src/main/java/com/anisync/android/presentation/review/ReviewDetailScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/review/ReviewDetailScreen.kt
@@ -136,7 +136,8 @@ fun ReviewDetailScreen(
                 if (showShareImage) {
                     ShareImageSheet(
                         onDismiss = { showShareImage = false },
-                        caption = "https://anilist.co/review/$reviewId"
+                        caption = "https://anilist.co/review/$reviewId",
+                        backdropUrl = review.mediaBannerUrl ?: review.mediaCoverUrl
                     ) {
                         ReviewShareCard(review = review)
                     }

--- a/app/src/main/java/com/anisync/android/presentation/share/FavouritesShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/FavouritesShareCard.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -43,7 +44,8 @@ fun FavouritesShareCard(
     modifier: Modifier = Modifier,
 ) {
     val expressive = LocalExpressiveTypography.current
-    val covers = entries.take(6)
+    val ranked = LocalShareCardConfig.current.template == ShareCardTemplate.HERO
+    val covers = entries.take(if (ranked) 5 else 6)
 
     ShareCardScaffold(modifier = modifier, handle = handle) {
         ShareCardBannerBox(bannerUrl = bannerUrl, height = 92.dp, scrimAlpha = 0.78f) {
@@ -69,20 +71,73 @@ fun FavouritesShareCard(
             }
         }
 
-        Column(modifier = Modifier.padding(16.dp)) {
-            covers.chunked(3).forEach { rowEntries ->
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(bottom = 10.dp),
-                    horizontalArrangement = Arrangement.spacedBy(10.dp)
-                ) {
-                    rowEntries.forEach { entry ->
-                        CoverTile(entry = entry, modifier = Modifier.weight(1f))
+        if (ranked) {
+            // "Ranked" template: a numbered top-5 list, order = the profile's favourite order.
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                covers.forEachIndexed { index, entry -> RankedRow(rank = index + 1, entry = entry) }
+            }
+        } else {
+            Column(modifier = Modifier.padding(16.dp)) {
+                covers.chunked(3).forEach { rowEntries ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(bottom = 10.dp),
+                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        rowEntries.forEach { entry ->
+                            CoverTile(entry = entry, modifier = Modifier.weight(1f))
+                        }
+                        // Pad the final row so a lone cover keeps the same tile width.
+                        repeat(3 - rowEntries.size) { Spacer(Modifier.weight(1f)) }
                     }
-                    // Pad the final row so a lone cover keeps the same tile width.
-                    repeat(3 - rowEntries.size) { Spacer(Modifier.weight(1f)) }
                 }
             }
         }
+    }
+}
+
+/** One row of the ranked template: big rank numeral, small cover, title. */
+@Composable
+private fun RankedRow(rank: Int, entry: LibraryEntry) {
+    val expressive = LocalExpressiveTypography.current
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = rank.toString(),
+            style = expressive.statNumericMedium,
+            fontWeight = FontWeight.Bold,
+            color = if (rank == 1) MaterialTheme.colorScheme.primary
+            else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
+            modifier = Modifier.width(34.dp)
+        )
+        Spacer(Modifier.width(10.dp))
+        Box(
+            modifier = Modifier
+                .width(44.dp)
+                .height(62.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+        ) {
+            val coverUrl = entry.coverUrl ?: entry.cover.url()
+            if (coverUrl != null) {
+                AsyncImage(
+                    model = coverUrl,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+        }
+        Spacer(Modifier.width(12.dp))
+        Text(
+            text = entry.titleUserPreferred,
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
     }
 }
 

--- a/app/src/main/java/com/anisync/android/presentation/share/MediaShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/MediaShareCard.kt
@@ -2,6 +2,8 @@ package com.anisync.android.presentation.share
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -37,9 +39,10 @@ import coil.compose.AsyncImage
 import com.anisync.android.R
 import com.anisync.android.domain.LibraryStatus
 import com.anisync.android.domain.MediaDetails
+import com.anisync.android.domain.ScoreFormat
+import com.anisync.android.domain.formatCommunityScore
 import com.anisync.android.domain.url
 import com.anisync.android.presentation.util.formatCompactNumber
-import com.anisync.android.presentation.util.formatDecimal
 import com.anisync.android.type.MediaType
 import com.anisync.android.ui.theme.LocalExpressiveTypography
 
@@ -49,24 +52,29 @@ import com.anisync.android.ui.theme.LocalExpressiveTypography
  * viewer's own list state — progress while watching, a neutral count while planning/completed,
  * or the media's release status (incl. upcoming/TBA) when it isn't on their list at all.
  */
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun MediaShareCard(
     details: MediaDetails,
+    scoreFormat: ScoreFormat,
     handle: String? = null,
     modifier: Modifier = Modifier,
 ) {
+    val config = LocalShareCardConfig.current
     val isManga = details.type == MediaType.MANGA
     val coverUrl = details.coverUrl ?: details.cover.url()
-    val score = details.score
     val accent = parseCoverColor(details.coverColor) ?: MaterialTheme.colorScheme.primary
     val onAccent = if (accent.luminance() > 0.5f) Color.Black else Color.White
+    // Community average, rendered in the viewer's own score scale; suppressed by the privacy toggle.
+    val scoreText = if (config.showScore) formatCommunityScore(details.score, scoreFormat) else null
+    val showScoreStar = scoreFormat != ScoreFormat.POINT_5 && scoreFormat != ScoreFormat.POINT_3
 
     ShareCardScaffold(modifier = modifier, handle = handle) {
         ShareCardBannerBox(
             bannerUrl = details.bannerUrl ?: coverUrl,
             height = 168.dp
         ) {
-            if (score != null && score > 0) {
+            if (scoreText != null) {
                 Row(
                     modifier = Modifier
                         .align(Alignment.TopEnd)
@@ -76,16 +84,17 @@ fun MediaShareCard(
                         .padding(horizontal = 12.dp, vertical = 6.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Icon(
-                        imageVector = Icons.Filled.Star,
-                        contentDescription = null,
-                        tint = onAccent,
-                        modifier = Modifier.size(14.dp)
-                    )
-                    Spacer(Modifier.width(4.dp))
-                    // Out of 10 to match the app's own header star rating (85 → "8.5").
+                    if (showScoreStar) {
+                        Icon(
+                            imageVector = Icons.Filled.Star,
+                            contentDescription = null,
+                            tint = onAccent,
+                            modifier = Modifier.size(14.dp)
+                        )
+                        Spacer(Modifier.width(4.dp))
+                    }
                     Text(
-                        text = formatDecimal(score / 10.0),
+                        text = scoreText,
                         style = MaterialTheme.typography.labelLarge,
                         fontWeight = FontWeight.Bold,
                         color = onAccent
@@ -194,12 +203,15 @@ fun MediaShareCard(
 
             val genres = details.genres.take(3)
             if (genres.isNotEmpty()) {
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
                     genres.forEach { genre -> ShareChip(genre) }
                 }
             }
 
-            MediaStatusStrip(details = details, isManga = isManga)
+            MediaStatusStrip(details = details, isManga = isManga, showProgress = config.showProgress)
         }
     }
 }
@@ -237,7 +249,7 @@ private fun MiniStat(icon: ImageVector, value: String, label: String, accent: Co
  * or a release year / TBA). Never shows "0 / 25" for a planned-but-unstarted entry.
  */
 @Composable
-private fun MediaStatusStrip(details: MediaDetails, isManga: Boolean) {
+private fun MediaStatusStrip(details: MediaDetails, isManga: Boolean, showProgress: Boolean) {
     val status = details.listStatus
     val onList = status != null && status != LibraryStatus.UNKNOWN
     val total = if (isManga) details.chapters else details.episodes
@@ -249,7 +261,8 @@ private fun MediaStatusStrip(details: MediaDetails, isManga: Boolean) {
         // The viewer's own tracked status — a filled, coloured pill.
         leftLabel = stringResource(listStatusLabel(status!!, isManga))
         val progress = details.listProgress ?: 0
-        rightText = when (status) {
+        // The progress toggle hides the personal "3 / 25" figure but keeps the status label.
+        rightText = if (!showProgress) null else when (status) {
             LibraryStatus.CURRENT, LibraryStatus.REPEATING, LibraryStatus.PAUSED, LibraryStatus.DROPPED ->
                 "$progress / ${total?.toString() ?: "?"} $unit"
             LibraryStatus.COMPLETED, LibraryStatus.PLANNING ->
@@ -321,7 +334,7 @@ private fun mediaReleaseLabel(status: String): Int = when (status) {
 }
 
 /** Parses AniList's `#RRGGBB` cover color; null when absent or malformed. */
-private fun parseCoverColor(hex: String?): Color? {
+internal fun parseCoverColor(hex: String?): Color? {
     if (hex.isNullOrBlank()) return null
     return try {
         Color(android.graphics.Color.parseColor(hex))

--- a/app/src/main/java/com/anisync/android/presentation/share/MediaShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/MediaShareCard.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
@@ -65,8 +64,10 @@ fun MediaShareCard(
     val config = LocalShareCardConfig.current
     val isManga = details.type == MediaType.MANGA
     val coverUrl = details.coverUrl ?: details.cover.url()
-    val accent = parseCoverColor(details.coverColor) ?: MaterialTheme.colorScheme.primary
-    val onAccent = if (accent.luminance() > 0.5f) Color.Black else Color.White
+    // Accent comes from the card's own scheme so it tracks the selected theme; under the COVER
+    // theme primary is already artwork-seeded, so the poster tint survives exactly there.
+    val accent = MaterialTheme.colorScheme.primary
+    val onAccent = MaterialTheme.colorScheme.onPrimary
     // Community average, rendered in the viewer's own score scale; suppressed by the privacy toggle.
     val scoreText = if (config.showScore) formatCommunityScore(details.score, scoreFormat) else null
     val showScoreStar = scoreFormat != ScoreFormat.POINT_5 && scoreFormat != ScoreFormat.POINT_3
@@ -76,8 +77,6 @@ fun MediaShareCard(
             details = details,
             isManga = isManga,
             coverUrl = coverUrl,
-            accent = accent,
-            onAccent = onAccent,
             scoreText = scoreText,
             showScoreStar = showScoreStar,
             showProgress = config.showProgress,
@@ -244,14 +243,14 @@ private fun MediaHeroCard(
     details: MediaDetails,
     isManga: Boolean,
     coverUrl: String?,
-    accent: Color,
-    onAccent: Color,
     scoreText: String?,
     showScoreStar: Boolean,
     showProgress: Boolean,
     handle: String?,
     modifier: Modifier = Modifier,
 ) {
+    val accent = MaterialTheme.colorScheme.primary
+    val onAccent = MaterialTheme.colorScheme.onPrimary
     ShareCardScaffold(modifier = modifier, handle = handle) {
         Box(modifier = Modifier.fillMaxWidth().aspectRatio(2f / 3f)) {
             if (coverUrl != null) {

--- a/app/src/main/java/com/anisync/android/presentation/share/MediaShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/MediaShareCard.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -27,6 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -68,6 +70,22 @@ fun MediaShareCard(
     // Community average, rendered in the viewer's own score scale; suppressed by the privacy toggle.
     val scoreText = if (config.showScore) formatCommunityScore(details.score, scoreFormat) else null
     val showScoreStar = scoreFormat != ScoreFormat.POINT_5 && scoreFormat != ScoreFormat.POINT_3
+
+    if (config.template == ShareCardTemplate.HERO) {
+        MediaHeroCard(
+            details = details,
+            isManga = isManga,
+            coverUrl = coverUrl,
+            accent = accent,
+            onAccent = onAccent,
+            scoreText = scoreText,
+            showScoreStar = showScoreStar,
+            showProgress = config.showProgress,
+            handle = handle,
+            modifier = modifier,
+        )
+        return
+    }
 
     ShareCardScaffold(modifier = modifier, handle = handle) {
         ShareCardBannerBox(
@@ -212,6 +230,128 @@ fun MediaShareCard(
             }
 
             MediaStatusStrip(details = details, isManga = isManga, showProgress = config.showProgress)
+        }
+    }
+}
+
+/**
+ * The "Poster" media template: the cover art full-bleed at 2:3 with the title, meta and genres set
+ * into its bottom scrim, then the same adaptive status strip. A bolder, artwork-first alternative to
+ * the standard stat-sheet card.
+ */
+@Composable
+private fun MediaHeroCard(
+    details: MediaDetails,
+    isManga: Boolean,
+    coverUrl: String?,
+    accent: Color,
+    onAccent: Color,
+    scoreText: String?,
+    showScoreStar: Boolean,
+    showProgress: Boolean,
+    handle: String?,
+    modifier: Modifier = Modifier,
+) {
+    ShareCardScaffold(modifier = modifier, handle = handle) {
+        Box(modifier = Modifier.fillMaxWidth().aspectRatio(2f / 3f)) {
+            if (coverUrl != null) {
+                AsyncImage(
+                    model = coverUrl,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            } else {
+                Box(Modifier.fillMaxSize().background(MaterialTheme.colorScheme.primaryContainer))
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        Brush.verticalGradient(
+                            0.45f to Color.Transparent,
+                            1f to Color.Black.copy(alpha = 0.88f)
+                        )
+                    )
+            )
+            if (scoreText != null) {
+                Row(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(14.dp)
+                        .clip(RoundedCornerShape(50))
+                        .background(accent)
+                        .padding(horizontal = 12.dp, vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    if (showScoreStar) {
+                        Icon(
+                            imageVector = Icons.Filled.Star,
+                            contentDescription = null,
+                            tint = onAccent,
+                            modifier = Modifier.size(14.dp)
+                        )
+                        Spacer(Modifier.width(4.dp))
+                    }
+                    Text(
+                        text = scoreText,
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = onAccent
+                    )
+                }
+            }
+            Column(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                val meta = listOfNotNull(
+                    details.format,
+                    details.seasonYear?.toString() ?: details.year?.toString(),
+                    details.studio?.name ?: details.studios.firstOrNull()?.name
+                ).joinToString(" · ")
+                if (meta.isNotBlank()) {
+                    Text(
+                        text = meta.uppercase(),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = Color.White.copy(alpha = 0.85f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Spacer(Modifier.height(2.dp))
+                }
+                Text(
+                    text = details.titleUserPreferred,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis
+                )
+                val genres = details.genres.take(3)
+                if (genres.isNotEmpty()) {
+                    Spacer(Modifier.height(8.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                        genres.forEach { genre ->
+                            Text(
+                                text = genre,
+                                style = MaterialTheme.typography.labelMedium,
+                                color = Color.White,
+                                maxLines = 1,
+                                modifier = Modifier
+                                    .clip(RoundedCornerShape(50))
+                                    .background(Color.White.copy(alpha = 0.22f))
+                                    .padding(horizontal = 10.dp, vertical = 4.dp)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        Box(Modifier.padding(horizontal = 16.dp, vertical = 14.dp)) {
+            MediaStatusStrip(details = details, isManga = isManga, showProgress = showProgress)
         }
     }
 }

--- a/app/src/main/java/com/anisync/android/presentation/share/PersonShareCards.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/PersonShareCards.kt
@@ -1,0 +1,245 @@
+package com.anisync.android.presentation.share
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.anisync.android.R
+import com.anisync.android.domain.CharacterDetails
+import com.anisync.android.domain.StaffDetails
+import com.anisync.android.presentation.util.formatCompactNumber
+import com.anisync.android.ui.theme.LocalExpressiveTypography
+
+/**
+ * Shareable card for a character: portrait, name (+ native name), favourites, quick facts, and a
+ * "known for" strip of their top series covers. [displayName] arrives pre-resolved through the
+ * viewer's title-language setting.
+ */
+@Composable
+fun CharacterShareCard(
+    details: CharacterDetails,
+    displayName: String,
+    handle: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    PersonShareCard(
+        modifier = modifier,
+        handle = handle,
+        eyebrow = stringResource(R.string.share_person_character),
+        portraitUrl = details.imageUrl,
+        name = displayName,
+        nativeName = details.nativeName?.takeIf { it != displayName },
+        favourites = details.favourites,
+        facts = listOfNotNull(details.gender, details.age, details.dateOfBirth),
+        knownFor = details.media.take(3).map { KnownForItem(it.coverUrl, it.titleUserPreferred) },
+    )
+}
+
+/**
+ * Shareable card for a staff member: portrait, name, favourites, occupations, and a "known for"
+ * strip — their top voiced characters when they act, else their top production covers.
+ */
+@Composable
+fun StaffShareCard(
+    details: StaffDetails,
+    displayName: String,
+    handle: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    val knownFor = if (details.voicedCharacters.isNotEmpty()) {
+        details.voicedCharacters.take(3).map {
+            KnownForItem(it.characterImageUrl, it.characterNameUserPreferred)
+        }
+    } else {
+        details.productionMedia.take(3).map { KnownForItem(it.coverUrl, it.titleUserPreferred) }
+    }
+    PersonShareCard(
+        modifier = modifier,
+        handle = handle,
+        eyebrow = stringResource(R.string.share_person_staff),
+        portraitUrl = details.imageUrl,
+        name = displayName,
+        nativeName = details.nativeName?.takeIf { it != displayName },
+        favourites = details.favourites,
+        facts = details.primaryOccupations.take(3),
+        knownFor = knownFor,
+    )
+}
+
+private data class KnownForItem(val imageUrl: String?, val label: String)
+
+/** Common layout for the character/staff cards: identity block, fact chips, known-for covers. */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun PersonShareCard(
+    modifier: Modifier,
+    handle: String?,
+    eyebrow: String,
+    portraitUrl: String?,
+    name: String,
+    nativeName: String?,
+    favourites: Int?,
+    facts: List<String>,
+    knownFor: List<KnownForItem>,
+) {
+    val expressive = LocalExpressiveTypography.current
+
+    ShareCardScaffold(modifier = modifier, handle = handle) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Row {
+                Box(
+                    modifier = Modifier
+                        .width(96.dp)
+                        .height(140.dp)
+                        .clip(RoundedCornerShape(14.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                ) {
+                    if (portraitUrl != null) {
+                        AsyncImage(
+                            model = portraitUrl,
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    }
+                }
+                Spacer(Modifier.width(16.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = eyebrow.uppercase(),
+                        style = expressive.statLabel,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = name,
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    if (nativeName != null) {
+                        Text(
+                            text = nativeName,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                    favourites?.takeIf { it > 0 }?.let {
+                        Spacer(Modifier.height(12.dp))
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                imageVector = Icons.Filled.Favorite,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(15.dp)
+                            )
+                            Spacer(Modifier.width(4.dp))
+                            Text(
+                                text = formatCompactNumber(it),
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.share_media_favourites).uppercase(),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
+            if (facts.isNotEmpty()) {
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    facts.forEach { fact -> ShareChip(fact) }
+                }
+            }
+
+            if (knownFor.isNotEmpty()) {
+                Column {
+                    Text(
+                        text = stringResource(R.string.share_known_for).uppercase(),
+                        style = expressive.statLabel,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                        knownFor.forEach { item ->
+                            Column(
+                                modifier = Modifier.weight(1f),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .aspectRatio(2f / 3f)
+                                        .clip(RoundedCornerShape(10.dp))
+                                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                                ) {
+                                    if (item.imageUrl != null) {
+                                        AsyncImage(
+                                            model = item.imageUrl,
+                                            contentDescription = null,
+                                            contentScale = ContentScale.Crop,
+                                            modifier = Modifier.fillMaxSize()
+                                        )
+                                    }
+                                }
+                                Spacer(Modifier.height(4.dp))
+                                Text(
+                                    text = item.label,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    textAlign = TextAlign.Center
+                                )
+                            }
+                        }
+                        // Pad so 1–2 items keep the same tile width as a full row.
+                        repeat(3 - knownFor.size) { Spacer(Modifier.weight(1f)) }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/anisync/android/presentation/share/ProfileStatsShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/ProfileStatsShareCard.kt
@@ -39,6 +39,10 @@ fun ProfileStatsShareCard(
     type: ProfileStatsType,
     modifier: Modifier = Modifier,
 ) {
+    if (LocalShareCardConfig.current.template == ShareCardTemplate.HERO) {
+        RecapShareCard(profile = profile, stats = stats, modifier = modifier)
+        return
+    }
     val expressive = LocalExpressiveTypography.current
     val isAnime = type == ProfileStatsType.ANIME
 
@@ -129,6 +133,125 @@ fun ProfileStatsShareCard(
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     genres.forEach { g -> ShareChip(g.genre) }
                 }
+            }
+        }
+    }
+}
+
+/**
+ * The "Recap" stats template: one Wrapped-style card across **both** libraries — combined title
+ * count as the hero figure, a 2×2 tile grid (days, episodes, chapters, mean score), the top genres
+ * merged across anime+manga, and the most-watched studio.
+ */
+@Composable
+private fun RecapShareCard(
+    profile: UserProfile,
+    stats: StatisticsUiModel,
+    modifier: Modifier = Modifier,
+) {
+    val expressive = LocalExpressiveTypography.current
+    val anime = stats.animeStats
+    val manga = stats.mangaStats
+    val totalTitles = anime.totalCount + (manga?.totalCount ?: 0)
+    // Merge the two genre distributions by summed count so the recap reflects the whole library.
+    val topGenres = (anime.genreDistribution + manga?.genreDistribution.orEmpty())
+        .groupBy { it.genre }
+        .map { (genre, entries) -> genre to entries.sumOf { it.count } }
+        .sortedByDescending { it.second }
+        .take(3)
+    val topStudio = anime.studioDistribution.firstOrNull()
+
+    ShareCardScaffold(modifier = modifier, handle = profile.name) {
+        ShareCardBannerBox(bannerUrl = profile.bannerUrl, height = 108.dp, scrimAlpha = 0.78f) {
+            Row(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                UserAvatar(
+                    contentDescription = null,
+                    size = 52.dp,
+                    url = profile.avatarUrl,
+                    borderColor = Color.White.copy(alpha = 0.9f),
+                    borderWidth = 2.dp
+                )
+                Spacer(Modifier.width(14.dp))
+                Column {
+                    Text(
+                        text = profile.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = stringResource(R.string.share_recap_eyebrow).uppercase(),
+                        style = expressive.statLabel,
+                        color = Color.White.copy(alpha = 0.85f)
+                    )
+                }
+            }
+        }
+
+        Column(modifier = Modifier.padding(20.dp)) {
+            Row(verticalAlignment = Alignment.Bottom) {
+                Text(
+                    text = formatCompactNumber(totalTitles),
+                    style = expressive.statNumericLarge,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Spacer(Modifier.width(10.dp))
+                Text(
+                    text = stringResource(R.string.share_recap_titles),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = 12.dp)
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                ShareStatTile(formatDecimal(anime.daysWatched), stringResource(R.string.share_stats_days), Modifier.weight(1f))
+                ShareStatTile(formatCompactNumber(anime.episodesWatched), stringResource(R.string.share_stats_episodes), Modifier.weight(1f))
+            }
+            Spacer(Modifier.height(10.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                ShareStatTile(formatCompactNumber(manga?.chaptersRead ?: 0), stringResource(R.string.share_stats_chapters), Modifier.weight(1f))
+                ShareStatTile(formatDecimal(anime.meanScore), stringResource(R.string.share_stats_mean), Modifier.weight(1f))
+            }
+
+            if (topGenres.isNotEmpty()) {
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = stringResource(R.string.share_stats_top_genres).uppercase(),
+                    style = expressive.statLabel,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(8.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    topGenres.forEach { (genre, _) -> ShareChip(genre) }
+                }
+            }
+
+            if (topStudio != null) {
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = stringResource(R.string.share_recap_top_studio).uppercase(),
+                    style = expressive.statLabel,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = topStudio.studioName,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
         }
     }

--- a/app/src/main/java/com/anisync/android/presentation/share/ProfileStatsShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/ProfileStatsShareCard.kt
@@ -40,7 +40,7 @@ fun ProfileStatsShareCard(
     modifier: Modifier = Modifier,
 ) {
     if (LocalShareCardConfig.current.template == ShareCardTemplate.HERO) {
-        RecapShareCard(profile = profile, stats = stats, modifier = modifier)
+        RecapShareCard(profile = profile, stats = stats, type = type, modifier = modifier)
         return
     }
     val expressive = LocalExpressiveTypography.current
@@ -139,27 +139,35 @@ fun ProfileStatsShareCard(
 }
 
 /**
- * The "Recap" stats template: one Wrapped-style card across **both** libraries — combined title
- * count as the hero figure, a 2×2 tile grid (days, episodes, chapters, mean score), the top genres
- * merged across anime+manga, and the most-watched studio.
+ * The "Recap" stats template: a Wrapped-style card for the **selected library** (anime or manga,
+ * matching the Stats tab toggle) — headline title count, a 2×2 tile grid, the library's top genres,
+ * and a spotlight line (most-watched studio for anime, most-read author for manga).
  */
 @Composable
 private fun RecapShareCard(
     profile: UserProfile,
     stats: StatisticsUiModel,
+    type: ProfileStatsType,
     modifier: Modifier = Modifier,
 ) {
     val expressive = LocalExpressiveTypography.current
+    val isAnime = type == ProfileStatsType.ANIME
     val anime = stats.animeStats
     val manga = stats.mangaStats
-    val totalTitles = anime.totalCount + (manga?.totalCount ?: 0)
-    // Merge the two genre distributions by summed count so the recap reflects the whole library.
-    val topGenres = (anime.genreDistribution + manga?.genreDistribution.orEmpty())
-        .groupBy { it.genre }
-        .map { (genre, entries) -> genre to entries.sumOf { it.count } }
-        .sortedByDescending { it.second }
-        .take(3)
-    val topStudio = anime.studioDistribution.firstOrNull()
+
+    val totalTitles = if (isAnime) anime.totalCount else (manga?.totalCount ?: 0)
+    val topGenres = (if (isAnime) anime.genreDistribution else manga?.genreDistribution.orEmpty()).take(3)
+    val completed = (if (isAnime) anime.statusDistribution else manga?.statusDistribution.orEmpty())
+        .firstOrNull { it.status.equals("COMPLETED", ignoreCase = true) }?.count
+    // Spotlight: the studio you watched most vs the author you read most.
+    val spotlightLabel = stringResource(
+        if (isAnime) R.string.share_recap_top_studio else R.string.share_recap_top_staff
+    )
+    val spotlightName = if (isAnime) {
+        anime.studioDistribution.firstOrNull()?.studioName
+    } else {
+        manga?.staffDistribution?.firstOrNull()?.name
+    }
 
     ShareCardScaffold(modifier = modifier, handle = profile.name) {
         ShareCardBannerBox(bannerUrl = profile.bannerUrl, height = 108.dp, scrimAlpha = 0.78f) {
@@ -204,7 +212,9 @@ private fun RecapShareCard(
                 )
                 Spacer(Modifier.width(10.dp))
                 Text(
-                    text = stringResource(R.string.share_recap_titles),
+                    text = stringResource(
+                        if (isAnime) R.string.share_stats_unit_anime else R.string.share_stats_unit_manga
+                    ),
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(bottom = 12.dp)
@@ -214,13 +224,26 @@ private fun RecapShareCard(
             Spacer(Modifier.height(16.dp))
 
             Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                ShareStatTile(formatDecimal(anime.daysWatched), stringResource(R.string.share_stats_days), Modifier.weight(1f))
-                ShareStatTile(formatCompactNumber(anime.episodesWatched), stringResource(R.string.share_stats_episodes), Modifier.weight(1f))
+                if (isAnime) {
+                    ShareStatTile(formatDecimal(anime.daysWatched), stringResource(R.string.share_stats_days), Modifier.weight(1f))
+                    ShareStatTile(formatCompactNumber(anime.episodesWatched), stringResource(R.string.share_stats_episodes), Modifier.weight(1f))
+                } else {
+                    ShareStatTile(formatCompactNumber(manga?.chaptersRead ?: 0), stringResource(R.string.share_stats_chapters), Modifier.weight(1f))
+                    ShareStatTile(formatCompactNumber(manga?.volumesRead ?: 0), stringResource(R.string.share_stats_volumes), Modifier.weight(1f))
+                }
             }
             Spacer(Modifier.height(10.dp))
             Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                ShareStatTile(formatCompactNumber(manga?.chaptersRead ?: 0), stringResource(R.string.share_stats_chapters), Modifier.weight(1f))
-                ShareStatTile(formatDecimal(anime.meanScore), stringResource(R.string.share_stats_mean), Modifier.weight(1f))
+                ShareStatTile(
+                    formatCompactNumber(completed ?: 0),
+                    stringResource(R.string.share_recap_completed),
+                    Modifier.weight(1f)
+                )
+                ShareStatTile(
+                    formatDecimal(if (isAnime) anime.meanScore else (manga?.meanScore ?: 0.0)),
+                    stringResource(R.string.share_stats_mean),
+                    Modifier.weight(1f)
+                )
             }
 
             if (topGenres.isNotEmpty()) {
@@ -232,20 +255,20 @@ private fun RecapShareCard(
                 )
                 Spacer(Modifier.height(8.dp))
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    topGenres.forEach { (genre, _) -> ShareChip(genre) }
+                    topGenres.forEach { g -> ShareChip(g.genre) }
                 }
             }
 
-            if (topStudio != null) {
+            if (spotlightName != null) {
                 Spacer(Modifier.height(16.dp))
                 Text(
-                    text = stringResource(R.string.share_recap_top_studio).uppercase(),
+                    text = spotlightLabel.uppercase(),
                     style = expressive.statLabel,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Spacer(Modifier.height(2.dp))
                 Text(
-                    text = topStudio.studioName,
+                    text = spotlightName,
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSurface,

--- a/app/src/main/java/com/anisync/android/presentation/share/ShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/ShareCard.kt
@@ -1,8 +1,12 @@
 package com.anisync.android.presentation.share
 
+import android.os.Build
+import android.view.WindowManager
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -16,10 +20,12 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
@@ -37,6 +43,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -53,12 +60,16 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.DialogWindowProvider
 import coil.compose.AsyncImage
 import com.anisync.android.R
 import com.anisync.android.util.ShareUtils
@@ -78,11 +89,11 @@ internal val ShareCardShape = RoundedCornerShape(28.dp)
 internal val ShareCardShapeFramed = RoundedCornerShape(32.dp)
 
 /**
- * Bottom sheet that previews a [card] exactly as it will be shared and lets the user **customize** it
- * live — theme, aspect (compact / square / story), an optional baked caption, and (when
- * [supportsPrivacy]) whether the score/progress show. Then it offers: save the PNG to the gallery,
- * copy the [link] to the clipboard, or open the system share sheet with the image (the user's
- * caption + [link] ride along as the share text).
+ * Share customizer entry point: previews a [card] exactly as it will be shared and lets the user
+ * **customize** it live — theme, aspect (compact / square / story), an optional baked caption, and
+ * (when [supportsPrivacy]) whether the score/progress show. Then it offers: save the PNG to the
+ * gallery, copy the [link] to the clipboard, or open the system share sheet with the image (the
+ * user's caption + [link] ride along as the share text).
  *
  * Layout keeps the preview and the action row **pinned**; only the customization controls scroll.
  * Every tweak is therefore visible on the card the instant it's made.
@@ -91,7 +102,13 @@ internal val ShareCardShapeFramed = RoundedCornerShape(32.dp)
  * the export is never blank. [seedColor] (artwork color) enables the COVER theme; [templates]
  * populates the style picker.
  */
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class, ExperimentalLayoutApi::class)
+/**
+ * UI experiment: when true the customizer opens as a full-screen overlay over a blurred app
+ * (window blur-behind, API 31+), instead of the modal bottom sheet. Flip back to false to
+ * restore the sheet — both hosts share [ShareCustomizerContent].
+ */
+private const val UseOverlayPresentation = true
+
 @Composable
 fun ShareImageSheet(
     onDismiss: () -> Unit,
@@ -100,6 +117,154 @@ fun ShareImageSheet(
     supportsPrivacy: Boolean = false,
     templates: List<ShareCardTemplate> = emptyList(),
     templateLabel: (@Composable (ShareCardTemplate) -> String)? = null,
+    card: @Composable () -> Unit,
+) {
+    if (UseOverlayPresentation) {
+        ShareImageOverlay(onDismiss, link, seedColor, supportsPrivacy, templates, templateLabel, card)
+    } else {
+        ShareImageBottomSheet(onDismiss, link, seedColor, supportsPrivacy, templates, templateLabel, card)
+    }
+}
+
+/** The classic host: a full-height modal bottom sheet. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ShareImageBottomSheet(
+    onDismiss: () -> Unit,
+    link: String?,
+    seedColor: Color?,
+    supportsPrivacy: Boolean,
+    templates: List<ShareCardTemplate>,
+    templateLabel: (@Composable (ShareCardTemplate) -> String)?,
+    card: @Composable () -> Unit,
+) {
+    // Full height from the start: the pinned preview/actions layout needs the whole sheet.
+    val sheetState = androidx.compose.material3.rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    com.anisync.android.presentation.components.AppModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .windowInsetsPadding(WindowInsets.navigationBars)
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            ShareCustomizerContent(
+                onDismiss = onDismiss,
+                link = link,
+                seedColor = seedColor,
+                supportsPrivacy = supportsPrivacy,
+                templates = templates,
+                templateLabel = templateLabel,
+                previewMaxHeight = 280.dp,
+                card = card,
+            )
+        }
+    }
+}
+
+/**
+ * The experimental host: a full-screen dialog whose window blurs the app behind it, with the
+ * customizer floating on a translucent, theme-tinted veil. Tapping the veil dismisses; taps on
+ * the content are consumed. Falls back to a heavier dim when window blur is unavailable.
+ */
+@Composable
+private fun ShareImageOverlay(
+    onDismiss: () -> Unit,
+    link: String?,
+    seedColor: Color?,
+    supportsPrivacy: Boolean,
+    templates: List<ShareCardTemplate>,
+    templateLabel: (@Composable (ShareCardTemplate) -> String)?,
+    card: @Composable () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false)
+    ) {
+        val view = LocalView.current
+        val context = LocalContext.current
+        // Cross-window blur is a device capability (OEMs/power-saving disable it); when it's off,
+        // FLAG_BLUR_BEHIND is silently ignored, so compensate with a much heavier veil + dim.
+        var blurActive by remember { mutableStateOf(false) }
+        DisposableEffect(view) {
+            val window = (view.parent as? DialogWindowProvider)?.window
+            val canBlur = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                context.getSystemService(WindowManager::class.java)?.isCrossWindowBlurEnabled == true
+            blurActive = canBlur
+            if (window != null) {
+                if (canBlur) {
+                    window.addFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
+                    window.attributes = window.attributes.apply { blurBehindRadius = 90 }
+                    window.setDimAmount(0.2f)
+                } else {
+                    window.setDimAmount(0.45f)
+                }
+            }
+            onDispose { }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                // Theme-tinted veil over the blur so text keeps contrast on any wallpaper/screen.
+                .background(
+                    MaterialTheme.colorScheme.surface.copy(alpha = if (blurActive) 0.5f else 0.88f)
+                )
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = onDismiss
+                )
+                .systemBarsPadding()
+                .imePadding(),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 16.dp)
+                    // Consume taps so interacting with the controls never falls through to dismiss.
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = {}
+                    ),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                ShareCustomizerContent(
+                    onDismiss = onDismiss,
+                    link = link,
+                    seedColor = seedColor,
+                    supportsPrivacy = supportsPrivacy,
+                    templates = templates,
+                    templateLabel = templateLabel,
+                    previewMaxHeight = 360.dp,
+                    card = card,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * The customizer itself — live preview pinned on top, scrollable controls + caption in the middle,
+ * action row pinned at the bottom — shared verbatim by both presentation hosts. Must live inside a
+ * height-bounded Column ([ColumnScope] receiver) so the middle section can flex-shrink.
+ */
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalLayoutApi::class)
+@Composable
+private fun ColumnScope.ShareCustomizerContent(
+    onDismiss: () -> Unit,
+    link: String?,
+    seedColor: Color?,
+    supportsPrivacy: Boolean,
+    templates: List<ShareCardTemplate>,
+    templateLabel: (@Composable (ShareCardTemplate) -> String)?,
+    previewMaxHeight: Dp,
     card: @Composable () -> Unit,
 ) {
     val context = LocalContext.current
@@ -130,33 +295,19 @@ fun ShareImageSheet(
     val shareText = listOfNotNull(config.caption.trim().ifBlank { null }, link).joinToString("\n\n")
         .ifBlank { null }
 
-    // Full height from the start: the pinned preview/actions layout needs the whole sheet.
-    val sheetState = androidx.compose.material3.rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    com.anisync.android.presentation.components.AppModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .windowInsetsPadding(WindowInsets.navigationBars)
-                .padding(horizontal = 20.dp)
-                .padding(bottom = 20.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            // Pinned: the live preview. Every control change repaints it in place. While the
-            // keyboard is up (caption editing) it shrinks instead of squashing the field away.
-            val previewMaxHeight by animateDpAsState(
-                targetValue = if (WindowInsets.isImeVisible) 136.dp else 280.dp,
-                label = "previewMaxHeight"
-            )
-            ShareCaptureArea(
-                controller = controller,
-                config = config,
-                seedColor = seedColor,
-                maxPreviewHeight = previewMaxHeight,
-                card = card,
-            )
+    // Pinned: the live preview. Every control change repaints it in place. While the
+    // keyboard is up (caption editing) it shrinks instead of squashing the field away.
+    val animatedPreviewHeight by animateDpAsState(
+        targetValue = if (WindowInsets.isImeVisible) 136.dp else previewMaxHeight,
+        label = "previewMaxHeight"
+    )
+    ShareCaptureArea(
+        controller = controller,
+        config = config,
+        seedColor = seedColor,
+        maxPreviewHeight = animatedPreviewHeight,
+        card = card,
+    )
 
             Spacer(Modifier.height(16.dp))
 
@@ -236,8 +387,6 @@ fun ShareImageSheet(
                     }
                 }
             }
-        }
-    }
 }
 
 /** One icon-over-label action tile in the share sheet's action row. Shows a spinner while busy. */

--- a/app/src/main/java/com/anisync/android/presentation/share/ShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/ShareCard.kt
@@ -95,6 +95,7 @@ fun ShareImageSheet(
     seedColor: Color? = null,
     supportsPrivacy: Boolean = false,
     templates: List<ShareCardTemplate> = emptyList(),
+    templateLabel: (@Composable (ShareCardTemplate) -> String)? = null,
     card: @Composable () -> Unit,
 ) {
     val context = LocalContext.current
@@ -161,6 +162,7 @@ fun ShareImageSheet(
                     coverAvailable = seedColor != null,
                     supportsPrivacy = supportsPrivacy,
                     templates = templates,
+                    templateLabel = templateLabel,
                 )
 
                 Spacer(Modifier.height(14.dp))

--- a/app/src/main/java/com/anisync/android/presentation/share/ShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/ShareCard.kt
@@ -14,18 +14,15 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -36,7 +33,6 @@ import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -99,14 +95,11 @@ internal val ShareCardShapeFramed = RoundedCornerShape(32.dp)
  * The live preview doubles as the load gate: Coil covers are decoded by the time the user acts, so
  * the export is never blank. [seedColor] (artwork color) enables the COVER theme; [templates]
  * populates the style picker.
+ *
+ * Presented as a full-screen dialog whose window blurs the app behind it, with the customizer
+ * floating on a translucent, theme-tinted veil. Tapping the veil dismisses; taps on the content
+ * are consumed. Falls back to a heavier dim when window blur is unavailable.
  */
-/**
- * UI experiment: when true the customizer opens as a full-screen overlay over a blurred app
- * (window blur-behind, API 31+), instead of the modal bottom sheet. Flip back to false to
- * restore the sheet — both hosts share [ShareCustomizerContent].
- */
-private const val UseOverlayPresentation = true
-
 @Composable
 fun ShareImageSheet(
     onDismiss: () -> Unit,
@@ -115,72 +108,6 @@ fun ShareImageSheet(
     supportsPrivacy: Boolean = false,
     templates: List<ShareCardTemplate> = emptyList(),
     templateLabel: (@Composable (ShareCardTemplate) -> String)? = null,
-    card: @Composable () -> Unit,
-) {
-    if (UseOverlayPresentation) {
-        ShareImageOverlay(onDismiss, link, seedColor, supportsPrivacy, templates, templateLabel, card)
-    } else {
-        ShareImageBottomSheet(onDismiss, link, seedColor, supportsPrivacy, templates, templateLabel, card)
-    }
-}
-
-/** The classic host: a full-height modal bottom sheet. */
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun ShareImageBottomSheet(
-    onDismiss: () -> Unit,
-    link: String?,
-    seedColor: Color?,
-    supportsPrivacy: Boolean,
-    templates: List<ShareCardTemplate>,
-    templateLabel: (@Composable (ShareCardTemplate) -> String)?,
-    card: @Composable () -> Unit,
-) {
-    // Full height from the start: the pinned preview/actions layout needs the whole sheet.
-    val sheetState = androidx.compose.material3.rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    com.anisync.android.presentation.components.AppModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-    ) {
-        // One scrolling flow: the preview scrolls with the controls; the keyboard just pushes
-        // the sheet up and the focused caption field auto-scrolls into view.
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .verticalScroll(rememberScrollState())
-                .windowInsetsPadding(WindowInsets.navigationBars)
-                .imePadding()
-                .padding(horizontal = 20.dp)
-                .padding(bottom = 20.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            ShareCustomizerContent(
-                onDismiss = onDismiss,
-                link = link,
-                seedColor = seedColor,
-                supportsPrivacy = supportsPrivacy,
-                templates = templates,
-                templateLabel = templateLabel,
-                previewMaxHeight = 340.dp,
-                card = card,
-            )
-        }
-    }
-}
-
-/**
- * The experimental host: a full-screen dialog whose window blurs the app behind it, with the
- * customizer floating on a translucent, theme-tinted veil. Tapping the veil dismisses; taps on
- * the content are consumed. Falls back to a heavier dim when window blur is unavailable.
- */
-@Composable
-private fun ShareImageOverlay(
-    onDismiss: () -> Unit,
-    link: String?,
-    seedColor: Color?,
-    supportsPrivacy: Boolean,
-    templates: List<ShareCardTemplate>,
-    templateLabel: (@Composable (ShareCardTemplate) -> String)?,
     card: @Composable () -> Unit,
 ) {
     Dialog(

--- a/app/src/main/java/com/anisync/android/presentation/share/ShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/ShareCard.kt
@@ -1,5 +1,6 @@
 package com.anisync.android.presentation.share
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -79,10 +80,12 @@ internal val ShareCardShapeFramed = RoundedCornerShape(32.dp)
  * [supportsPrivacy]) whether the score/progress show. Then it offers: save the PNG to the gallery,
  * copy the [caption] link, or open the system share sheet with the image.
  *
+ * Layout keeps the preview and the action row **pinned**; only the customization controls scroll.
+ * Every tweak is therefore visible on the card the instant it's made.
+ *
  * The live preview doubles as the load gate: Coil covers are decoded by the time the user acts, so
- * the export is never blank. [seedColor] (artwork color) enables the COVER theme and tints the
- * backdrop; [backdropUrl] is the blurred image behind the framed formats; [templates] populates the
- * style picker.
+ * the export is never blank. [seedColor] (artwork color) enables the COVER theme; [templates]
+ * populates the style picker.
  */
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
@@ -90,7 +93,6 @@ fun ShareImageSheet(
     onDismiss: () -> Unit,
     caption: String? = null,
     seedColor: Color? = null,
-    backdropUrl: String? = null,
     supportsPrivacy: Boolean = false,
     templates: List<ShareCardTemplate> = emptyList(),
     card: @Composable () -> Unit,
@@ -100,7 +102,6 @@ fun ShareImageSheet(
     val haptic = LocalHapticFeedback.current
     val controller = rememberCaptureController()
     var busy by remember { mutableStateOf(false) }
-    var statusRes by remember { mutableStateOf<Int?>(null) }
     var config by remember {
         mutableStateOf(ShareCardConfig(template = templates.firstOrNull() ?: ShareCardTemplate.STANDARD))
     }
@@ -124,54 +125,56 @@ fun ShareImageSheet(
     val shareText = listOfNotNull(config.caption.trim().ifBlank { null }, caption).joinToString("\n\n")
         .ifBlank { null }
 
-    com.anisync.android.presentation.components.AppModalBottomSheet(onDismissRequest = onDismiss) {
+    // Full height from the start: the pinned preview/actions layout needs the whole sheet.
+    val sheetState = androidx.compose.material3.rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    com.anisync.android.presentation.components.AppModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .verticalScroll(rememberScrollState())
                 .windowInsetsPadding(WindowInsets.navigationBars)
                 .padding(horizontal = 20.dp)
                 .padding(bottom = 20.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Text(
-                text = stringResource(R.string.share_image_preview_title),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 16.dp)
-            )
-
+            // Pinned: the live preview. Every control change repaints it in place.
             ShareCaptureArea(
                 controller = controller,
                 config = config,
                 seedColor = seedColor,
-                backdropUrl = backdropUrl,
                 card = card,
-            )
-
-            Spacer(Modifier.height(20.dp))
-
-            ShareCustomizeControls(
-                config = config,
-                onConfig = { config = it },
-                coverAvailable = seedColor != null,
-                supportsPrivacy = supportsPrivacy,
-                templates = templates,
             )
 
             Spacer(Modifier.height(16.dp))
 
-            OutlinedTextField(
-                value = config.caption,
-                onValueChange = { config = config.copy(caption = it.take(80)) },
-                label = { Text(stringResource(R.string.share_caption_hint)) },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth()
-            )
+            // Only this middle section scrolls; preview and actions stay on screen.
+            Column(
+                modifier = Modifier
+                    .weight(1f, fill = false)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                ShareCustomizeControls(
+                    config = config,
+                    onConfig = { config = it },
+                    coverAvailable = seedColor != null,
+                    supportsPrivacy = supportsPrivacy,
+                    templates = templates,
+                )
 
-            Spacer(Modifier.height(20.dp))
+                Spacer(Modifier.height(14.dp))
+
+                OutlinedTextField(
+                    value = config.caption,
+                    onValueChange = { config = config.copy(caption = it.take(80)) },
+                    label = { Text(stringResource(R.string.share_caption_hint)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -186,8 +189,14 @@ fun ShareImageSheet(
                 ) {
                     runAction { bmp ->
                         val ok = ShareUtils.saveCardToGallery(context, bmp)
-                        statusRes = if (ok) R.string.share_saved_to_gallery else R.string.share_save_failed
                         if (ok) haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        Toast.makeText(
+                            context,
+                            context.getString(
+                                if (ok) R.string.share_saved_to_gallery else R.string.share_save_failed
+                            ),
+                            Toast.LENGTH_SHORT
+                        ).show()
                     }
                 }
                 SheetAction(
@@ -199,8 +208,8 @@ fun ShareImageSheet(
                 ) {
                     // Copy just the link — no capture needed; pastes cleanly into the Feed composer.
                     caption?.let { ShareUtils.copyText(context, it) }
-                    statusRes = R.string.share_copied
                     haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    Toast.makeText(context, R.string.share_copied, Toast.LENGTH_SHORT).show()
                 }
                 SheetAction(
                     icon = Icons.Filled.Share,
@@ -214,15 +223,6 @@ fun ShareImageSheet(
                         onDismiss()
                     }
                 }
-            }
-
-            if (statusRes != null) {
-                Spacer(Modifier.height(12.dp))
-                Text(
-                    text = stringResource(statusRes!!),
-                    style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.primary
-                )
             }
         }
     }

--- a/app/src/main/java/com/anisync/android/presentation/share/ShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/ShareCard.kt
@@ -2,11 +2,13 @@ package com.anisync.android.presentation.share
 
 import android.widget.Toast
 import androidx.compose.foundation.background
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
@@ -14,6 +16,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -87,7 +90,7 @@ internal val ShareCardShapeFramed = RoundedCornerShape(32.dp)
  * the export is never blank. [seedColor] (artwork color) enables the COVER theme; [templates]
  * populates the style picker.
  */
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class, ExperimentalLayoutApi::class)
 @Composable
 fun ShareImageSheet(
     onDismiss: () -> Unit,
@@ -140,11 +143,17 @@ fun ShareImageSheet(
                 .padding(bottom = 20.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            // Pinned: the live preview. Every control change repaints it in place.
+            // Pinned: the live preview. Every control change repaints it in place. While the
+            // keyboard is up (caption editing) it shrinks instead of squashing the field away.
+            val previewMaxHeight by animateDpAsState(
+                targetValue = if (WindowInsets.isImeVisible) 136.dp else 280.dp,
+                label = "previewMaxHeight"
+            )
             ShareCaptureArea(
                 controller = controller,
                 config = config,
                 seedColor = seedColor,
+                maxPreviewHeight = previewMaxHeight,
                 card = card,
             )
 

--- a/app/src/main/java/com/anisync/android/presentation/share/ShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/ShareCard.kt
@@ -81,7 +81,8 @@ internal val ShareCardShapeFramed = RoundedCornerShape(32.dp)
  * Bottom sheet that previews a [card] exactly as it will be shared and lets the user **customize** it
  * live — theme, aspect (compact / square / story), an optional baked caption, and (when
  * [supportsPrivacy]) whether the score/progress show. Then it offers: save the PNG to the gallery,
- * copy the [caption] link, or open the system share sheet with the image.
+ * copy the [link] to the clipboard, or open the system share sheet with the image (the user's
+ * caption + [link] ride along as the share text).
  *
  * Layout keeps the preview and the action row **pinned**; only the customization controls scroll.
  * Every tweak is therefore visible on the card the instant it's made.
@@ -94,7 +95,7 @@ internal val ShareCardShapeFramed = RoundedCornerShape(32.dp)
 @Composable
 fun ShareImageSheet(
     onDismiss: () -> Unit,
-    caption: String? = null,
+    link: String? = null,
     seedColor: Color? = null,
     supportsPrivacy: Boolean = false,
     templates: List<ShareCardTemplate> = emptyList(),
@@ -126,7 +127,7 @@ fun ShareImageSheet(
     }
 
     // The caption baked onto the card also rides along as the shared text, above the link.
-    val shareText = listOfNotNull(config.caption.trim().ifBlank { null }, caption).joinToString("\n\n")
+    val shareText = listOfNotNull(config.caption.trim().ifBlank { null }, link).joinToString("\n\n")
         .ifBlank { null }
 
     // Full height from the start: the pinned preview/actions layout needs the whole sheet.
@@ -218,7 +219,7 @@ fun ShareImageSheet(
                     contentColor = MaterialTheme.colorScheme.onSurface
                 ) {
                     // Copy just the link — no capture needed; pastes cleanly into the Feed composer.
-                    caption?.let { ShareUtils.copyText(context, it) }
+                    link?.let { ShareUtils.copyText(context, it) }
                     haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                     Toast.makeText(context, R.string.share_copied, Toast.LENGTH_SHORT).show()
                 }

--- a/app/src/main/java/com/anisync/android/presentation/share/ShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/ShareCard.kt
@@ -1,6 +1,5 @@
 package com.anisync.android.presentation.share
 
-import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,7 +13,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -27,9 +25,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -45,8 +45,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -56,7 +58,6 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.anisync.android.R
 import com.anisync.android.util.ShareUtils
-import dev.shreyaspatil.capturable.capturable
 import dev.shreyaspatil.capturable.controller.rememberCaptureController
 import kotlinx.coroutines.launch
 
@@ -67,25 +68,42 @@ import kotlinx.coroutines.launch
 val ShareCardWidth = 340.dp
 
 /** Rounded outer shape shared by all share cards (matches the app's 28dp hero radius). */
-private val ShareCardShape = RoundedCornerShape(28.dp)
+internal val ShareCardShape = RoundedCornerShape(28.dp)
+
+/** Slightly larger radius for the Square/Story backdrop frame the card sits inside. */
+internal val ShareCardShapeFramed = RoundedCornerShape(32.dp)
 
 /**
- * Bottom sheet that previews a [card] exactly as it will be shared, then offers: save the PNG to
- * the gallery, copy the [caption] link to the clipboard, or open the system share sheet with the
- * PNG. Showing the live card first doubles as the load gate — Coil covers are decoded by the time
- * the user acts, so the exported image is never blank.
+ * Bottom sheet that previews a [card] exactly as it will be shared and lets the user **customize** it
+ * live — theme, aspect (compact / square / story), an optional baked caption, and (when
+ * [supportsPrivacy]) whether the score/progress show. Then it offers: save the PNG to the gallery,
+ * copy the [caption] link, or open the system share sheet with the image.
+ *
+ * The live preview doubles as the load gate: Coil covers are decoded by the time the user acts, so
+ * the export is never blank. [seedColor] (artwork color) enables the COVER theme and tints the
+ * backdrop; [backdropUrl] is the blurred image behind the framed formats; [templates] populates the
+ * style picker.
  */
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 fun ShareImageSheet(
     onDismiss: () -> Unit,
     caption: String? = null,
+    seedColor: Color? = null,
+    backdropUrl: String? = null,
+    supportsPrivacy: Boolean = false,
+    templates: List<ShareCardTemplate> = emptyList(),
     card: @Composable () -> Unit,
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+    val haptic = LocalHapticFeedback.current
     val controller = rememberCaptureController()
     var busy by remember { mutableStateOf(false) }
+    var statusRes by remember { mutableStateOf<Int?>(null) }
+    var config by remember {
+        mutableStateOf(ShareCardConfig(template = templates.firstOrNull() ?: ShareCardTemplate.STANDARD))
+    }
 
     // Capture once per tap, then run [block] over the bitmap. Guards against concurrent taps.
     fun runAction(block: suspend (androidx.compose.ui.graphics.ImageBitmap) -> Unit) {
@@ -102,10 +120,15 @@ fun ShareImageSheet(
         }
     }
 
+    // The caption baked onto the card also rides along as the shared text, above the link.
+    val shareText = listOfNotNull(config.caption.trim().ifBlank { null }, caption).joinToString("\n\n")
+        .ifBlank { null }
+
     com.anisync.android.presentation.components.AppModalBottomSheet(onDismissRequest = onDismiss) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
                 .windowInsetsPadding(WindowInsets.navigationBars)
                 .padding(horizontal = 20.dp)
                 .padding(bottom = 20.dp),
@@ -120,23 +143,33 @@ fun ShareImageSheet(
                     .padding(bottom = 16.dp)
             )
 
-            // Height-capped + scrollable so a tall card still leaves the action row visible.
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(max = 440.dp)
-                    .verticalScroll(rememberScrollState()),
-                contentAlignment = Alignment.TopCenter
-            ) {
-                Box(
-                    modifier = Modifier
-                        .width(ShareCardWidth)
-                        .clip(ShareCardShape)
-                        .capturable(controller)
-                ) {
-                    card()
-                }
-            }
+            ShareCaptureArea(
+                controller = controller,
+                config = config,
+                seedColor = seedColor,
+                backdropUrl = backdropUrl,
+                card = card,
+            )
+
+            Spacer(Modifier.height(20.dp))
+
+            ShareCustomizeControls(
+                config = config,
+                onConfig = { config = it },
+                coverAvailable = seedColor != null,
+                supportsPrivacy = supportsPrivacy,
+                templates = templates,
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            OutlinedTextField(
+                value = config.caption,
+                onValueChange = { config = config.copy(caption = it.take(80)) },
+                label = { Text(stringResource(R.string.share_caption_hint)) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
 
             Spacer(Modifier.height(20.dp))
 
@@ -147,62 +180,67 @@ fun ShareImageSheet(
                 SheetAction(
                     icon = Icons.Filled.Download,
                     label = stringResource(R.string.share_action_save),
-                    enabled = !busy,
+                    busy = busy,
                     container = MaterialTheme.colorScheme.surfaceContainerHighest,
                     contentColor = MaterialTheme.colorScheme.onSurface
                 ) {
                     runAction { bmp ->
                         val ok = ShareUtils.saveCardToGallery(context, bmp)
-                        Toast.makeText(
-                            context,
-                            context.getString(
-                                if (ok) R.string.share_saved_to_gallery else R.string.share_save_failed
-                            ),
-                            Toast.LENGTH_SHORT
-                        ).show()
+                        statusRes = if (ok) R.string.share_saved_to_gallery else R.string.share_save_failed
+                        if (ok) haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                     }
                 }
                 SheetAction(
                     icon = Icons.Filled.ContentCopy,
                     label = stringResource(R.string.share_action_copy),
-                    enabled = !busy,
+                    busy = busy,
                     container = MaterialTheme.colorScheme.surfaceContainerHighest,
                     contentColor = MaterialTheme.colorScheme.onSurface
                 ) {
                     // Copy just the link — no capture needed; pastes cleanly into the Feed composer.
                     caption?.let { ShareUtils.copyText(context, it) }
-                    Toast.makeText(context, R.string.share_copied, Toast.LENGTH_SHORT).show()
+                    statusRes = R.string.share_copied
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                 }
                 SheetAction(
                     icon = Icons.Filled.Share,
                     label = stringResource(R.string.share_action_share),
-                    enabled = !busy,
+                    busy = busy,
                     container = MaterialTheme.colorScheme.primary,
                     contentColor = MaterialTheme.colorScheme.onPrimary
                 ) {
                     runAction { bmp ->
-                        ShareUtils.shareBitmap(context, bmp, caption)
+                        ShareUtils.shareBitmap(context, bmp, shareText)
                         onDismiss()
                     }
                 }
+            }
+
+            if (statusRes != null) {
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = stringResource(statusRes!!),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary
+                )
             }
         }
     }
 }
 
-/** One icon-over-label action tile in the share sheet's action row. */
+/** One icon-over-label action tile in the share sheet's action row. Shows a spinner while busy. */
 @Composable
 private fun RowScope.SheetAction(
     icon: ImageVector,
     label: String,
-    enabled: Boolean,
+    busy: Boolean,
     container: Color,
     contentColor: Color,
     onClick: () -> Unit,
 ) {
     Surface(
         onClick = onClick,
-        enabled = enabled,
+        enabled = !busy,
         shape = RoundedCornerShape(18.dp),
         color = container,
         contentColor = contentColor,
@@ -215,9 +253,17 @@ private fun RowScope.SheetAction(
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(20.dp))
-            Spacer(Modifier.height(4.dp))
-            Text(text = label, style = MaterialTheme.typography.labelMedium, maxLines = 1)
+            if (busy) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp,
+                    color = contentColor
+                )
+            } else {
+                Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(20.dp))
+                Spacer(Modifier.height(4.dp))
+                Text(text = label, style = MaterialTheme.typography.labelMedium, maxLines = 1)
+            }
         }
     }
 }
@@ -262,7 +308,8 @@ fun ShareCardBannerBox(
 /**
  * Opaque, rounded, self-contained surface every share card sits on. Opaque matters: the PNG
  * is composited over arbitrary chat/story backgrounds, so no theme transparency may leak
- * through. Ends with the shared AniSync footer so every exported image is attributed.
+ * through. Renders the optional user [caption] then the shared AniSync footer, so every exported
+ * image is captioned + attributed.
  *
  * [handle] is the AniList username shown in the footer (omitted when unknown).
  */
@@ -272,6 +319,7 @@ fun ShareCardScaffold(
     handle: String? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
+    val caption = LocalShareCardConfig.current.caption.trim()
     Column(
         modifier = modifier
             .width(ShareCardWidth)
@@ -279,8 +327,26 @@ fun ShareCardScaffold(
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
     ) {
         content()
+        if (caption.isNotBlank()) ShareCardCaption(caption)
         ShareCardFooter(handle = handle)
     }
+}
+
+/** The user's baked one-liner, set just above the footer. */
+@Composable
+private fun ShareCardCaption(caption: String) {
+    Text(
+        text = caption,
+        style = MaterialTheme.typography.bodyMedium,
+        fontWeight = FontWeight.Medium,
+        color = MaterialTheme.colorScheme.onSurface,
+        maxLines = 3,
+        overflow = TextOverflow.Ellipsis,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
+            .padding(top = 4.dp, bottom = 16.dp)
+    )
 }
 
 /** AniSync wordmark + monochrome mark + optional @handle. Kept consistent across all cards. */

--- a/app/src/main/java/com/anisync/android/presentation/share/ShareCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/ShareCard.kt
@@ -4,7 +4,6 @@ import android.os.Build
 import android.view.WindowManager
 import android.widget.Toast
 import androidx.compose.foundation.background
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -12,7 +11,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
@@ -21,12 +19,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -95,8 +93,8 @@ internal val ShareCardShapeFramed = RoundedCornerShape(32.dp)
  * gallery, copy the [link] to the clipboard, or open the system share sheet with the image (the
  * user's caption + [link] ride along as the share text).
  *
- * Layout keeps the preview and the action row **pinned**; only the customization controls scroll.
- * Every tweak is therefore visible on the card the instant it's made.
+ * Preview, controls, caption and actions form one scrolling flow — the card scrolls along rather
+ * than pinning or resizing (no size jump when the keyboard opens).
  *
  * The live preview doubles as the load gate: Coil covers are decoded by the time the user acts, so
  * the export is never blank. [seedColor] (artwork color) enables the COVER theme; [templates]
@@ -144,10 +142,14 @@ private fun ShareImageBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
     ) {
+        // One scrolling flow: the preview scrolls with the controls; the keyboard just pushes
+        // the sheet up and the focused caption field auto-scrolls into view.
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
                 .windowInsetsPadding(WindowInsets.navigationBars)
+                .imePadding()
                 .padding(horizontal = 20.dp)
                 .padding(bottom = 20.dp),
             horizontalAlignment = Alignment.CenterHorizontally
@@ -159,7 +161,7 @@ private fun ShareImageBottomSheet(
                 supportsPrivacy = supportsPrivacy,
                 templates = templates,
                 templateLabel = templateLabel,
-                previewMaxHeight = 280.dp,
+                previewMaxHeight = 340.dp,
                 card = card,
             )
         }
@@ -223,9 +225,13 @@ private fun ShareImageOverlay(
                 .imePadding(),
             contentAlignment = Alignment.Center
         ) {
+            // One scrolling flow (card included); width-capped so tablets get a centered column,
+            // not edge-to-edge controls.
             Column(
                 modifier = Modifier
+                    .widthIn(max = 480.dp)
                     .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
                     .padding(horizontal = 24.dp, vertical = 16.dp)
                     // Consume taps so interacting with the controls never falls through to dismiss.
                     .clickable(
@@ -242,7 +248,7 @@ private fun ShareImageOverlay(
                     supportsPrivacy = supportsPrivacy,
                     templates = templates,
                     templateLabel = templateLabel,
-                    previewMaxHeight = 360.dp,
+                    previewMaxHeight = 420.dp,
                     card = card,
                 )
             }
@@ -251,13 +257,14 @@ private fun ShareImageOverlay(
 }
 
 /**
- * The customizer itself — live preview pinned on top, scrollable controls + caption in the middle,
- * action row pinned at the bottom — shared verbatim by both presentation hosts. Must live inside a
- * height-bounded Column ([ColumnScope] receiver) so the middle section can flex-shrink.
+ * The customizer itself — preview, controls, caption and actions in **one scrolling flow** (the
+ * card scrolls along like any other element; nothing pins or resizes when the keyboard opens —
+ * focusing the caption simply scrolls it into view). Shared verbatim by both presentation hosts,
+ * which wrap it in their own scroll container.
  */
-@OptIn(ExperimentalComposeUiApi::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
-private fun ColumnScope.ShareCustomizerContent(
+private fun ShareCustomizerContent(
     onDismiss: () -> Unit,
     link: String?,
     seedColor: Color?,
@@ -295,47 +302,34 @@ private fun ColumnScope.ShareCustomizerContent(
     val shareText = listOfNotNull(config.caption.trim().ifBlank { null }, link).joinToString("\n\n")
         .ifBlank { null }
 
-    // Pinned: the live preview. Every control change repaints it in place. While the
-    // keyboard is up (caption editing) it shrinks instead of squashing the field away.
-    val animatedPreviewHeight by animateDpAsState(
-        targetValue = if (WindowInsets.isImeVisible) 136.dp else previewMaxHeight,
-        label = "previewMaxHeight"
-    )
     ShareCaptureArea(
         controller = controller,
         config = config,
         seedColor = seedColor,
-        maxPreviewHeight = animatedPreviewHeight,
+        maxPreviewHeight = previewMaxHeight,
         card = card,
     )
 
             Spacer(Modifier.height(16.dp))
 
-            // Only this middle section scrolls; preview and actions stay on screen.
-            Column(
-                modifier = Modifier
-                    .weight(1f, fill = false)
-                    .verticalScroll(rememberScrollState())
-            ) {
-                ShareCustomizeControls(
-                    config = config,
-                    onConfig = { config = it },
-                    coverAvailable = seedColor != null,
-                    supportsPrivacy = supportsPrivacy,
-                    templates = templates,
-                    templateLabel = templateLabel,
-                )
+            ShareCustomizeControls(
+                config = config,
+                onConfig = { config = it },
+                coverAvailable = seedColor != null,
+                supportsPrivacy = supportsPrivacy,
+                templates = templates,
+                templateLabel = templateLabel,
+            )
 
-                Spacer(Modifier.height(14.dp))
+            Spacer(Modifier.height(14.dp))
 
-                OutlinedTextField(
-                    value = config.caption,
-                    onValueChange = { config = config.copy(caption = it.take(80)) },
-                    label = { Text(stringResource(R.string.share_caption_hint)) },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
+            OutlinedTextField(
+                value = config.caption,
+                onValueChange = { config = config.copy(caption = it.take(80)) },
+                label = { Text(stringResource(R.string.share_caption_hint)) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
 
             Spacer(Modifier.height(16.dp))
 

--- a/app/src/main/java/com/anisync/android/presentation/share/ShareCardConfig.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/ShareCardConfig.kt
@@ -1,0 +1,372 @@
+package com.anisync.android.presentation.share
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.anisync.android.R
+import com.anisync.android.ui.theme.shareCardColorScheme
+import dev.shreyaspatil.capturable.capturable
+import dev.shreyaspatil.capturable.controller.CaptureController
+import kotlin.math.roundToInt
+
+/** Card color palette for the exported image, independent of the app's active theme. */
+enum class ShareCardTheme { AUTO, LIGHT, DARK, AMOLED, COVER }
+
+/** Canvas aspect. COMPACT = content-height chat preview; SQUARE/STORY sit the card on a backdrop. */
+enum class ShareCardFormat { COMPACT, SQUARE, STORY }
+
+/** Per-card layout variant. Only the media card ships a second (HERO) template today. */
+enum class ShareCardTemplate { STANDARD, HERO }
+
+/** User-tunable state for a share card, owned by [ShareImageSheet] and read by the cards. */
+@Immutable
+data class ShareCardConfig(
+    val theme: ShareCardTheme = ShareCardTheme.AUTO,
+    val format: ShareCardFormat = ShareCardFormat.COMPACT,
+    val template: ShareCardTemplate = ShareCardTemplate.STANDARD,
+    val showScore: Boolean = true,
+    val showProgress: Boolean = true,
+    val caption: String = "",
+)
+
+/** Lets the scaffold and cards read live customization without threading it through every param. */
+val LocalShareCardConfig = compositionLocalOf { ShareCardConfig() }
+
+/** Extra width the framed formats add around the [ShareCardWidth] card for backdrop margins. */
+private val FrameMargin = 16.dp
+
+/** Fixed export width in px. Density is overridden so the PNG is this crisp on every device. */
+private const val ExportWidthPx = 1080f
+
+/**
+ * Renders [card] exactly as it will be exported — under the chosen [ShareCardTheme], inside the
+ * chosen [ShareCardFormat] frame — and attaches the [controller] so the sheet can snapshot it.
+ *
+ * The capture node is laid out under an **overridden density** so it always measures to
+ * [ExportWidthPx] px wide (crisp regardless of the device's real density), then scaled *down* for
+ * on-screen display via [scaledToFit]. The capture reads the node's own high-res layer, so the
+ * export stays full resolution while the preview fits the sheet.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun ShareCaptureArea(
+    controller: CaptureController,
+    config: ShareCardConfig,
+    seedColor: Color?,
+    backdropUrl: String?,
+    modifier: Modifier = Modifier,
+    card: @Composable () -> Unit,
+) {
+    val displayDensity = LocalDensity.current
+    val frameWidthDp: Dp = if (config.format == ShareCardFormat.COMPACT) {
+        ShareCardWidth
+    } else {
+        ShareCardWidth + FrameMargin * 2
+    }
+    val captureDensity = ExportWidthPx / frameWidthDp.value
+    val maxPreviewHeightPx = with(displayDensity) { 380.dp.toPx() }
+
+    BoxWithConstraints(
+        modifier = modifier.fillMaxWidth(),
+        contentAlignment = Alignment.TopCenter,
+    ) {
+        val availWidthPx = constraints.maxWidth.toFloat()
+        // Never upscale past the card's natural dp size; otherwise fit within the sheet's width/height.
+        val naturalScale = (frameWidthDp.value * displayDensity.density) / ExportWidthPx
+
+        CompositionLocalProvider(
+            LocalDensity provides Density(captureDensity, displayDensity.fontScale)
+        ) {
+            Box(
+                Modifier
+                    .scaledToFit(naturalScale, availWidthPx, maxPreviewHeightPx)
+                    .capturable(controller)
+            ) {
+                ShareCardThemeScope(config.theme, seedColor) {
+                    CompositionLocalProvider(LocalShareCardConfig provides config) {
+                        ShareFrame(config.format, frameWidthDp, backdropUrl, card)
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Measures the child at its natural (export-resolution) size, then places it scaled so it fits
+ * within [maxWidthPx] × [maxHeightPx] without ever exceeding [baseScale]. The captured node keeps
+ * its full pixel size — only the on-screen placement shrinks.
+ */
+private fun Modifier.scaledToFit(baseScale: Float, maxWidthPx: Float, maxHeightPx: Float): Modifier =
+    layout { measurable, _ ->
+        val placeable = measurable.measure(Constraints())
+        val fit = minOf(
+            baseScale,
+            maxWidthPx / placeable.width.coerceAtLeast(1),
+            maxHeightPx / placeable.height.coerceAtLeast(1),
+        )
+        layout((placeable.width * fit).roundToInt(), (placeable.height * fit).roundToInt()) {
+            placeable.placeWithLayer(0, 0) {
+                transformOrigin = TransformOrigin(0f, 0f)
+                scaleX = fit
+                scaleY = fit
+            }
+        }
+    }
+
+/**
+ * Wraps [content] in a [MaterialTheme] carrying the card's own color scheme when the user picks a
+ * non-[ShareCardTheme.AUTO] look. COVER seeds a MaterialKolor scheme from the artwork [seedColor],
+ * in the app's current light/dark polarity; with no seed it falls through to AUTO.
+ */
+@Composable
+fun ShareCardThemeScope(theme: ShareCardTheme, seedColor: Color?, content: @Composable () -> Unit) {
+    if (theme == ShareCardTheme.AUTO || (theme == ShareCardTheme.COVER && seedColor == null)) {
+        content()
+        return
+    }
+    val appDark = MaterialTheme.colorScheme.surface.luminance() < 0.5f
+    val scheme = when (theme) {
+        ShareCardTheme.LIGHT -> shareCardColorScheme(dark = false)
+        ShareCardTheme.DARK -> shareCardColorScheme(dark = true)
+        ShareCardTheme.AMOLED -> shareCardColorScheme(dark = true, amoled = true)
+        ShareCardTheme.COVER -> shareCardColorScheme(dark = appDark, seed = seedColor)
+        ShareCardTheme.AUTO -> shareCardColorScheme(dark = appDark) // unreachable; keeps when exhaustive
+    }
+    MaterialTheme(
+        colorScheme = scheme,
+        typography = MaterialTheme.typography,
+        shapes = MaterialTheme.shapes,
+        content = content,
+    )
+}
+
+/**
+ * Sits [card] on a full-bleed backdrop for the SQUARE / STORY formats: a blurred, scrimmed copy of
+ * [backdropUrl] (or a scheme gradient when absent). COMPACT renders the card bare so its rounded
+ * corners stay transparent for chat bubbles.
+ */
+@Composable
+private fun ShareFrame(
+    format: ShareCardFormat,
+    frameWidth: Dp,
+    backdropUrl: String?,
+    card: @Composable () -> Unit,
+) {
+    if (format == ShareCardFormat.COMPACT) {
+        card()
+        return
+    }
+    val minHeight = if (format == ShareCardFormat.SQUARE) frameWidth else frameWidth * 16f / 9f
+    Box(
+        modifier = Modifier
+            .width(frameWidth)
+            .heightIn(min = minHeight)
+            .clip(ShareCardShapeFramed),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (backdropUrl != null) {
+            AsyncImage(
+                model = backdropUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize().blur(28.dp),
+            )
+            Box(
+                Modifier.fillMaxSize().background(
+                    Brush.verticalGradient(
+                        0f to Color.Black.copy(alpha = 0.45f),
+                        1f to Color.Black.copy(alpha = 0.65f),
+                    )
+                )
+            )
+        } else {
+            Box(
+                Modifier.fillMaxSize().background(
+                    Brush.verticalGradient(
+                        0f to MaterialTheme.colorScheme.surfaceContainerHigh,
+                        1f to MaterialTheme.colorScheme.surfaceDim,
+                    )
+                )
+            )
+        }
+        Box(Modifier.padding(FrameMargin)) { card() }
+    }
+}
+
+/**
+ * The customization row shown under the live preview: theme + format (+ template) pickers and the
+ * per-card privacy toggles. [coverAvailable] gates the COVER theme (needs an artwork seed);
+ * [templates] drives the style picker; [supportsPrivacy] the score/progress toggles.
+ */
+@Composable
+fun ShareCustomizeControls(
+    config: ShareCardConfig,
+    onConfig: (ShareCardConfig) -> Unit,
+    coverAvailable: Boolean,
+    supportsPrivacy: Boolean,
+    templates: List<ShareCardTemplate>,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        // Theme — a scrollable pill row so five options never crowd on a narrow sheet.
+        ControlRow(label = stringResource(R.string.share_customize_theme)) {
+            val themes = buildList {
+                addAll(listOf(ShareCardTheme.AUTO, ShareCardTheme.LIGHT, ShareCardTheme.DARK, ShareCardTheme.AMOLED))
+                if (coverAvailable) add(ShareCardTheme.COVER)
+            }
+            Row(
+                modifier = Modifier.horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                themes.forEach { t ->
+                    FilterChip(
+                        selected = config.theme == t,
+                        onClick = { onConfig(config.copy(theme = t)) },
+                        label = { Text(themeLabel(t)) },
+                    )
+                }
+            }
+        }
+
+        // Format — a segmented control (three short, mutually exclusive options).
+        ControlRow(label = stringResource(R.string.share_customize_format)) {
+            val formats = ShareCardFormat.entries
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                formats.forEachIndexed { i, f ->
+                    SegmentedButton(
+                        selected = config.format == f,
+                        onClick = { onConfig(config.copy(format = f)) },
+                        shape = SegmentedButtonDefaults.itemShape(i, formats.size),
+                    ) { Text(formatLabel(f)) }
+                }
+            }
+        }
+
+        if (templates.size > 1) {
+            ControlRow(label = stringResource(R.string.share_customize_template)) {
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    templates.forEachIndexed { i, tmpl ->
+                        SegmentedButton(
+                            selected = config.template == tmpl,
+                            onClick = { onConfig(config.copy(template = tmpl)) },
+                            shape = SegmentedButtonDefaults.itemShape(i, templates.size),
+                        ) { Text(templateLabel(tmpl)) }
+                    }
+                }
+            }
+        }
+
+        if (supportsPrivacy) {
+            ControlRow(label = stringResource(R.string.share_customize_show)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    ToggleChip(
+                        selected = config.showScore,
+                        label = stringResource(R.string.share_toggle_score),
+                        onToggle = { onConfig(config.copy(showScore = it)) },
+                    )
+                    ToggleChip(
+                        selected = config.showProgress,
+                        label = stringResource(R.string.share_toggle_progress),
+                        onToggle = { onConfig(config.copy(showProgress = it)) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** Small labelled group: an eyebrow over its control [content]. */
+@Composable
+private fun ControlRow(label: String, content: @Composable () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        content()
+    }
+}
+
+/** A leading-check FilterChip used as an on/off privacy toggle. */
+@Composable
+private fun ToggleChip(selected: Boolean, label: String, onToggle: (Boolean) -> Unit) {
+    FilterChip(
+        selected = selected,
+        onClick = { onToggle(!selected) },
+        label = { Text(label) },
+        leadingIcon = if (selected) {
+            { Icon(Icons.Filled.Check, contentDescription = null) }
+        } else null,
+    )
+}
+
+@Composable
+private fun themeLabel(theme: ShareCardTheme): String = stringResource(
+    when (theme) {
+        ShareCardTheme.AUTO -> R.string.share_theme_auto
+        ShareCardTheme.LIGHT -> R.string.share_theme_light
+        ShareCardTheme.DARK -> R.string.share_theme_dark
+        ShareCardTheme.AMOLED -> R.string.share_theme_amoled
+        ShareCardTheme.COVER -> R.string.share_theme_cover
+    }
+)
+
+@Composable
+private fun formatLabel(format: ShareCardFormat): String = stringResource(
+    when (format) {
+        ShareCardFormat.COMPACT -> R.string.share_format_compact
+        ShareCardFormat.SQUARE -> R.string.share_format_square
+        ShareCardFormat.STORY -> R.string.share_format_story
+    }
+)
+
+@Composable
+private fun templateLabel(template: ShareCardTemplate): String = stringResource(
+    when (template) {
+        ShareCardTemplate.STANDARD -> R.string.share_template_standard
+        ShareCardTemplate.HERO -> R.string.share_template_hero
+    }
+)

--- a/app/src/main/java/com/anisync/android/presentation/share/ShareCardConfig.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/ShareCardConfig.kt
@@ -1,7 +1,6 @@
 package com.anisync.android.presentation.share
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -12,30 +11,26 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.luminance
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
@@ -43,8 +38,8 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
 import com.anisync.android.R
+import com.anisync.android.presentation.components.SegmentedTabGroup
 import com.anisync.android.ui.theme.shareCardColorScheme
 import dev.shreyaspatil.capturable.capturable
 import dev.shreyaspatil.capturable.controller.CaptureController
@@ -74,10 +69,13 @@ data class ShareCardConfig(
 val LocalShareCardConfig = compositionLocalOf { ShareCardConfig() }
 
 /** Extra width the framed formats add around the [ShareCardWidth] card for backdrop margins. */
-private val FrameMargin = 16.dp
+private val FrameMargin = 20.dp
 
 /** Fixed export width in px. Density is overridden so the PNG is this crisp on every device. */
 private const val ExportWidthPx = 1080f
+
+/** Preview cap so the card + controls both stay on screen without scrolling the card away. */
+private val PreviewMaxHeight = 280.dp
 
 /**
  * Renders [card] exactly as it will be exported — under the chosen [ShareCardTheme], inside the
@@ -94,7 +92,6 @@ fun ShareCaptureArea(
     controller: CaptureController,
     config: ShareCardConfig,
     seedColor: Color?,
-    backdropUrl: String?,
     modifier: Modifier = Modifier,
     card: @Composable () -> Unit,
 ) {
@@ -105,7 +102,7 @@ fun ShareCaptureArea(
         ShareCardWidth + FrameMargin * 2
     }
     val captureDensity = ExportWidthPx / frameWidthDp.value
-    val maxPreviewHeightPx = with(displayDensity) { 380.dp.toPx() }
+    val maxPreviewHeightPx = with(displayDensity) { PreviewMaxHeight.toPx() }
 
     BoxWithConstraints(
         modifier = modifier.fillMaxWidth(),
@@ -125,7 +122,7 @@ fun ShareCaptureArea(
             ) {
                 ShareCardThemeScope(config.theme, seedColor) {
                     CompositionLocalProvider(LocalShareCardConfig provides config) {
-                        ShareFrame(config.format, frameWidthDp, backdropUrl, card)
+                        ShareFrame(config.format, frameWidthDp, card)
                     }
                 }
             }
@@ -183,62 +180,48 @@ fun ShareCardThemeScope(theme: ShareCardTheme, seedColor: Color?, content: @Comp
 }
 
 /**
- * Sits [card] on a full-bleed backdrop for the SQUARE / STORY formats: a blurred, scrimmed copy of
- * [backdropUrl] (or a scheme gradient when absent). COMPACT renders the card bare so its rounded
- * corners stay transparent for chat bubbles.
+ * Sits [card] on a full-bleed backdrop for the SQUARE / STORY formats: a soft theme-derived gradient
+ * (so it reads right in light, dark and AMOLED) with the card floating above it on a shadow. COMPACT
+ * renders the card bare so its rounded corners stay transparent for chat bubbles.
+ *
+ * The gradient is built from the *card's* scheme (this runs inside [ShareCardThemeScope]), so it
+ * tracks the chosen theme automatically — no image, no blur, nothing to leak into the capture.
  */
 @Composable
 private fun ShareFrame(
     format: ShareCardFormat,
     frameWidth: Dp,
-    backdropUrl: String?,
     card: @Composable () -> Unit,
 ) {
     if (format == ShareCardFormat.COMPACT) {
         card()
         return
     }
+    val scheme = MaterialTheme.colorScheme
     val minHeight = if (format == ShareCardFormat.SQUARE) frameWidth else frameWidth * 16f / 9f
     Box(
         modifier = Modifier
             .width(frameWidth)
             .heightIn(min = minHeight)
-            .clip(ShareCardShapeFramed),
+            .clip(ShareCardShapeFramed)
+            .background(Brush.verticalGradient(listOf(scheme.surfaceBright, scheme.surfaceDim))),
         contentAlignment = Alignment.Center,
     ) {
-        if (backdropUrl != null) {
-            AsyncImage(
-                model = backdropUrl,
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier.fillMaxSize().blur(28.dp),
-            )
-            Box(
-                Modifier.fillMaxSize().background(
-                    Brush.verticalGradient(
-                        0f to Color.Black.copy(alpha = 0.45f),
-                        1f to Color.Black.copy(alpha = 0.65f),
-                    )
-                )
-            )
-        } else {
-            Box(
-                Modifier.fillMaxSize().background(
-                    Brush.verticalGradient(
-                        0f to MaterialTheme.colorScheme.surfaceContainerHigh,
-                        1f to MaterialTheme.colorScheme.surfaceDim,
-                    )
-                )
-            )
+        Box(
+            Modifier
+                .padding(FrameMargin)
+                .shadow(elevation = 18.dp, shape = ShareCardShape, clip = false)
+        ) {
+            card()
         }
-        Box(Modifier.padding(FrameMargin)) { card() }
     }
 }
 
 /**
  * The customization row shown under the live preview: theme + format (+ template) pickers and the
- * per-card privacy toggles. [coverAvailable] gates the COVER theme (needs an artwork seed);
- * [templates] drives the style picker; [supportsPrivacy] the score/progress toggles.
+ * per-card privacy toggles, all built on the app's [SegmentedTabGroup]. [coverAvailable] gates the
+ * COVER theme (needs an artwork seed); [templates] drives the style picker; [supportsPrivacy] the
+ * score/progress toggles.
  */
 @Composable
 fun ShareCustomizeControls(
@@ -249,52 +232,41 @@ fun ShareCustomizeControls(
     templates: List<ShareCardTemplate>,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        // Theme — a scrollable pill row so five options never crowd on a narrow sheet.
+    Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(14.dp)) {
         ControlRow(label = stringResource(R.string.share_customize_theme)) {
-            val themes = buildList {
-                addAll(listOf(ShareCardTheme.AUTO, ShareCardTheme.LIGHT, ShareCardTheme.DARK, ShareCardTheme.AMOLED))
-                if (coverAvailable) add(ShareCardTheme.COVER)
-            }
-            Row(
-                modifier = Modifier.horizontalScroll(rememberScrollState()),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                themes.forEach { t ->
-                    FilterChip(
-                        selected = config.theme == t,
-                        onClick = { onConfig(config.copy(theme = t)) },
-                        label = { Text(themeLabel(t)) },
-                    )
+            val themes = remember(coverAvailable) {
+                buildList {
+                    addAll(listOf(ShareCardTheme.AUTO, ShareCardTheme.LIGHT, ShareCardTheme.DARK, ShareCardTheme.AMOLED))
+                    if (coverAvailable) add(ShareCardTheme.COVER)
                 }
             }
+            SegmentedTabGroup(
+                options = themes,
+                selected = config.theme,
+                onSelect = { onConfig(config.copy(theme = it)) },
+                label = { themeLabel(it) },
+            )
         }
 
-        // Format — a segmented control (three short, mutually exclusive options).
         ControlRow(label = stringResource(R.string.share_customize_format)) {
-            val formats = ShareCardFormat.entries
-            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                formats.forEachIndexed { i, f ->
-                    SegmentedButton(
-                        selected = config.format == f,
-                        onClick = { onConfig(config.copy(format = f)) },
-                        shape = SegmentedButtonDefaults.itemShape(i, formats.size),
-                    ) { Text(formatLabel(f)) }
-                }
-            }
+            SegmentedTabGroup(
+                options = ShareCardFormat.entries,
+                selected = config.format,
+                onSelect = { onConfig(config.copy(format = it)) },
+                label = { formatLabel(it) },
+                fillEqually = true,
+            )
         }
 
         if (templates.size > 1) {
             ControlRow(label = stringResource(R.string.share_customize_template)) {
-                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                    templates.forEachIndexed { i, tmpl ->
-                        SegmentedButton(
-                            selected = config.template == tmpl,
-                            onClick = { onConfig(config.copy(template = tmpl)) },
-                            shape = SegmentedButtonDefaults.itemShape(i, templates.size),
-                        ) { Text(templateLabel(tmpl)) }
-                    }
-                }
+                SegmentedTabGroup(
+                    options = templates,
+                    selected = config.template,
+                    onSelect = { onConfig(config.copy(template = it)) },
+                    label = { templateLabel(it) },
+                    fillEqually = true,
+                )
             }
         }
 

--- a/app/src/main/java/com/anisync/android/presentation/share/ShareCardConfig.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/ShareCardConfig.kt
@@ -221,7 +221,8 @@ private fun ShareFrame(
  * The customization row shown under the live preview: theme + format (+ template) pickers and the
  * per-card privacy toggles, all built on the app's [SegmentedTabGroup]. [coverAvailable] gates the
  * COVER theme (needs an artwork seed); [templates] drives the style picker; [supportsPrivacy] the
- * score/progress toggles.
+ * score/progress toggles. [templateLabel] renames the style options per card type (Card/Poster,
+ * Stats/Recap, Grid/Ranked); null falls back to the generic labels.
  */
 @Composable
 fun ShareCustomizeControls(
@@ -231,6 +232,7 @@ fun ShareCustomizeControls(
     supportsPrivacy: Boolean,
     templates: List<ShareCardTemplate>,
     modifier: Modifier = Modifier,
+    templateLabel: (@Composable (ShareCardTemplate) -> String)? = null,
 ) {
     Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(14.dp)) {
         ControlRow(label = stringResource(R.string.share_customize_theme)) {
@@ -264,7 +266,7 @@ fun ShareCustomizeControls(
                     options = templates,
                     selected = config.template,
                     onSelect = { onConfig(config.copy(template = it)) },
-                    label = { templateLabel(it) },
+                    label = { templateLabel?.invoke(it) ?: defaultTemplateLabel(it) },
                     fillEqually = true,
                 )
             }
@@ -336,7 +338,7 @@ private fun formatLabel(format: ShareCardFormat): String = stringResource(
 )
 
 @Composable
-private fun templateLabel(template: ShareCardTemplate): String = stringResource(
+private fun defaultTemplateLabel(template: ShareCardTemplate): String = stringResource(
     when (template) {
         ShareCardTemplate.STANDARD -> R.string.share_template_standard
         ShareCardTemplate.HERO -> R.string.share_template_hero

--- a/app/src/main/java/com/anisync/android/presentation/share/ShareCardConfig.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/ShareCardConfig.kt
@@ -93,6 +93,7 @@ fun ShareCaptureArea(
     config: ShareCardConfig,
     seedColor: Color?,
     modifier: Modifier = Modifier,
+    maxPreviewHeight: Dp = PreviewMaxHeight,
     card: @Composable () -> Unit,
 ) {
     val displayDensity = LocalDensity.current
@@ -102,7 +103,7 @@ fun ShareCaptureArea(
         ShareCardWidth + FrameMargin * 2
     }
     val captureDensity = ExportWidthPx / frameWidthDp.value
-    val maxPreviewHeightPx = with(displayDensity) { PreviewMaxHeight.toPx() }
+    val maxPreviewHeightPx = with(displayDensity) { maxPreviewHeight.toPx() }
 
     BoxWithConstraints(
         modifier = modifier.fillMaxWidth(),

--- a/app/src/main/java/com/anisync/android/presentation/share/ShareCardConfig.kt
+++ b/app/src/main/java/com/anisync/android/presentation/share/ShareCardConfig.kt
@@ -208,10 +208,18 @@ private fun ShareFrame(
             .background(Brush.verticalGradient(listOf(scheme.surfaceBright, scheme.surfaceDim))),
         contentAlignment = Alignment.Center,
     ) {
+        // Soft lift, not a heavy drop: reduced elevation + translucent shadow colors, otherwise
+        // the card reads as heavily outlined on the light gradient.
         Box(
             Modifier
                 .padding(FrameMargin)
-                .shadow(elevation = 18.dp, shape = ShareCardShape, clip = false)
+                .shadow(
+                    elevation = 8.dp,
+                    shape = ShareCardShape,
+                    clip = false,
+                    ambientColor = Color.Black.copy(alpha = 0.35f),
+                    spotColor = Color.Black.copy(alpha = 0.35f),
+                )
         ) {
             card()
         }

--- a/app/src/main/java/com/anisync/android/ui/theme/Theme.kt
+++ b/app/src/main/java/com/anisync/android/ui/theme/Theme.kt
@@ -399,7 +399,12 @@ fun AppTheme(
     }
 
     CompositionLocalProvider(
-        LocalExpressiveTypography provides expressiveTypography
+        LocalExpressiveTypography provides expressiveTypography,
+        LocalAppThemeSpec provides AppThemeSpec(
+            dynamicColor = dynamicColor,
+            seedColor = seedColor,
+            paletteStyle = paletteStyle
+        )
     ) {
         MaterialTheme(
             colorScheme = colorScheme,
@@ -412,15 +417,31 @@ fun AppTheme(
 }
 
 /**
- * A color scheme for a **share card**, decoupled from the app's active theme so an exported image
- * can be light / dark / AMOLED / artwork-seeded regardless of the in-app setting. Lives here (not in
- * the share package) so it can reach the file-private base schemes and [toAmoled].
- *
- * @param seed when non-null, generates a MaterialKolor scheme from the artwork color; otherwise uses
- *   the app's static light/dark scheme. AMOLED is our Seal-style container shift, dark-only.
+ * The palette inputs [AppTheme] resolved its scheme from, minus the light/dark polarity. Lets a
+ * consumer (share cards) re-derive **the same palette** in a *forced* polarity instead of falling
+ * back to the static brand scheme.
+ */
+@Immutable
+data class AppThemeSpec(
+    val dynamicColor: Boolean,
+    val seedColor: Color?,
+    val paletteStyle: PaletteStyle,
+)
+
+val LocalAppThemeSpec = androidx.compose.runtime.staticCompositionLocalOf {
+    AppThemeSpec(dynamicColor = false, seedColor = null, paletteStyle = PaletteStyle.TonalSpot)
+}
+
+/**
+ * A color scheme for a **share card**: the app's own palette (user seed > Android dynamic > static,
+ * via [LocalAppThemeSpec]) re-derived in the forced [dark] polarity, so Light/Dark/AMOLED cards
+ * differ from the in-app look only by brightness — never by hue. [seed] (artwork color) overrides
+ * the palette entirely for the COVER theme. AMOLED is our Seal-style container shift, dark-only.
+ * Lives here (not in the share package) so it can reach the file-private base schemes and [toAmoled].
  */
 @Composable
 fun shareCardColorScheme(dark: Boolean, amoled: Boolean = false, seed: Color? = null): ColorScheme {
+    val spec = LocalAppThemeSpec.current
     val base = when {
         seed != null -> rememberDynamicColorScheme(
             seedColor = seed,
@@ -428,6 +449,16 @@ fun shareCardColorScheme(dark: Boolean, amoled: Boolean = false, seed: Color? = 
             isAmoled = false,
             style = PaletteStyle.TonalSpot
         )
+        spec.seedColor != null -> rememberDynamicColorScheme(
+            seedColor = spec.seedColor,
+            isDark = dark,
+            isAmoled = false,
+            style = spec.paletteStyle
+        )
+        spec.dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (dark) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
         dark -> darkScheme
         else -> lightScheme
     }

--- a/app/src/main/java/com/anisync/android/ui/theme/Theme.kt
+++ b/app/src/main/java/com/anisync/android/ui/theme/Theme.kt
@@ -411,3 +411,26 @@ fun AppTheme(
     }
 }
 
+/**
+ * A color scheme for a **share card**, decoupled from the app's active theme so an exported image
+ * can be light / dark / AMOLED / artwork-seeded regardless of the in-app setting. Lives here (not in
+ * the share package) so it can reach the file-private base schemes and [toAmoled].
+ *
+ * @param seed when non-null, generates a MaterialKolor scheme from the artwork color; otherwise uses
+ *   the app's static light/dark scheme. AMOLED is our Seal-style container shift, dark-only.
+ */
+@Composable
+fun shareCardColorScheme(dark: Boolean, amoled: Boolean = false, seed: Color? = null): ColorScheme {
+    val base = when {
+        seed != null -> rememberDynamicColorScheme(
+            seedColor = seed,
+            isDark = dark,
+            isAmoled = false,
+            style = PaletteStyle.TonalSpot
+        )
+        dark -> darkScheme
+        else -> lightScheme
+    }
+    return if (amoled && dark) base.toAmoled() else base
+}
+

--- a/app/src/main/java/com/anisync/android/util/ShareUtils.kt
+++ b/app/src/main/java/com/anisync/android/util/ShareUtils.kt
@@ -96,10 +96,10 @@ object ShareUtils {
      * File I/O runs off the main thread; the chooser launch hops back to it.
      */
     suspend fun shareBitmap(context: Context, bitmap: ImageBitmap, text: String? = null) {
-        val uri = withContext(Dispatchers.IO) { writeShareablePng(context, bitmap) }
+        val (uri, mime) = withContext(Dispatchers.IO) { writeShareableImage(context, bitmap) }
 
         val intent = Intent(Intent.ACTION_SEND).apply {
-            type = "image/png"
+            type = mime
             putExtra(Intent.EXTRA_STREAM, uri)
             text?.let { putExtra(Intent.EXTRA_TEXT, it) }
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
@@ -151,14 +151,25 @@ object ShareUtils {
             }
         }
 
-    /** One reusable cache PNG (overwritten each call) exposed as a FileProvider URI. */
-    private fun writeShareablePng(context: Context, bitmap: ImageBitmap): Uri {
+    /**
+     * One reusable cache image (overwritten each call) exposed as a FileProvider URI. Uses WEBP
+     * lossless on API 30+ — smaller than PNG while still preserving the card's rounded transparent
+     * corners — and falls back to PNG below. Returns the URI with its MIME type.
+     */
+    private fun writeShareableImage(context: Context, bitmap: ImageBitmap): Pair<Uri, String> {
         val dir = File(context.cacheDir, "shared").apply { mkdirs() }
-        val file = File(dir, "anisync_share.png")
+        val useWebp = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+        val file = File(dir, if (useWebp) "anisync_share.webp" else "anisync_share.png")
+        val bmp = bitmap.asAndroidBitmap()
         file.outputStream().use { out ->
-            bitmap.asAndroidBitmap().compress(Bitmap.CompressFormat.PNG, 100, out)
+            if (useWebp) {
+                bmp.compress(Bitmap.CompressFormat.WEBP_LOSSLESS, 100, out)
+            } else {
+                bmp.compress(Bitmap.CompressFormat.PNG, 100, out)
+            }
         }
-        return FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+        val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+        return uri to (if (useWebp) "image/webp" else "image/png")
     }
 
     /**

--- a/app/src/main/java/com/anisync/android/util/ShareUtils.kt
+++ b/app/src/main/java/com/anisync/android/util/ShareUtils.kt
@@ -191,22 +191,6 @@ object ShareUtils {
     }
 
     /**
-     * Shares character content using Android's share sheet.
-     */
-    fun shareCharacter(context: Context, name: String, characterId: Int) {
-        val url = AniListUrls.characterUrl(characterId)
-        shareText(context, "$name\n$url")
-    }
-
-    /**
-     * Shares staff content using Android's share sheet.
-     */
-    fun shareStaff(context: Context, name: String, staffId: Int) {
-        val url = AniListUrls.staffUrl(staffId)
-        shareText(context, "$name\n$url")
-    }
-
-    /**
      * Shares studio content using Android's share sheet.
      */
     fun shareStudio(context: Context, name: String, studioId: Int) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1309,4 +1309,7 @@
     <string name="share_toggle_score">Score</string>
     <string name="share_toggle_progress">Progress</string>
     <string name="share_caption_hint">Add a caption (optional)</string>
+    <string name="share_person_character">Character</string>
+    <string name="share_person_staff">Staff</string>
+    <string name="share_known_for">Known for</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1312,4 +1312,11 @@
     <string name="share_person_character">Character</string>
     <string name="share_person_staff">Staff</string>
     <string name="share_known_for">Known for</string>
+    <string name="share_template_stats">Stats</string>
+    <string name="share_template_recap">Recap</string>
+    <string name="share_template_grid">Grid</string>
+    <string name="share_template_ranked">Ranked</string>
+    <string name="share_recap_eyebrow">All-time recap</string>
+    <string name="share_recap_titles">titles</string>
+    <string name="share_recap_top_studio">Most watched studio</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1291,4 +1291,22 @@
     <string name="share_fav_eyebrow">Favourites</string>
     <string name="share_fav_heading_anime">Favourite Anime</string>
     <string name="share_fav_heading_manga">Favourite Manga</string>
+    <!-- Share-card customization sheet -->
+    <string name="share_customize_theme">Theme</string>
+    <string name="share_customize_format">Format</string>
+    <string name="share_customize_template">Style</string>
+    <string name="share_customize_show">Show</string>
+    <string name="share_theme_auto">Auto</string>
+    <string name="share_theme_light">Light</string>
+    <string name="share_theme_dark">Dark</string>
+    <string name="share_theme_amoled">AMOLED</string>
+    <string name="share_theme_cover">Cover</string>
+    <string name="share_format_compact">Compact</string>
+    <string name="share_format_square">Square</string>
+    <string name="share_format_story">Story</string>
+    <string name="share_template_standard">Card</string>
+    <string name="share_template_hero">Poster</string>
+    <string name="share_toggle_score">Score</string>
+    <string name="share_toggle_progress">Progress</string>
+    <string name="share_caption_hint">Add a caption (optional)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1254,7 +1254,6 @@
 
     <!-- Share-as-image cards -->
     <string name="share_as_image">Share image</string>
-    <string name="share_image_preview_title">Preview</string>
     <string name="share_action_save">Save</string>
     <string name="share_action_copy">Copy</string>
     <string name="share_action_share">Share</string>
@@ -1317,6 +1316,7 @@
     <string name="share_template_grid">Grid</string>
     <string name="share_template_ranked">Ranked</string>
     <string name="share_recap_eyebrow">All-time recap</string>
-    <string name="share_recap_titles">titles</string>
+    <string name="share_recap_completed">Completed</string>
     <string name="share_recap_top_studio">Most watched studio</string>
+    <string name="share_recap_top_staff">Most read author</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1253,7 +1253,8 @@
     <string name="rail_collapsed">Navigation collapsed</string>
 
     <!-- Share-as-image cards -->
-    <string name="share_as_image">Share image</string>
+    <string name="share_stats_card">Share stats</string>
+    <string name="share_favourites_card">Share favourites</string>
     <string name="share_action_save">Save</string>
     <string name="share_action_copy">Copy</string>
     <string name="share_action_share">Share</string>

--- a/app/src/test/java/com/anisync/android/domain/ScoreFormatterTest.kt
+++ b/app/src/test/java/com/anisync/android/domain/ScoreFormatterTest.kt
@@ -47,4 +47,38 @@ class ScoreFormatterTest {
         assertEquals(":|", formatScore(2.0, ScoreFormat.POINT_3))
         assertEquals(":)", formatScore(3.0, ScoreFormat.POINT_3))
     }
+
+    // formatCommunityScore: a 0-100 community average re-scaled into the viewer's own format,
+    // used by the share cards' score badge.
+
+    @Test
+    fun `community score hides when absent or zero`() {
+        for (format in ScoreFormat.entries) {
+            assertEquals(null, formatCommunityScore(null, format))
+            assertEquals(null, formatCommunityScore(0, format))
+        }
+    }
+
+    @Test
+    fun `community score converts the 0-100 average into each numeric scale`() {
+        assertEquals("87", formatCommunityScore(87, ScoreFormat.POINT_100))
+        assertEquals("9", formatCommunityScore(87, ScoreFormat.POINT_10))
+        assertEquals("8", formatCommunityScore(83, ScoreFormat.POINT_10))
+        assertEquals("8.7", formatCommunityScore(87, ScoreFormat.POINT_10_DECIMAL))
+    }
+
+    @Test
+    fun `community score rounds to the nearest star count`() {
+        assertEquals("★★★★", formatCommunityScore(87, ScoreFormat.POINT_5))
+        assertEquals("★★★★★", formatCommunityScore(90, ScoreFormat.POINT_5))
+        assertEquals("★★", formatCommunityScore(45, ScoreFormat.POINT_5))
+    }
+
+    @Test
+    fun `community score maps thirds of the scale onto smileys`() {
+        assertEquals(":)", formatCommunityScore(67, ScoreFormat.POINT_3))
+        assertEquals(":|", formatCommunityScore(66, ScoreFormat.POINT_3))
+        assertEquals(":|", formatCommunityScore(34, ScoreFormat.POINT_3))
+        assertEquals(":(", formatCommunityScore(33, ScoreFormat.POINT_3))
+    }
 }


### PR DESCRIPTION
Reworks the capturable share cards into a fully customizable system and expands where they are available.

**Customization**
- Theme: Auto / Light / Dark / AMOLED / Cover (artwork-seeded) - forced themes re-derive the app's own palette, so only brightness changes, never the hue
- Format: Compact, Square and Story canvases with a soft gradient backdrop frame
- Per-card styles: media Card/Poster, stats Stats/Recap (type-aware), favourites Grid/Ranked
- Privacy toggles (hide score / progress), optional baked caption, and the score badge rendered in the viewer's own AniList score format

**New cards**
- Character and staff cards with a Known-for strip; staff details now fetch Staff.characters(sort: FAVOURITES_DESC) so a VA's most iconic characters lead - the characterMedia grid can only sort by media, which made the old order feel irrelevant

**Presentation**
- The customizer opens as a full-screen overlay over the blurred app (window blur-behind where the device supports it, tinted-veil fallback elsewhere); preview, controls, caption and actions form one scrolling flow, width-capped on large screens
- Fixed-resolution capture (1080 px) so exports are crisp on every density; WEBP-lossless share path

**Misc**
- Library view-options List/Grid switch migrated to the shared SegmentedTabGroup
- Context-specific share buttons on the profile Stats and Favourites tabs
- Unit tests for the community-score formatter

Verified on a physical S21+ (blur-fallback path) and the Pixel emulator in phone and tablet form (real window blur).