### PR TITLE
feat(library): show eps behind and next episode together on cards

### DIFF
--- a/app/src/main/java/com/anisync/android/presentation/components/AiringCountdownText.kt
+++ b/app/src/main/java/com/anisync/android/presentation/components/AiringCountdownText.kt
@@ -1,0 +1,97 @@
+package com.anisync.android.presentation.components
+
+import androidx.compose.foundation.MarqueeSpacing
+import androidx.compose.foundation.basicMarquee
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+private val FadeEdgeWidth = 12.dp
+
+/**
+ * Scrolls the content sideways when it is wider than the space it was given, and leaves it alone
+ * when it fits. Library cards use it to keep the "episodes behind" badge and the next-episode
+ * countdown both readable on a narrow grid card instead of truncating either one.
+ *
+ * The trailing fade is drawn only while scrolling, so content that fits keeps its last few pixels
+ * at full opacity.
+ */
+fun Modifier.scrollWhenTooWide(): Modifier = composed {
+    // Written during measure and read only from the draw lambdas below, so a change invalidates
+    // drawing rather than recomposing the caller.
+    var tooWide by remember { mutableStateOf(false) }
+
+    Modifier
+        // Offscreen so the fade masks the content alone, not whatever sits beneath it.
+        .graphicsLayer {
+            compositingStrategy =
+                if (tooWide) CompositingStrategy.Offscreen else CompositingStrategy.Auto
+        }
+        .drawWithContent {
+            drawContent()
+            if (!tooWide) return@drawWithContent
+            val edge = FadeEdgeWidth.toPx()
+            drawRect(
+                topLeft = Offset(size.width - edge, 0f),
+                size = Size(edge, size.height),
+                brush = Brush.horizontalGradient(
+                    colors = listOf(Color.Transparent, Color.Black),
+                    startX = size.width,
+                    endX = size.width - edge
+                ),
+                blendMode = BlendMode.DstIn
+            )
+        }
+        .layout { measurable, constraints ->
+            tooWide = measurable.maxIntrinsicWidth(constraints.maxHeight) > constraints.maxWidth
+            val placeable = measurable.measure(constraints)
+            layout(placeable.width, placeable.height) { placeable.place(0, 0) }
+        }
+        .basicMarquee(
+            iterations = Int.MAX_VALUE,
+            repeatDelayMillis = 2000,
+            initialDelayMillis = 1500,
+            spacing = MarqueeSpacing(16.dp)
+        )
+}
+
+/**
+ * The "Ep 12 in 3d" countdown, sized to sit on one line beside the "episodes behind" badge. It
+ * scrolls rather than truncates when a many-column grid, a long locale or a large font scale leaves
+ * it too little room, and stays still in the common case where it fits.
+ */
+@Composable
+fun AiringCountdownText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.onSurfaceVariant
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodySmall,
+        fontSize = 10.sp,
+        color = color,
+        maxLines = 1,
+        softWrap = false,
+        overflow = TextOverflow.Clip,
+        modifier = modifier.scrollWhenTooWide()
+    )
+}

--- a/app/src/main/java/com/anisync/android/presentation/components/LibraryMediaCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/components/LibraryMediaCard.kt
@@ -2,28 +2,22 @@ package com.anisync.android.presentation.components
 
 import com.anisync.android.domain.url
 
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
-import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -44,11 +38,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -67,7 +57,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
-import kotlinx.coroutines.delay
 import com.anisync.android.R
 import com.anisync.android.data.AppSettings
 import com.anisync.android.data.TitleLanguage
@@ -117,18 +106,6 @@ val CompletedCardConfig = LibraryCardConfig(
     showBehindBadge = false,
     showMetadata = false
 )
