### PR TITLE
feat(notifications): unread indicator in the inbox

### DIFF
--- a/app/src/main/java/com/anisync/android/data/NotificationBadgeStore.kt
+++ b/app/src/main/java/com/anisync/android/data/NotificationBadgeStore.kt
@@ -13,10 +13,10 @@ import javax.inject.Singleton
 /**
  * Holds the authenticated viewer's unread-notification count for the
  * inbox badge. Source of truth is AniList's `Viewer.unreadNotificationCount`,
- * but writers can clear it optimistically when the inbox opens (server
- * resets it via `resetNotificationCount=true` on the next notifications
- * fetch) and debug callers can bump it locally so the UI is testable
- * without waiting for real notifications.
+ * but writers can clear it optimistically when the user marks the inbox read
+ * (the server reset rides along on that same action's notifications fetch,
+ * via `resetNotificationCount=true`) and debug callers can bump it locally so
+ * the UI is testable without waiting for real notifications.
  */
 @Singleton
 class NotificationBadgeStore @Inject constructor(
@@ -29,21 +29,13 @@ class NotificationBadgeStore @Inject constructor(
      * Local-only count for debug testing. Decoupled from the server
      * count so refreshes don't clobber a fake bump — that would mask
      * the persistence behaviour we want the test to exercise (real
-     * unreads only clear when the inbox is opened, never on a plain
-     * profile resume).
+     * unreads only clear when the user marks them read, never on a plain
+     * profile resume or a visit to the inbox).
      */
     private val _debugCount = MutableStateFlow(0)
 
     private val _unreadCount = MutableStateFlow(0)
     val unreadCount: StateFlow<Int> = _unreadCount.asStateFlow()
-
-    /**
-     * What the last clear wiped, held for the inbox.
-     *
-     * The inbox marks its unread rows from this number and cannot always read [unreadCount] itself:
-     * tapping the bell on Profile clears the badge before the inbox view model is constructed.
-     */
-    private var pendingInboxCount = 0
 
     /**
      * Update from a count already obtained out-of-band (e.g. piggy-backed on
@@ -77,32 +69,15 @@ class NotificationBadgeStore @Inject constructor(
      * test cycle (bump → open inbox) returns to the zero state cleanly.
      */
     fun clearOptimistically() {
-        // Only a real count overwrites it, so clearing twice on the way into the inbox (Profile
-        // first, then the inbox itself) cannot wipe the number the inbox still needs.
-        if (_unreadCount.value > 0) pendingInboxCount = _unreadCount.value
         _serverCount.value = 0
         _debugCount.value = 0
         recompute()
-    }
-
-    /**
-     * The count the inbox draws its unread boundary from, and the clear that goes with opening it.
-     *
-     * Consumed on read: a second visit with nothing new in between gets zero, so the same rows are
-     * never marked new twice.
-     */
-    fun takeUnreadAtOpen(): Int {
-        val value = if (_unreadCount.value > 0) _unreadCount.value else pendingInboxCount
-        clearOptimistically()
-        pendingInboxCount = 0
-        return value
     }
 
     /** Clears all counts when switching accounts so the badge doesn't carry over. */
     fun reset() {
         _serverCount.value = 0
         _debugCount.value = 0
-        pendingInboxCount = 0
         recompute()
     }
 

--- a/app/src/main/java/com/anisync/android/data/NotificationBadgeStore.kt
+++ b/app/src/main/java/com/anisync/android/data/NotificationBadgeStore.kt
@@ -38,6 +38,14 @@ class NotificationBadgeStore @Inject constructor(
     val unreadCount: StateFlow<Int> = _unreadCount.asStateFlow()
 
     /**
+     * What the last clear wiped, held for the inbox.
+     *
+     * The inbox marks its unread rows from this number and cannot always read [unreadCount] itself:
+     * tapping the bell on Profile clears the badge before the inbox view model is constructed.
+     */
+    private var pendingInboxCount = 0
+
+    /**
      * Update from a count already obtained out-of-band (e.g. piggy-backed on
      * a `GetUserProfile` query that included `Viewer.unreadNotificationCount`).
      * Lets us skip the separate `GetViewer` round-trip when the profile
@@ -69,15 +77,32 @@ class NotificationBadgeStore @Inject constructor(
      * test cycle (bump → open inbox) returns to the zero state cleanly.
      */
     fun clearOptimistically() {
+        // Only a real count overwrites it, so clearing twice on the way into the inbox (Profile
+        // first, then the inbox itself) cannot wipe the number the inbox still needs.
+        if (_unreadCount.value > 0) pendingInboxCount = _unreadCount.value
         _serverCount.value = 0
         _debugCount.value = 0
         recompute()
+    }
+
+    /**
+     * The count the inbox draws its unread boundary from, and the clear that goes with opening it.
+     *
+     * Consumed on read: a second visit with nothing new in between gets zero, so the same rows are
+     * never marked new twice.
+     */
+    fun takeUnreadAtOpen(): Int {
+        val value = if (_unreadCount.value > 0) _unreadCount.value else pendingInboxCount
+        clearOptimistically()
+        pendingInboxCount = 0
+        return value
     }
 
     /** Clears all counts when switching accounts so the badge doesn't carry over. */
     fun reset() {
         _serverCount.value = 0
         _debugCount.value = 0
+        pendingInboxCount = 0
         recompute()
     }
 

--- a/app/src/main/java/com/anisync/android/presentation/components/CollapsingTopBarScaffold.kt
+++ b/app/src/main/java/com/anisync/android/presentation/components/CollapsingTopBarScaffold.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -23,6 +24,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.filled.Close
@@ -102,6 +104,7 @@ fun CollapsingTopBarScaffold(
     scrolledContainerColor: Color = MaterialTheme.colorScheme.surfaceContainer,
     navigationIcon: ImageVector = Icons.AutoMirrored.Outlined.ArrowBack,
     actions: @Composable RowScope.() -> Unit = {},
+    titleTrailing: (@Composable () -> Unit)? = null,
     belowBar: (@Composable () -> Unit)? = null,
     bottomBar: @Composable () -> Unit = {},
     floatingActionButton: @Composable () -> Unit = {},
@@ -276,6 +279,7 @@ fun CollapsingTopBarScaffold(
                 scrolledContainerColor = scrolledContainerColor,
                 navigationIcon = navigationIcon,
                 actions = actions,
+                titleTrailing = titleTrailing,
             )
 
             Box(
@@ -309,6 +313,8 @@ fun CollapsibleCommonTopBar(
     scrolledContainerColor: Color = MaterialTheme.colorScheme.surfaceContainer,
     navigationIcon: ImageVector = Icons.AutoMirrored.Outlined.ArrowBack,
     actions: @Composable RowScope.() -> Unit = {},
+    /** Optional content beside the title, e.g. a count pill. Follows the title as the bar shrinks. */
+    titleTrailing: (@Composable () -> Unit)? = null,
     maxLines: Int = 2,
     expandedTitleStartPadding: Dp = 16.dp,
     collapsedTitleStartPadding: Dp = 68.dp,
@@ -396,22 +402,38 @@ fun CollapsibleCommonTopBar(
             val titleBottomPadding =
                 androidx.compose.ui.unit.lerp(16.dp, 24.dp, collapseFraction)
 
-            Text(
-                text = title,
-                fontSize = titleFontSize,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = if (collapseFraction > 0.8f) 1 else maxLines,
-                overflow = TextOverflow.Ellipsis,
-                lineHeight = titleFontSize * 1.2f,
-                modifier = Modifier
-                    .align(Alignment.BottomStart)
-                    .padding(
-                        start = titleStartPadding,
-                        end = titleEndPadding,
-                        bottom = titleBottomPadding
-                    )
-            )
+            val titleText: @Composable (Modifier) -> Unit = { textModifier ->
+                Text(
+                    text = title,
+                    fontSize = titleFontSize,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = if (collapseFraction > 0.8f) 1 else maxLines,
+                    overflow = TextOverflow.Ellipsis,
+                    lineHeight = titleFontSize * 1.2f,
+                    modifier = textModifier
+                )
+            }
+            val titleModifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(
+                    start = titleStartPadding,
+                    end = titleEndPadding,
+                    bottom = titleBottomPadding
+                )
+
+            if (titleTrailing == null) {
+                titleText(titleModifier)
+            } else {
+                Row(
+                    modifier = titleModifier,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    titleText(Modifier.weight(1f, fill = false))
+                    Spacer(modifier = Modifier.width(12.dp))
+                    titleTrailing()
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/anisync/android/presentation/notifications/NotificationEntry.kt
+++ b/app/src/main/java/com/anisync/android/presentation/notifications/NotificationEntry.kt
@@ -19,7 +19,9 @@ data class NotificationEntry(
     val key: String,
     val representative: Notification,
     val all: List<Notification>,
-    val actors: List<User>
+    val actors: List<User>,
+    /** Inside the unread window captured when the inbox opened. See [unreadWindow]. */
+    val isUnread: Boolean = false
 ) {
     val count: Int get() = all.size
     val isGrouped: Boolean get() = count > 1

--- a/app/src/main/java/com/anisync/android/presentation/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/notifications/NotificationsScreen.kt
@@ -1,19 +1,24 @@
 package com.anisync.android.presentation.notifications
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.outlined.Settings
 import com.anisync.android.presentation.components.AppCircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -21,6 +26,7 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
@@ -31,8 +37,15 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.anisync.android.R
@@ -62,6 +75,12 @@ fun NotificationsScreen(
     val listState = rememberLazyListState()
     val pullState = rememberPullToRefreshState()
 
+    // Unread rows are always the newest run, so the split is a prefix rather than a filter.
+    val newEntries = remember(uiState.entries) { uiState.entries.takeWhile { it.isUnread } }
+    val earlierEntries = remember(uiState.entries, newEntries) {
+        uiState.entries.drop(newEntries.size)
+    }
+
     val shouldLoadMore by remember {
         derivedStateOf {
             val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
@@ -72,6 +91,18 @@ fun NotificationsScreen(
         if (shouldLoadMore && uiState.entries.isNotEmpty() && uiState.hasNextPage) {
             viewModel.onAction(NotificationsAction.LoadNextPage)
         }
+    }
+
+    val notificationCard: @Composable (NotificationEntry) -> Unit = { entry ->
+        NotificationGroupCard(
+            entry = entry,
+            onMediaClick = onMediaClick,
+            onUserClick = onUserClick,
+            onActivityClick = onActivityClick,
+            onThreadClick = onThreadClick,
+            selectedTarget = selectedTarget,
+            isUnread = entry.isUnread
+        )
     }
 
     CollapsingTopBarScaffold(
@@ -87,6 +118,11 @@ fun NotificationsScreen(
                     contentDescription = stringResource(R.string.settings_notifications)
                 )
             }
+        },
+        titleTrailing = if (newEntries.isNotEmpty()) {
+            { NewCountPill(count = newEntries.size) }
+        } else {
+            null
         },
         belowBar = {
             FilterChipsRow(
@@ -152,15 +188,35 @@ fun NotificationsScreen(
                         ),
                         verticalArrangement = Arrangement.spacedBy(10.dp)
                     ) {
-                        items(uiState.entries, key = { it.key }) { entry ->
-                            NotificationGroupCard(
-                                entry = entry,
-                                onMediaClick = onMediaClick,
-                                onUserClick = onUserClick,
-                                onActivityClick = onActivityClick,
-                                onThreadClick = onThreadClick,
-                                selectedTarget = selectedTarget
-                            )
+                        if (newEntries.isNotEmpty()) {
+                            item(key = "section_new") {
+                                NotificationSectionHeader(
+                                    label = stringResource(R.string.notifications_section_new),
+                                    color = MaterialTheme.colorScheme.primary
+                                ) {
+                                    MarkAllReadButton(
+                                        onClick = {
+                                            viewModel.onAction(NotificationsAction.MarkAllRead)
+                                        }
+                                    )
+                                }
+                            }
+                            items(newEntries, key = { it.key }) { entry ->
+                                notificationCard(entry)
+                            }
+                            if (earlierEntries.isNotEmpty()) {
+                                item(key = "section_earlier") {
+                                    NotificationSectionHeader(
+                                        label = stringResource(
+                                            R.string.notifications_section_earlier
+                                        ),
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
+                        }
+                        items(earlierEntries, key = { it.key }) { entry ->
+                            notificationCard(entry)
                         }
                         if (uiState.isPaginating) {
                             item(key = "paginating") {
@@ -178,6 +234,85 @@ fun NotificationsScreen(
                 }
             }
         }
+    }
+}
+
+/** "2 new" beside the screen title. Counts the rows on screen, so filtering narrows it. */
+@Composable
+private fun NewCountPill(count: Int) {
+    val amount = if (count > 99) {
+        stringResource(R.string.notifications_new_count_overflow)
+    } else {
+        count.toString()
+    }
+    Surface(
+        color = MaterialTheme.colorScheme.primaryContainer,
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        shape = RoundedCornerShape(50)
+    ) {
+        Text(
+            text = stringResource(R.string.notifications_new_count, amount),
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 5.dp)
+        )
+    }
+}
+
+/**
+ * NEW / EARLIER divider. The 10dp above and below lands on the design's 20dp once the list's own
+ * 10dp item spacing is added.
+ */
+@Composable
+private fun NotificationSectionHeader(
+    label: String,
+    color: Color,
+    modifier: Modifier = Modifier,
+    trailing: (@Composable () -> Unit)? = null
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label.uppercase(),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            letterSpacing = 1.4.sp,
+            color = color,
+            modifier = Modifier
+                .weight(1f)
+                .semantics { heading() }
+        )
+        trailing?.invoke()
+    }
+}
+
+/** Sits next to what it acts on rather than in the app bar, and only exists while a NEW run does. */
+@Composable
+private fun MarkAllReadButton(onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(50))
+            .clickable(role = Role.Button, onClick = onClick)
+            .padding(horizontal = 10.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.Default.Check,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(18.dp)
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = stringResource(R.string.notifications_mark_all_read),
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.primary
+        )
     }
 }
 

--- a/app/src/main/java/com/anisync/android/presentation/notifications/NotificationsUiState.kt
+++ b/app/src/main/java/com/anisync/android/presentation/notifications/NotificationsUiState.kt
@@ -12,11 +12,19 @@ data class NotificationsUiState(
     val isPaginating: Boolean = false,
     val hasNextPage: Boolean = true,
     val errorMessage: String? = null
-)
+) {
+    /**
+     * Unread rows in the list currently on screen, which is what the count beside the title shows.
+     * Filtering narrows it, so the pill and the New section always agree. The inbox-wide count
+     * stays on the Profile tab badge.
+     */
+    val newCount: Int get() = entries.count { it.isUnread }
+}
 
 sealed interface NotificationsAction {
     data class SetFilter(val filter: NotificationFilter) : NotificationsAction
     data object Refresh : NotificationsAction
     data object LoadNextPage : NotificationsAction
     data object Retry : NotificationsAction
+    data object MarkAllRead : NotificationsAction
 }

--- a/app/src/main/java/com/anisync/android/presentation/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/notifications/NotificationsViewModel.kt
@@ -39,11 +39,22 @@ class NotificationsViewModel @Inject constructor(
 
     private val snapshots = mutableMapOf<NotificationFilter, FilterSnapshot>()
 
+    /**
+     * How many rows were unread when the inbox opened. AniList has no per-notification read flag,
+     * only this count, so it has to be captured before the first page load resets it server-side.
+     *
+     * Taking it also clears the badge, on any entry into the inbox (profile bell, deep link, system
+     * notification tap) rather than just the profile path. The ALL first-page load below asks the
+     * server to reset its count too, so the next badge refresh agrees.
+     */
+    private val unreadAtOpen = badgeStore.takeUnreadAtOpen()
+
+    private var unreadIds: Set<Int> = emptySet()
+
+    /** Stops a later page or refresh from re-seeding a window the user already dismissed. */
+    private var boundaryCleared = false
+
     init {
-        // Clear the unread badge on any entry into the inbox (profile bell, deep link, system
-        // notification tap) — not just the profile path. The ALL first-page load below asks the
-        // server to reset its count too, so the next badge refresh agrees.
-        badgeStore.clearOptimistically()
         load(reset = true, isInitial = true)
     }
 
@@ -57,6 +68,22 @@ class NotificationsViewModel @Inject constructor(
                 load(reset = false, isInitial = false)
             }
             NotificationsAction.Retry -> load(reset = true, isInitial = true)
+            NotificationsAction.MarkAllRead -> markAllRead()
+        }
+    }
+
+    private fun markAllRead() {
+        if (unreadIds.isEmpty()) return
+        unreadIds = emptySet()
+        boundaryCleared = true
+        applyUnread()
+    }
+
+    /** Re-flags the visible list and every cached filter, so switching back shows the same state. */
+    private fun applyUnread() {
+        _uiState.update { it.copy(entries = it.entries.markUnread(unreadIds)) }
+        for ((filter, snapshot) in snapshots.toList()) {
+            snapshots[filter] = snapshot.copy(entries = snapshot.entries.markUnread(unreadIds))
         }
     }
 
@@ -82,7 +109,7 @@ class NotificationsViewModel @Inject constructor(
                 it.copy(
                     filter = filter,
                     items = cached.items,
-                    entries = cached.entries,
+                    entries = cached.entries.markUnread(unreadIds),
                     hasNextPage = cached.hasNextPage,
                     isLoading = false,
                     isRefreshing = false,
@@ -149,10 +176,16 @@ class NotificationsViewModel @Inject constructor(
                         if (reset) page.items
                         else (state.items + page.items).distinctBy { it.id }
                     val grouped = withContext(Dispatchers.Default) { groupNotifications(merged) }
+                    // Seeded off the unfiltered list only: a filtered page is a subset of the same
+                    // ids, so widening the window from it would mark rows the inbox never counted.
+                    if (filter == NotificationFilter.ALL && !boundaryCleared) {
+                        unreadIds = unreadWindow(unreadIds, merged, unreadAtOpen)
+                    }
+                    val flagged = grouped.markUnread(unreadIds)
                     _uiState.update {
                         it.copy(
                             items = merged,
-                            entries = grouped,
+                            entries = flagged,
                             isLoading = false,
                             isRefreshing = false,
                             isPaginating = false,
@@ -162,7 +195,7 @@ class NotificationsViewModel @Inject constructor(
                     }
                     snapshots[filter] = FilterSnapshot(
                         items = merged,
-                        entries = grouped,
+                        entries = flagged,
                         nextPage = if (page.hasNextPage) nextPage + 1 else nextPage,
                         hasNextPage = page.hasNextPage
                     )

--- a/app/src/main/java/com/anisync/android/presentation/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/notifications/NotificationsViewModel.kt
@@ -41,13 +41,12 @@ class NotificationsViewModel @Inject constructor(
 
     /**
      * How many rows were unread when the inbox opened. AniList has no per-notification read flag,
-     * only this count, so it has to be captured before the first page load resets it server-side.
+     * only this count, so the newest [unreadAtOpen] rows are the ones marked new.
      *
-     * Taking it also clears the badge, on any entry into the inbox (profile bell, deep link, system
-     * notification tap) rather than just the profile path. The ALL first-page load below asks the
-     * server to reset its count too, so the next badge refresh agrees.
+     * Reading it leaves it alone. Opening the inbox no longer counts as reading anything, so the
+     * same rows stay marked across visits until the user taps Mark all read.
      */
-    private val unreadAtOpen = badgeStore.takeUnreadAtOpen()
+    private val unreadAtOpen = badgeStore.unreadCount.value
 
     private var unreadIds: Set<Int> = emptySet()
 
@@ -72,11 +71,20 @@ class NotificationsViewModel @Inject constructor(
         }
     }
 
+    /**
+     * The only thing that marks the inbox read. AniList has no mutation for it: the count resets as
+     * a side effect of a notifications query, so this fires a throwaway first page carrying the
+     * flag. The badge is zeroed locally straight away and the next refresh reconciles.
+     */
     private fun markAllRead() {
         if (unreadIds.isEmpty()) return
         unreadIds = emptySet()
         boundaryCleared = true
         applyUnread()
+        badgeStore.clearOptimistically()
+        viewModelScope.launch {
+            getNotifications.getPage(page = 1, typeFilter = null, resetUnreadCount = true)
+        }
     }
 
     /** Re-flags the visible list and every cached filter, so switching back shows the same state. */
@@ -153,14 +161,14 @@ class NotificationsViewModel @Inject constructor(
         }
 
         val filter = _uiState.value.filter
-        // Reset unread count only on first page load with the All filter (matches AniList web behavior).
-        val resetUnread = reset && filter == NotificationFilter.ALL
 
         loadJob = viewModelScope.launch {
+            // Never resets the unread count. Reading the inbox is not the same as reading the
+            // notifications in it, and a reset here would leave Mark all read with nothing to do.
             val result = getNotifications.getPage(
                 page = nextPage,
                 typeFilter = filter.types,
-                resetUnreadCount = resetUnread
+                resetUnreadCount = false
             )
             // Late response from a previous filter — drop it.
             if (_uiState.value.filter != filter) return@launch

--- a/app/src/main/java/com/anisync/android/presentation/notifications/UnreadWindow.kt
+++ b/app/src/main/java/com/anisync/android/presentation/notifications/UnreadWindow.kt
@@ -1,0 +1,31 @@
+package com.anisync.android.presentation.notifications
+
+import com.anisync.android.domain.Notification
+
+/**
+ * Which notifications count as unread.
+ *
+ * AniList has no per-notification read flag, only `Viewer.unreadNotificationCount`, so the unread
+ * set is the newest [count] rows as they stood the moment the inbox opened. That number is read off
+ * [com.anisync.android.data.NotificationBadgeStore] before the first page load asks the server to
+ * reset it, which is why nothing new has to be fetched.
+ *
+ * The result is unioned with [previous] and never shrinks. Two cases depend on that: a first page
+ * shorter than [count] widens the window as later pages arrive, and a notification that lands
+ * mid-visit joins the window instead of pushing the oldest unread row back to read while the user
+ * is looking at it.
+ */
+fun unreadWindow(previous: Set<Int>, newestFirst: List<Notification>, count: Int): Set<Int> {
+    if (count <= 0) return previous
+    return previous + newestFirst.take(count).map { it.id }
+}
+
+/**
+ * Flags the rows holding an unread notification. A fold of likes or replies is unread when any
+ * member is, and since members are always older than the representative, unread rows stay a prefix
+ * of the list.
+ */
+fun List<NotificationEntry>.markUnread(unreadIds: Set<Int>): List<NotificationEntry> = map { entry ->
+    val unread = unreadIds.isNotEmpty() && entry.all.any { it.id in unreadIds }
+    if (unread == entry.isUnread) entry else entry.copy(isUnread = unread)
+}

--- a/app/src/main/java/com/anisync/android/presentation/notifications/components/NotificationGroupCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/notifications/components/NotificationGroupCard.kt
@@ -43,11 +43,15 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.anisync.android.R
 import com.anisync.android.ui.theme.emphasis
 import com.anisync.android.domain.ActivityKind
 import com.anisync.android.domain.ActivityLikeNotification
@@ -87,12 +91,21 @@ fun NotificationGroupCard(
     modifier: Modifier = Modifier,
     // The target open in the two-pane detail (or null). When this card resolves to that target it
     // shows the Material 3 selection ring (two-pane only).
-    selectedTarget: NotificationTarget? = null
+    selectedTarget: NotificationTarget? = null,
+    // Inside the unread window captured when the inbox opened: one step brighter container, and a
+    // dot beside a primary-coloured timestamp.
+    isUnread: Boolean = false
 ) {
     val payload = entry.toPayload()
     // Moderation notes (data change / merge / deletion reasons) can be long; the card expands in
     // place instead of navigating, and the cover thumb keeps the media-details click.
     var expanded by rememberSaveable(entry.key) { mutableStateOf(false) }
+    val containerColor = if (isUnread) {
+        MaterialTheme.colorScheme.surfaceContainerHigh
+    } else {
+        MaterialTheme.colorScheme.surfaceContainerLow
+    }
+    val unreadLabel = stringResource(R.string.a11y_notification_unread)
     Card(
         onClick = {
             if (payload.expandableNote) {
@@ -104,10 +117,13 @@ fun NotificationGroupCard(
         modifier = modifier
             .fillMaxWidth()
             .animateContentSize()
-            .selectedPaneItem(payload.isSelectedBy(selectedTarget), MaterialTheme.shapes.large),
+            .selectedPaneItem(payload.isSelectedBy(selectedTarget), MaterialTheme.shapes.large)
+            // State rather than a description prefix, so TalkBack says "Unread" before the content
+            // and the dot itself stays decorative.
+            .semantics { if (isUnread) stateDescription = unreadLabel },
         shape = MaterialTheme.shapes.large,
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+            containerColor = containerColor,
             contentColor = MaterialTheme.colorScheme.onSurface
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
@@ -120,6 +136,7 @@ fun NotificationGroupCard(
                 entry = entry,
                 payload = payload,
                 expanded = expanded,
+                isUnread = isUnread,
                 onMediaClick = onMediaClick
             )
         } else {
@@ -128,10 +145,39 @@ fun NotificationGroupCard(
                 entry = entry,
                 payload = payload,
                 expanded = expanded,
+                isUnread = isUnread,
+                containerColor = containerColor,
                 onMediaClick = onMediaClick,
                 onUserClick = onUserClick
             )
         }
+    }
+}
+
+/**
+ * Timestamp, and for an unread row the 8dp dot that goes with it. The dot sits inside the same
+ * cluster and shares its colour so it reads as part of the time rather than a loose bullet.
+ */
+@Composable
+private fun TimestampCluster(entry: NotificationEntry, isUnread: Boolean) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        if (isUnread) {
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .background(MaterialTheme.colorScheme.primary, CircleShape)
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+        }
+        Text(
+            text = formatRelative(entry.representative.createdAt.toLong()),
+            style = MaterialTheme.typography.labelMedium,
+            color = if (isUnread) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            }
+        )
     }
 }
 
@@ -162,6 +208,7 @@ private fun MediaCardBody(
     entry: NotificationEntry,
     payload: GroupPayload,
     expanded: Boolean,
+    isUnread: Boolean,
     onMediaClick: (Int) -> Unit
 ) {
     Row(
@@ -187,11 +234,7 @@ private fun MediaCardBody(
             }
         }
         Spacer(modifier = Modifier.width(8.dp))
-        Text(
-            text = formatRelative(entry.representative.createdAt.toLong()),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
+        TimestampCluster(entry = entry, isUnread = isUnread)
     }
 }
 
@@ -200,6 +243,8 @@ private fun SocialCardBody(
     entry: NotificationEntry,
     payload: GroupPayload,
     expanded: Boolean,
+    isUnread: Boolean,
+    containerColor: Color,
     onMediaClick: (Int) -> Unit,
     onUserClick: (String) -> Unit
 ) {
@@ -209,14 +254,10 @@ private fun SocialCardBody(
                 payload = payload,
                 onMediaClick = onMediaClick,
                 onUserClick = onUserClick,
-                containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+                containerColor = containerColor
             )
             Spacer(modifier = Modifier.weight(1f))
-            Text(
-                text = formatRelative(entry.representative.createdAt.toLong()),
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            TimestampCluster(entry = entry, isUnread = isUnread)
         }
 
         Spacer(modifier = Modifier.height(12.dp))

--- a/app/src/main/java/com/anisync/android/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/ProfileScreen.kt
@@ -129,10 +129,7 @@ fun ProfileScreen(
                         animatedVisibilityScope = animatedVisibilityScope,
                         onAction = viewModel::onAction,
                         onSettingsClick = onNavigateToSettings,
-                        onNotificationsClick = {
-                            viewModel.onNotificationsOpened()
-                            onNavigateToNotifications()
-                        },
+                        onNotificationsClick = onNavigateToNotifications,
                         unreadNotificationCount = uiState.unreadNotificationCount,
                         onMediaClick = onMediaClick,
                         onCharacterClick = onCharacterClick,

--- a/app/src/main/java/com/anisync/android/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/ProfileViewModel.kt
@@ -509,16 +509,6 @@ class ProfileViewModel @Inject constructor(
         viewModelScope.launch { notificationBadgeStore.refresh() }
     }
 
-    /**
-     * Optimistically zero the badge when the user taps the bell. The
-     * server-side reset rides on NotificationsScreen's first ALL fetch
-     * (`resetNotificationCount=true`); the next on-resume refresh
-     * reconciles either way.
-     */
-    fun onNotificationsOpened() {
-        notificationBadgeStore.clearOptimistically()
-    }
-
     fun onAction(action: ProfileAction) {
         when (action) {
             is ProfileAction.Refresh -> refresh(forceNetwork = action.forceNetwork)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -580,6 +580,12 @@
         <item quantity="one">%1$d unread notification</item>
         <item quantity="other">%1$d unread notifications</item>
     </plurals>
+    <string name="notifications_section_new">New</string>
+    <string name="notifications_section_earlier">Earlier</string>
+    <string name="notifications_new_count">%1$s new</string>
+    <string name="notifications_new_count_overflow" translatable="false">99+</string>
+    <string name="notifications_mark_all_read">Mark all read</string>
+    <string name="a11y_notification_unread">Unread</string>
     <string name="profile_edit">Edit Profile</string>
     <string name="profile_unknown_error">Something went wrong while loading your profile.</string>
     <string name="profile_user_load_error">We could not load this user profile right now. The account may be private, unavailable, or temporarily rate-limited.</string>

--- a/app/src/test/java/com/anisync/android/presentation/notifications/UnreadWindowTest.kt
+++ b/app/src/test/java/com/anisync/android/presentation/notifications/UnreadWindowTest.kt
@@ -1,0 +1,86 @@
+package com.anisync.android.presentation.notifications
+
+import com.anisync.android.domain.FollowingNotification
+import com.anisync.android.domain.Notification
+import com.anisync.android.type.NotificationType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UnreadWindowTest {
+
+    private fun notification(id: Int, createdAt: Int = id): Notification = FollowingNotification(
+        id = id,
+        type = NotificationType.FOLLOWING,
+        createdAt = createdAt,
+        context = "followed you",
+        user = null
+    )
+
+    /** Newest first, the order AniList returns and the list keeps. */
+    private val page = listOf(70, 60, 50, 40, 30).map { notification(it) }
+
+    @Test
+    fun `takes the newest rows for the unread count`() {
+        assertEquals(setOf(70, 60), unreadWindow(emptySet(), page, count = 2))
+    }
+
+    @Test
+    fun `zero unread marks nothing`() {
+        assertTrue(unreadWindow(emptySet(), page, count = 0).isEmpty())
+    }
+
+    @Test
+    fun `a count past the end of the page marks everything loaded so far`() {
+        assertEquals(setOf(70, 60, 50, 40, 30), unreadWindow(emptySet(), page, count = 8))
+    }
+
+    @Test
+    fun `later pages widen a window the first page could not fill`() {
+        val firstPage = page.take(2)
+        val afterFirst = unreadWindow(emptySet(), firstPage, count = 4)
+        val afterSecond = unreadWindow(afterFirst, page, count = 4)
+        assertEquals(setOf(70, 60, 50, 40), afterSecond)
+    }
+
+    @Test
+    fun `a notification arriving mid-visit joins the window instead of evicting the oldest`() {
+        val opened = unreadWindow(emptySet(), page, count = 2)
+        val refreshed = listOf(notification(80)) + page
+        assertEquals(setOf(80, 70, 60), unreadWindow(opened, refreshed, count = 2))
+    }
+
+    @Test
+    fun `a fold is unread when any member is`() {
+        val entries = listOf(
+            NotificationEntry(
+                key = "fold",
+                representative = notification(60),
+                all = listOf(notification(60), notification(20)),
+                actors = emptyList()
+            ),
+            NotificationEntry(
+                key = "old",
+                representative = notification(20),
+                all = listOf(notification(20)),
+                actors = emptyList()
+            )
+        )
+        val marked = entries.markUnread(setOf(60))
+        assertTrue(marked[0].isUnread)
+        assertFalse(marked[1].isUnread)
+    }
+
+    @Test
+    fun `an empty window clears the flags again`() {
+        val entry = NotificationEntry(
+            key = "one",
+            representative = notification(60),
+            all = listOf(notification(60)),
+            actors = emptyList(),
+            isUnread = true
+        )
+        assertFalse(listOf(entry).markUnread(emptySet()).single().isUnread)
+    }
+}


### PR DESCRIPTION
Marks which notifications are new, and stops the inbox from marking everything read the moment it opens.

- the newest `Viewer.unreadNotificationCount` rows are marked new: a container step, a dot beside the timestamp, and a NEW / EARLIER split
- count pill beside the title, Mark all read on the NEW row
- only Mark all read clears the count now, so the button means something. This diverges from anilist.co, which resets on open

Closes #97