-
-private const val STATUS_ROTATE_INTERVAL_MS = 3000L
-
-/**
- * One rotating status chip shown under the cover: either the "episodes behind" badge or the
- * next-airing countdown. On a narrow grid card both can't sit side by side without squeezing the
- * airing time out of view, so we cross-fade between them instead.
- */
-private sealed interface CardStatusSlot {
-    data class Behind(val text: String) : CardStatusSlot
-    data class Airing(val text: String) : CardStatusSlot
-}
 
 /**
  * A reusable media card for library screens.
@@ -338,59 +315,29 @@ fun LibraryMediaCard(
                             )
                         } else null
 
-                    // Both pieces would overflow a narrow grid card and push the airing time out of
-                    // view, so when both are present rotate between them with a cross-fade.
-                    val slots = remember(behindText, airingText) {
-                        buildList {
-                            behindText?.let { add(CardStatusSlot.Behind(it)) }
-                            airingText?.let { add(CardStatusSlot.Airing(it)) }
-                        }
-                    }
-
-                    var slotIndex by remember { mutableIntStateOf(0) }
-                    LaunchedEffect(slots.size) {
-                        slotIndex = 0
-                        if (slots.size > 1) {
-                            while (true) {
-                                delay(STATUS_ROTATE_INTERVAL_MS)
-                                slotIndex = (slotIndex + 1) % slots.size
-                            }
-                        }
-                    }
-
-                    Box(
-                        contentAlignment = Alignment.CenterStart,
-                        modifier = Modifier.height(20.dp) // Reserve fixed height matching badge/text
+                    // Both stay on screen. They sit side by side while the card is wide enough and
+                    // drop onto a second line when a many-column grid makes it too narrow, rather
+                    // than the badge clipping the countdown out of view. The min height keeps card
+                    // heights aligned across the grid when neither piece applies.
+                    FlowRow(
+                        itemVerticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                        maxLines = 2,
+                        modifier = Modifier.heightIn(min = 20.dp)
                     ) {
-                        val current = if (slots.isEmpty()) null else slots[slotIndex % slots.size]
-                        AnimatedContent(
-                            targetState = current,
-                            // Only animate when the kind of chip changes, not when the airing label ticks.
-                            contentKey = { it?.let { slot -> slot::class } },
-                            transitionSpec = {
-                                val anim = tween<Float>(durationMillis = 320)
-                                (fadeIn(anim) + slideInVertically(tween(320)) { it / 2 }) togetherWith
-                                    (fadeOut(anim) + slideOutVertically(tween(320)) { -it / 2 }) using
-                                    SizeTransform(clip = false)
-                            },
-                            label = "StatusRotator"
-                        ) { slot ->
-                            when (slot) {
-                                is CardStatusSlot.Behind -> StatusBadge(
-                                    slot.text,
-                                    MaterialTheme.colorScheme.error,
-                                    MaterialTheme.colorScheme.onError
-                                )
-                                is CardStatusSlot.Airing -> Text(
-                                    text = slot.text,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    fontSize = 10.sp,
-                                    color = MaterialTheme.colorScheme.onSurface,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis
-                                )
-                                null -> Spacer(Modifier.size(0.dp))
-                            }
+                        if (behindText != null) {
+                            StatusBadge(
+                                behindText,
+                                MaterialTheme.colorScheme.error,
+                                MaterialTheme.colorScheme.onError
+                            )
+                        }
+                        if (airingText != null) {
+                            AiringCountdownText(
+                                text = airingText,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
                         }
                     }
                     Spacer(modifier = Modifier.height(8.dp))
@@ -617,7 +564,6 @@ private fun mockEntry(
     )
 }
 
-// Simplified mock StatusBadge for preview context if it's not available in this file scope
 @Composable
 private fun StatusBadge(text: String, containerColor: Color, contentColor: Color) {
     Surface(
@@ -627,8 +573,15 @@ private fun StatusBadge(text: String, containerColor: Color, contentColor: Color
     ) {
         Text(
             text = text,
-            modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp),
-            style = MaterialTheme.typography.labelSmall
+            modifier = Modifier
+                .padding(horizontal = 4.dp, vertical = 2.dp)
+                .scrollWhenTooWide(),
+            style = MaterialTheme.typography.labelSmall,
+            // A many-column grid can squeeze the badge past its text; scroll it instead of
+            // stacking letters down the card.
+            maxLines = 1,
+            softWrap = false,
+            overflow = TextOverflow.Clip
         )
     }
 }
@@ -674,6 +627,26 @@ private fun PreviewLibraryCardUpToDate() {
             .width(200.dp)) {
             LibraryMediaCard(
                 entry = mockEntry(progress = 11, total = 24, nextAiring = 12),
+                mediaType = MediaType.ANIME,
+                titleLanguage = TitleLanguage.ROMAJI,
+                onClick = {},
+                config = WatchingCardConfig,
+                onIncrement = {},
+                onDecrement = {}
+            )
+        }
+    }
+}
+
+@Preview(name = "Anime - Behind (Narrow)", showBackground = true)
+@Composable
+private fun PreviewLibraryCardWatchingBehindNarrow() {
+    PreviewMediaCardTheme {
+        Box(modifier = Modifier
+            .padding(16.dp)
+            .width(140.dp)) {
+            LibraryMediaCard(
+                entry = mockEntry(progress = 108, total = 1200, nextAiring = 120),
                 mediaType = MediaType.ANIME,
                 titleLanguage = TitleLanguage.ROMAJI,
                 onClick = {},

--- a/app/src/main/java/com/anisync/android/presentation/library/components/LibraryListCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/library/components/LibraryListCard.kt
@@ -62,6 +62,7 @@ import com.anisync.android.data.TitleLanguage
 import com.anisync.android.domain.LibraryEntry
 import com.anisync.android.domain.LibraryStatus
 import com.anisync.android.domain.ScoreFormat
+import com.anisync.android.presentation.components.AiringCountdownText
 import com.anisync.android.presentation.components.CompletedCardConfig
 import com.anisync.android.presentation.components.ScoreChip
 import com.anisync.android.presentation.components.LibraryCardConfig
@@ -271,17 +272,13 @@ fun LibraryListCard(
                         }
 
                         if (config.showAiringInfo && entry.dynamicTimeUntilAiring != null && entry.nextAiringEpisode != null) {
-                            Text(
+                            AiringCountdownText(
                                 text = stringResource(
                                     R.string.airing_episode_in,
                                     entry.nextAiringEpisode ?: 0,
                                     formatTimeUntilAiring(entry.dynamicTimeUntilAiring ?: 0)
                                 ),
-                                style = MaterialTheme.typography.bodySmall,
-                                fontSize = 10.sp,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
+                                modifier = Modifier.weight(1f)
                             )
                         }
                     }
@@ -458,7 +455,10 @@ private fun StatusBadge(text: String, containerColor: Color, contentColor: Color
             modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
             style = MaterialTheme.typography.labelSmall,
             fontWeight = FontWeight.Bold,
-            fontSize = 10.sp
+            fontSize = 10.sp,
+            maxLines = 1,
+            softWrap = false,
+            overflow = TextOverflow.Clip
         )
     }
 }


### PR DESCRIPTION
Closes #102

## Problem

Library grid cards rotated between the "episodes behind" badge and the next-episode countdown on a 3 second timer, each card running on its own phase. Only one of the two was ever readable, and the unsynchronised swapping was distracting while scanning the list.

## Change

Both pieces now stay on screen at the same time. The countdown scrolls itself into view when it does not fit rather than being truncated.

- New `AiringCountdownText.kt` with `Modifier.scrollWhenTooWide()`. It compares the content's intrinsic width against the space it was given and only then enables `basicMarquee` plus a trailing fade. Content that fits renders untouched, with no animation and no offscreen compositing layer.
- `LibraryMediaCard` drops the `CardStatusSlot` rotator for a `FlowRow`. Badge and countdown sit side by side while the card is wide enough and drop onto a second line when a many-column grid makes it too narrow. The badge is single line and scrolls instead of stacking letters vertically, which it did at four columns or more.
- `LibraryListCard` uses the same countdown component, so it scrolls instead of ellipsising when a score chip and a long badge crowd the row.
