### PR TITLE
feat(profile): add a week view to Activity History

### DIFF
--- a/app/src/main/graphql/Profile.graphql
+++ b/app/src/main/graphql/Profile.graphql
@@ -572,15 +572,23 @@ Every activity a user posted inside one day window, for the Activity History wee
 Deliberately its own query rather than a field on GetFullUserProfile: that query already embeds
 ActivityFields across four activity lists and sits close to AniList's complexity ceiling, where
 extra fields make it return null instead of erroring.
+
+MESSAGE is left out of type_in on purpose. `userId` matches a message's *recipient*, so including
+it would list what other people sent this user, which is neither what they did that day nor what
+AniList counted into the day's bar.
+
+perPage is `Int` rather than `Int!` deliberately: AniList rejects a non-null variable that carries
+a default and is then omitted, and answers with data.Page = null rather than an error the client
+can see, because the normalized cache drops response.errors on the way through.
 """
-query GetUserDayActivities($userId: Int, $from: Int!, $to: Int!, $perPage: Int! = 25) {
+query GetUserDayActivities($userId: Int, $from: Int!, $to: Int!, $perPage: Int = 25) {
   Page(page: 1, perPage: $perPage) {
     activities(
       userId: $userId,
       createdAt_greater: $from,
       createdAt_lesser: $to,
       sort: [ID_DESC],
-      type_in: [ANIME_LIST, MANGA_LIST, TEXT, MESSAGE]
+      type_in: [ANIME_LIST, MANGA_LIST, TEXT]
     ) {
       ...ActivityFields
     }

--- a/app/src/main/graphql/Profile.graphql
+++ b/app/src/main/graphql/Profile.graphql
@@ -565,3 +565,24 @@ mutation SaveMessageActivity(
     id
   }
 }
+
+"""
+Every activity a user posted inside one day window, for the Activity History week breakdown.
+
+Deliberately its own query rather than a field on GetFullUserProfile: that query already embeds
+ActivityFields across four activity lists and sits close to AniList's complexity ceiling, where
+extra fields make it return null instead of erroring.
+"""
+query GetUserDayActivities($userId: Int, $from: Int!, $to: Int!, $perPage: Int! = 25) {
+  Page(page: 1, perPage: $perPage) {
+    activities(
+      userId: $userId,
+      createdAt_greater: $from,
+      createdAt_lesser: $to,
+      sort: [ID_DESC],
+      type_in: [ANIME_LIST, MANGA_LIST, TEXT, MESSAGE]
+    ) {
+      ...ActivityFields
+    }
+  }
+}

--- a/app/src/main/java/com/anisync/android/data/ProfileRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/ProfileRepositoryImpl.kt
@@ -742,6 +742,39 @@ class ProfileRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getUserDayActivities(
+        userId: Int,
+        fromEpochSeconds: Long,
+        toEpochSeconds: Long,
+        policy: CachePolicy
+    ): Result<List<com.anisync.android.domain.UserActivity>> {
+        return dedupe("dayActivities:$userId:$fromEpochSeconds:$policy") {
+            safeApiCall {
+                val response = apolloClient.query(
+                    com.anisync.android.GetUserDayActivitiesQuery(
+                        userId = Optional.present(userId),
+                        from = fromEpochSeconds.toInt(),
+                        to = toEpochSeconds.toInt()
+                    )
+                )
+                    .fetchPolicy(policy.toFetchPolicy())
+                    .execute()
+
+                if (response.hasErrors()) {
+                    throw Exception(
+                        response.errors?.firstOrNull()?.message ?: "Failed to load activities"
+                    )
+                }
+
+                response.data?.Page?.activities
+                    ?.filterNotNull()
+                    ?.mapNotNull { it.activityFields.activityFieldsToDomain() }
+                    ?.distinctBy { it.id }
+                    ?: emptyList()
+            }
+        }
+    }
+
     /** Maps a domain activity type to the AniList query enum; UNKNOWN has no query form. */
     private fun com.anisync.android.domain.ActivityType.toApiActivityType(): com.anisync.android.type.ActivityType? =
         when (this) {

--- a/app/src/main/java/com/anisync/android/domain/ProfileRepository.kt
+++ b/app/src/main/java/com/anisync/android/domain/ProfileRepository.kt
@@ -126,6 +126,21 @@ interface ProfileRepository {
     ): Result<UserActivitiesPage>
 
     /**
+     * Fetch the activities a user posted inside one day, newest-first.
+     *
+     * [fromEpochSeconds] and [toEpochSeconds] bound the same UTC day the Activity History
+     * heatmap buckets into, so a day's bar and the list behind it describe the same window.
+     * AniList's own per-day count may still differ, since `activityHistory` counts every kind
+     * of activity and this asks for a filtered set.
+     */
+    suspend fun getUserDayActivities(
+        userId: Int,
+        fromEpochSeconds: Long,
+        toEpochSeconds: Long,
+        policy: CachePolicy = CachePolicy.NetworkFirst
+    ): Result<List<UserActivity>>
+
+    /**
      * Fetch the user's full favourite-anime list (all pages). Loaded lazily when
      * the Favorites tab opens; the profile fetch itself only carries page 1, so
      * a normal profile load/refresh no longer fans out across favourite pages.

--- a/app/src/main/java/com/anisync/android/presentation/profile/ProfileContent.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/ProfileContent.kt
@@ -522,6 +522,8 @@ internal fun LazyListScope.profileSelectedTabContent(
                 onVoiceActorClick = onVoiceActorClick,
                 onStaffClick = onStaffClick,
                 onStudioClick = onStudioClick,
+                onMediaClick = onMediaClick,
+                onActivityClick = onActivityClick,
                 statsColumns = statsColumns
             )
         }

--- a/app/src/main/java/com/anisync/android/presentation/profile/components/ActivityCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/components/ActivityCard.kt
@@ -564,7 +564,7 @@ private fun ActivityListStatusText(activity: UserActivity, modifier: Modifier = 
  * accent-colored label in AniList's brand blue (anime) / orange (manga). See [AniListLinkCard].
  */
 @Composable
-private fun MediaTypeLabel(type: ActivityMediaType) {
+internal fun MediaTypeLabel(type: ActivityMediaType) {
     val (labelRes, color) = when (type) {
         ActivityMediaType.ANIME -> R.string.media_type_anime to Color(0xFF3DB4F2)
         ActivityMediaType.MANGA -> R.string.media_type_manga to Color(0xFFF2A33D)

--- a/app/src/main/java/com/anisync/android/presentation/profile/sections/ProfileOverviewSection.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/sections/ProfileOverviewSection.kt
@@ -45,7 +45,7 @@ import com.anisync.android.presentation.details.components.CharacterItem
 import com.anisync.android.presentation.profile.ProfileTab
 import com.anisync.android.presentation.profile.RecentUpdatesSection
 import com.anisync.android.presentation.profile.components.PlaceholderTabContent
-import com.anisync.android.presentation.statistics.ActivityHeatmapSection
+import com.anisync.android.presentation.statistics.ActivityHistorySection
 import com.anisync.android.presentation.statistics.GenreCardModern
 import com.anisync.android.presentation.util.bouncyClickable
 
@@ -119,7 +119,7 @@ fun ProfileOverviewSection(
 
         // Activity heatmap — leads the tab as the most glanceable "what they've been up to".
         if (activityHistory.isNotEmpty()) {
-            ActivityHeatmapSection(activityHistory)
+            ActivityHistorySection(activityHistory)
             Spacer(modifier = Modifier.height(24.dp))
         }
 

--- a/app/src/main/java/com/anisync/android/presentation/profile/sections/ProfileOverviewSection.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/sections/ProfileOverviewSection.kt
@@ -119,7 +119,7 @@ fun ProfileOverviewSection(
 
         // Activity heatmap — leads the tab as the most glanceable "what they've been up to".
         if (activityHistory.isNotEmpty()) {
-            ActivityHistorySection(activityHistory)
+            ActivityHistorySection(activityHistory, userId = profile.id)
             Spacer(modifier = Modifier.height(24.dp))
         }
 

--- a/app/src/main/java/com/anisync/android/presentation/profile/sections/ProfileOverviewSection.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/sections/ProfileOverviewSection.kt
@@ -119,7 +119,12 @@ fun ProfileOverviewSection(
 
         // Activity heatmap — leads the tab as the most glanceable "what they've been up to".
         if (activityHistory.isNotEmpty()) {
-            ActivityHistorySection(activityHistory, userId = profile.id)
+            ActivityHistorySection(
+                activityHistory,
+                userId = profile.id,
+                onMediaClick = onMediaClick,
+                onActivityClick = onActivityClick
+            )
             Spacer(modifier = Modifier.height(24.dp))
         }
 

--- a/app/src/main/java/com/anisync/android/presentation/profile/sections/ProfileStatsSection.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/sections/ProfileStatsSection.kt
@@ -61,6 +61,8 @@ fun LazyListScope.profileStatsTab(
     onVoiceActorClick: (Int) -> Unit = {},
     onStaffClick: (Int) -> Unit = {},
     onStudioClick: (Int) -> Unit = {},
+    onMediaClick: (Int) -> Unit = {},
+    onActivityClick: (Int) -> Unit = {},
     statsColumns: Int = 1,
     modifier: Modifier = Modifier
 ) {
@@ -147,7 +149,12 @@ fun LazyListScope.profileStatsTab(
 
     if (statsData.activityHistory.isNotEmpty()) {
         item(key = "activity_heatmap") {
-            ActivityHistorySection(statsData.activityHistory, userId = uiState.profile?.id ?: 0)
+            ActivityHistorySection(
+                statsData.activityHistory,
+                userId = uiState.profile?.id ?: 0,
+                onMediaClick = onMediaClick,
+                onActivityClick = onActivityClick
+            )
             Spacer(modifier = Modifier.height(24.dp))
         }
     }

--- a/app/src/main/java/com/anisync/android/presentation/profile/sections/ProfileStatsSection.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/sections/ProfileStatsSection.kt
@@ -147,7 +147,7 @@ fun LazyListScope.profileStatsTab(
 
     if (statsData.activityHistory.isNotEmpty()) {
         item(key = "activity_heatmap") {
-            ActivityHistorySection(statsData.activityHistory)
+            ActivityHistorySection(statsData.activityHistory, userId = uiState.profile?.id ?: 0)
             Spacer(modifier = Modifier.height(24.dp))
         }
     }

--- a/app/src/main/java/com/anisync/android/presentation/profile/sections/ProfileStatsSection.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/sections/ProfileStatsSection.kt
@@ -32,7 +32,7 @@ import com.anisync.android.R
 import com.anisync.android.presentation.components.SegmentedTabItem
 import com.anisync.android.presentation.profile.ProfileStatsType
 import com.anisync.android.presentation.profile.ProfileUiState
-import com.anisync.android.presentation.statistics.ActivityHeatmapSection
+import com.anisync.android.presentation.statistics.ActivityHistorySection
 import com.anisync.android.presentation.statistics.CountryDistributionRow
 import com.anisync.android.presentation.statistics.EditorialStat
 import com.anisync.android.presentation.statistics.EpisodeLengthDistributionSection
@@ -147,7 +147,7 @@ fun LazyListScope.profileStatsTab(
 
     if (statsData.activityHistory.isNotEmpty()) {
         item(key = "activity_heatmap") {
-            ActivityHeatmapSection(statsData.activityHistory)
+            ActivityHistorySection(statsData.activityHistory)
             Spacer(modifier = Modifier.height(24.dp))
         }
     }

--- a/app/src/main/java/com/anisync/android/presentation/statistics/ActivityDaySheet.kt
+++ b/app/src/main/java/com/anisync/android/presentation/statistics/ActivityDaySheet.kt
@@ -1,5 +1,6 @@
 package com.anisync.android.presentation.statistics
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,13 +11,19 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.MenuBook
+import androidx.compose.material.icons.automirrored.rounded.Notes
+import androidx.compose.material.icons.rounded.Tv
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -39,15 +46,23 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.anisync.android.R
+import com.anisync.android.domain.ActivityMediaType
 import com.anisync.android.domain.UserActivity
 import com.anisync.android.presentation.components.AppCircularProgressIndicator
 import com.anisync.android.presentation.components.AppModalBottomSheet
+import com.anisync.android.presentation.profile.components.MediaTypeLabel
 import com.anisync.android.ui.theme.emphasis
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
+
+private val CoverWidth = 42.dp
+private val CoverHeight = 56.dp
+
+/** Keeps a status row, whose tile is square, the same height as the rows carrying cover art. */
+private val RowMinHeight = 72.dp
 
 /**
  * What actually happened on one day of the week breakdown.
@@ -158,9 +173,13 @@ internal fun ActivityDaySheetContent(
     }
 }
 
+/**
+ * One entry of the day. Every kind of activity keeps the same skeleton — leading slot, title, one
+ * line of meta, time — so a day that mixes list updates with a written status still scans as one
+ * list. Only the leading slot and the trailing tag change.
+ */
 @Composable
 private fun ActivityDayRow(activity: UserActivity) {
-    val context = LocalContext.current
     val timeFormatter = remember { DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT) }
     val time = remember(activity.timestamp) {
         Instant.ofEpochSecond(activity.timestamp).atZone(ZoneId.systemDefault()).toLocalTime()
@@ -169,43 +188,41 @@ private fun ActivityDayRow(activity: UserActivity) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .heightIn(min = RowMinHeight)
             .clip(RoundedCornerShape(16.dp))
             .padding(8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        if (activity.mediaCoverUrl != null) {
-            AsyncImage(
-                model = ImageRequest.Builder(context)
-                    .data(activity.mediaCoverUrl)
-                    .crossfade(true)
-                    .build(),
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier
-                    .size(width = 42.dp, height = 56.dp)
-                    .clip(RoundedCornerShape(8.dp))
-            )
-            Spacer(Modifier.width(12.dp))
-        }
+        ActivityLeading(activity)
+        Spacer(Modifier.width(12.dp))
 
         Column(Modifier.weight(1f)) {
             Text(
-                text = activity.mediaTitle.ifBlank {
-                    stringResource(R.string.statistics_activity_day_status)
-                },
+                text = activityTitle(activity),
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis
-            )
-            Text(
-                text = activitySubtitle(activity),
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = activityMeta(activity),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false)
+                )
+                activity.mediaType?.let { type ->
+                    Text(
+                        text = "  ·  ",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    MediaTypeLabel(type)
+                }
+            }
         }
 
         Spacer(Modifier.width(8.dp))
@@ -217,15 +234,77 @@ private fun ActivityDayRow(activity: UserActivity) {
     }
 }
 
-/** "Watched episode 5", or the post's first line for text and message activities. */
+/**
+ * Cover art where there is any, the media kind where AniList has no cover, and a distinct tile for
+ * a written status, which has no media at all. The slot keeps its width either way so the titles
+ * below each other stay aligned.
+ */
 @Composable
-private fun activitySubtitle(activity: UserActivity): String {
-    val status = activity.status
-    if (status.isNullOrBlank()) {
-        return activity.bodyMarkdown?.lineSequence()?.firstOrNull()?.takeIf { it.isNotBlank() }
-            ?: stringResource(R.string.statistics_activity_day_status)
+private fun ActivityLeading(activity: UserActivity) {
+    val context = LocalContext.current
+    val cover = activity.mediaCoverUrl
+    when {
+        cover != null -> AsyncImage(
+            model = ImageRequest.Builder(context).data(cover).crossfade(true).build(),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(width = CoverWidth, height = CoverHeight)
+                .clip(RoundedCornerShape(8.dp))
+        )
+        activity.mediaType != null -> Box(
+            modifier = Modifier
+                .size(width = CoverWidth, height = CoverHeight)
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = if (activity.mediaType == ActivityMediaType.MANGA) {
+                    Icons.AutoMirrored.Rounded.MenuBook
+                } else {
+                    Icons.Rounded.Tv
+                },
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+        else -> Box(
+            modifier = Modifier
+                .size(CoverWidth)
+                .clip(RoundedCornerShape(12.dp))
+                .background(MaterialTheme.colorScheme.secondaryContainer),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Rounded.Notes,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                modifier = Modifier.size(20.dp)
+            )
+        }
     }
+}
+
+/** The media's title, or the opening line of a status the user wrote. */
+@Composable
+private fun activityTitle(activity: UserActivity): String = activity.mediaTitle.ifBlank {
+    firstLine(activity.bodyMarkdown ?: activity.text)
+        ?: stringResource(R.string.statistics_activity_day_status)
+}
+
+/** "Watched episode 5" for a list update, otherwise what kind of post it was. */
+@Composable
+private fun activityMeta(activity: UserActivity): String {
+    val status = activity.status
+    if (status.isNullOrBlank()) return stringResource(R.string.statistics_activity_day_posted)
     val capitalised = status.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
     val progress = activity.progress
     return if (progress.isNullOrBlank()) capitalised else "$capitalised $progress"
 }
+
+private fun firstLine(body: String?): String? = body
+    ?.lineSequence()
+    ?.map { it.trim() }
+    ?.firstOrNull { it.isNotEmpty() }

--- a/app/src/main/java/com/anisync/android/presentation/statistics/ActivityDaySheet.kt
+++ b/app/src/main/java/com/anisync/android/presentation/statistics/ActivityDaySheet.kt
@@ -1,0 +1,231 @@
+package com.anisync.android.presentation.statistics
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.anisync.android.R
+import com.anisync.android.domain.UserActivity
+import com.anisync.android.presentation.components.AppCircularProgressIndicator
+import com.anisync.android.presentation.components.AppModalBottomSheet
+import com.anisync.android.ui.theme.emphasis
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+/**
+ * What actually happened on one day of the week breakdown.
+ *
+ * The bars come from AniList's precomputed per-day counts, which carry no detail at all, so the
+ * list behind a day is a separate fetch of that day's activity feed. Counts can therefore differ
+ * from the bar: `activityHistory` counts every kind of activity, this asks for list, text and
+ * message activities only.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ActivityDaySheet(
+    userId: Int,
+    date: LocalDate,
+    onDismiss: () -> Unit,
+    viewModel: ActivityDayViewModel = hiltViewModel()
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+    val activities by viewModel.activities.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+    val errorMessage by viewModel.errorMessage.collectAsState()
+
+    LaunchedEffect(userId, date) { viewModel.load(userId, date) }
+
+    AppModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface
+    ) {
+        ActivityDaySheetContent(
+            date = date,
+            activities = activities,
+            isLoading = isLoading,
+            errorMessage = errorMessage
+        )
+    }
+}
+
+@Composable
+internal fun ActivityDaySheetContent(
+    date: LocalDate,
+    activities: List<UserActivity>,
+    isLoading: Boolean,
+    errorMessage: String?,
+    modifier: Modifier = Modifier
+) {
+    val dateFormatter = remember { DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL) }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .fillMaxHeight(0.7f)
+    ) {
+        Column(Modifier.padding(horizontal = 24.dp, vertical = 16.dp)) {
+            Text(
+                text = date.format(dateFormatter),
+                style = MaterialTheme.typography.titleLarge.emphasis()
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = pluralStringResource(
+                    R.plurals.statistics_activity_count, activities.size, activities.size
+                ),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        when {
+            isLoading && activities.isEmpty() -> {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    AppCircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+                }
+            }
+            errorMessage != null && activities.isEmpty() -> {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text(
+                        text = errorMessage,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            }
+            activities.isEmpty() -> {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text(
+                        text = stringResource(R.string.statistics_activity_day_empty),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(horizontal = 32.dp)
+                    )
+                }
+            }
+            else -> {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 4.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(activities, key = { it.id }) { activity ->
+                        ActivityDayRow(activity)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActivityDayRow(activity: UserActivity) {
+    val context = LocalContext.current
+    val timeFormatter = remember { DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT) }
+    val time = remember(activity.timestamp) {
+        Instant.ofEpochSecond(activity.timestamp).atZone(ZoneId.systemDefault()).toLocalTime()
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .padding(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (activity.mediaCoverUrl != null) {
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(activity.mediaCoverUrl)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(width = 42.dp, height = 56.dp)
+                    .clip(RoundedCornerShape(8.dp))
+            )
+            Spacer(Modifier.width(12.dp))
+        }
+
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = activity.mediaTitle.ifBlank {
+                    stringResource(R.string.statistics_activity_day_status)
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = activitySubtitle(activity),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = time.format(timeFormatter),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+/** "Watched episode 5", or the post's first line for text and message activities. */
+@Composable
+private fun activitySubtitle(activity: UserActivity): String {
+    val status = activity.status
+    if (status.isNullOrBlank()) {
+        return activity.bodyMarkdown?.lineSequence()?.firstOrNull()?.takeIf { it.isNotBlank() }
+            ?: stringResource(R.string.statistics_activity_day_status)
+    }
+    val capitalised = status.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+    val progress = activity.progress
+    return if (progress.isNullOrBlank()) capitalised else "$capitalised $progress"
+}

--- a/app/src/main/java/com/anisync/android/presentation/statistics/ActivityDaySheet.kt
+++ b/app/src/main/java/com/anisync/android/presentation/statistics/ActivityDaySheet.kt
@@ -61,7 +61,7 @@ import java.time.format.FormatStyle
 @Composable
 internal fun ActivityDaySheet(
     userId: Int,
-    date: LocalDate,
+    day: ActivityDay,
     onDismiss: () -> Unit,
     viewModel: ActivityDayViewModel = hiltViewModel()
 ) {
@@ -70,7 +70,7 @@ internal fun ActivityDaySheet(
     val isLoading by viewModel.isLoading.collectAsState()
     val errorMessage by viewModel.errorMessage.collectAsState()
 
-    LaunchedEffect(userId, date) { viewModel.load(userId, date) }
+    LaunchedEffect(userId, day.date) { viewModel.load(userId, day) }
 
     AppModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -78,7 +78,7 @@ internal fun ActivityDaySheet(
         containerColor = MaterialTheme.colorScheme.surface
     ) {
         ActivityDaySheetContent(
-            date = date,
+            date = day.date,
             activities = activities,
             isLoading = isLoading,
             errorMessage = errorMessage

--- a/app/src/main/java/com/anisync/android/presentation/statistics/ActivityDaySheet.kt
+++ b/app/src/main/java/com/anisync/android/presentation/statistics/ActivityDaySheet.kt
@@ -1,6 +1,7 @@
 package com.anisync.android.presentation.statistics
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -78,6 +79,7 @@ internal fun ActivityDaySheet(
     userId: Int,
     day: ActivityDay,
     onDismiss: () -> Unit,
+    onOpenActivity: (UserActivity) -> Unit,
     viewModel: ActivityDayViewModel = hiltViewModel()
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
@@ -96,7 +98,8 @@ internal fun ActivityDaySheet(
             date = day.date,
             activities = activities,
             isLoading = isLoading,
-            errorMessage = errorMessage
+            errorMessage = errorMessage,
+            onOpenActivity = onOpenActivity
         )
     }
 }
@@ -107,6 +110,7 @@ internal fun ActivityDaySheetContent(
     activities: List<UserActivity>,
     isLoading: Boolean,
     errorMessage: String?,
+    onOpenActivity: (UserActivity) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val dateFormatter = remember { DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL) }
@@ -165,7 +169,7 @@ internal fun ActivityDaySheetContent(
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     items(activities, key = { it.id }) { activity ->
-                        ActivityDayRow(activity)
+                        ActivityDayRow(activity, onClick = { onOpenActivity(activity) })
                     }
                 }
             }
@@ -179,7 +183,7 @@ internal fun ActivityDaySheetContent(
  * list. Only the leading slot and the trailing tag change.
  */
 @Composable
-private fun ActivityDayRow(activity: UserActivity) {
+private fun ActivityDayRow(activity: UserActivity, onClick: () -> Unit) {
     val timeFormatter = remember { DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT) }
     val time = remember(activity.timestamp) {
         Instant.ofEpochSecond(activity.timestamp).atZone(ZoneId.systemDefault()).toLocalTime()
@@ -190,6 +194,7 @@ private fun ActivityDayRow(activity: UserActivity) {
             .fillMaxWidth()
             .heightIn(min = RowMinHeight)
             .clip(RoundedCornerShape(16.dp))
+            .clickable(onClick = onClick)
             .padding(8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/app/src/main/java/com/anisync/android/presentation/statistics/ActivityDaySheet.kt
+++ b/app/src/main/java/com/anisync/android/presentation/statistics/ActivityDaySheet.kt
@@ -199,6 +199,7 @@ private fun ActivityDayRow(activity: UserActivity, onClick: () -> Unit) {
             .fillMaxWidth()
             .heightIn(min = RowMinHeight)
             .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainer)
             .clickable(onClick = onClick)
             .padding(8.dp),
         verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/java/com/anisync/android/presentation/statistics/ActivityDaySheet.kt
+++ b/app/src/main/java/com/anisync/android/presentation/statistics/ActivityDaySheet.kt
@@ -188,6 +188,11 @@ private fun ActivityDayRow(activity: UserActivity, onClick: () -> Unit) {
     val time = remember(activity.timestamp) {
         Instant.ofEpochSecond(activity.timestamp).atZone(ZoneId.systemDefault()).toLocalTime()
     }
+    val excerpt = remember(activity.id) { statusExcerpt(activity.bodyMarkdown ?: activity.text) }
+    val title = activity.mediaTitle.ifBlank {
+        excerpt ?: stringResource(R.string.statistics_activity_day_posted)
+    }
+    val meta = activityMeta(activity, hasExcerpt = excerpt != null)
 
     Row(
         modifier = Modifier
@@ -203,29 +208,31 @@ private fun ActivityDayRow(activity: UserActivity, onClick: () -> Unit) {
 
         Column(Modifier.weight(1f)) {
             Text(
-                text = activityTitle(activity),
+                text = title,
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = activityMeta(activity),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f, fill = false)
-                )
-                activity.mediaType?.let { type ->
+            if (meta.isNotEmpty() || activity.mediaType != null) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
-                        text = "  ·  ",
+                        text = meta,
                         style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false)
                     )
-                    MediaTypeLabel(type)
+                    activity.mediaType?.let { type ->
+                        Text(
+                            text = "  ·  ",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        MediaTypeLabel(type)
+                    }
                 }
             }
         }
@@ -292,24 +299,42 @@ private fun ActivityLeading(activity: UserActivity) {
     }
 }
 
-/** The media's title, or the opening line of a status the user wrote. */
-@Composable
-private fun activityTitle(activity: UserActivity): String = activity.mediaTitle.ifBlank {
-    firstLine(activity.bodyMarkdown ?: activity.text)
-        ?: stringResource(R.string.statistics_activity_day_status)
-}
-
 /** "Watched episode 5" for a list update, otherwise what kind of post it was. */
 @Composable
-private fun activityMeta(activity: UserActivity): String {
+private fun activityMeta(activity: UserActivity, hasExcerpt: Boolean): String {
     val status = activity.status
-    if (status.isNullOrBlank()) return stringResource(R.string.statistics_activity_day_posted)
-    val capitalised = status.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
-    val progress = activity.progress
-    return if (progress.isNullOrBlank()) capitalised else "$capitalised $progress"
+    if (!status.isNullOrBlank()) {
+        val capitalised = status.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+        val progress = activity.progress
+        return if (progress.isNullOrBlank()) capitalised else "$capitalised $progress"
+    }
+    // Without an excerpt the title already says the post is a status, and repeating it under
+    // itself reads like a bug.
+    return if (hasExcerpt) stringResource(R.string.statistics_activity_day_posted) else ""
 }
 
-private fun firstLine(body: String?): String? = body
-    ?.lineSequence()
-    ?.map { it.trim() }
-    ?.firstOrNull { it.isNotEmpty() }
+private val EmbedMarkup = Regex("""(img|youtube|webm|video)\d*\([^)]*\)""", RegexOption.IGNORE_CASE)
+private val LinkMarkup = Regex("""\[([^\]]*)]\([^)]*\)""")
+private val HtmlTag = Regex("""<[^>]+>""")
+private val BareUrl = Regex("""https?://\S+""")
+private val LeftoverMarkup = Regex("""[#*_>`~]+""")
+
+/**
+ * The readable opening of a status post, for use as a row title.
+ *
+ * AniList posts routinely open with an image embed, a link or a spoiler marker, none of which say
+ * anything in one line, so the markup is stripped before the first surviving line is taken. A post
+ * that is nothing but an image has no excerpt at all, and the row falls back to naming the kind.
+ */
+internal fun statusExcerpt(body: String?): String? {
+    if (body.isNullOrBlank()) return null
+    return body
+        .replace(EmbedMarkup, " ")
+        .replace(LinkMarkup, "$1")
+        .replace(HtmlTag, " ")
+        .replace(BareUrl, " ")
+        .replace(LeftoverMarkup, " ")
+        .lineSequence()
+        .map { it.replace(Regex("""\s+"""), " ").trim() }
+        .firstOrNull { it.isNotEmpty() }
+}

--- a/app/src/main/java/com/anisync/android/presentation/statistics/ActivityDayViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/statistics/ActivityDayViewModel.kt
@@ -1,0 +1,60 @@
+package com.anisync.android.presentation.statistics
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.anisync.android.domain.ProfileRepository
+import com.anisync.android.domain.Result
+import com.anisync.android.domain.UserActivity
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import javax.inject.Inject
+
+/** Half a day in seconds — the offset the heatmap rounds timestamps by. */
+private const val HALF_DAY_SECONDS = 43_200L
+private const val DAY_SECONDS = 86_400L
+
+/**
+ * Loads the activities behind one day of the Activity History week breakdown.
+ *
+ * Sheet-scoped rather than part of `ProfileViewModel`, matching the app's other on-demand sheets,
+ * so the profile screen carries no state for a list that only exists while the sheet is open.
+ */
+@HiltViewModel
+class ActivityDayViewModel @Inject constructor(
+    private val profileRepository: ProfileRepository
+) : ViewModel() {
+
+    private val _activities = MutableStateFlow<List<UserActivity>>(emptyList())
+    val activities: StateFlow<List<UserActivity>> = _activities.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+
+    private var loaded: Pair<Int, LocalDate>? = null
+
+    fun load(userId: Int, date: LocalDate) {
+        if (loaded == userId to date) return
+        loaded = userId to date
+        _activities.value = emptyList()
+        _errorMessage.value = null
+
+        // The same window the heatmap buckets into: AniList stamps a day at midnight in its own
+        // zone, so the day runs from noon UTC the day before to noon UTC on the day itself.
+        val from = date.toEpochDay() * DAY_SECONDS - HALF_DAY_SECONDS
+        viewModelScope.launch {
+            _isLoading.value = true
+            when (val result = profileRepository.getUserDayActivities(userId, from, from + DAY_SECONDS)) {
+                is Result.Success -> _activities.value = result.data
+                is Result.Error -> _errorMessage.value = result.message
+            }
+            _isLoading.value = false
+        }
+    }
+}

--- a/app/src/main/java/com/anisync/android/presentation/statistics/ActivityDayViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/statistics/ActivityDayViewModel.kt
@@ -39,15 +39,16 @@ class ActivityDayViewModel @Inject constructor(
 
     private var loaded: Pair<Int, LocalDate>? = null
 
-    fun load(userId: Int, date: LocalDate) {
-        if (loaded == userId to date) return
-        loaded = userId to date
+    internal fun load(userId: Int, day: ActivityDay) {
+        if (loaded == userId to day.date) return
+        loaded = userId to day.date
         _activities.value = emptyList()
         _errorMessage.value = null
 
-        // The same window the heatmap buckets into: AniList stamps a day at midnight in its own
-        // zone, so the day runs from noon UTC the day before to noon UTC on the day itself.
-        val from = date.toEpochDay() * DAY_SECONDS - HALF_DAY_SECONDS
+        // AniList stamps each bucket at midnight in its own zone, so its own timestamp is the only
+        // exact day boundary available. Without one, fall back to the window the heatmap buckets
+        // into: noon UTC the day before, to noon UTC on the day itself.
+        val from = day.epochSeconds ?: (day.date.toEpochDay() * DAY_SECONDS - HALF_DAY_SECONDS)
         viewModelScope.launch {
             _isLoading.value = true
             when (val result = profileRepository.getUserDayActivities(userId, from, from + DAY_SECONDS)) {

--- a/app/src/main/java/com/anisync/android/presentation/statistics/ActivityHeatmapSection.kt
+++ b/app/src/main/java/com/anisync/android/presentation/statistics/ActivityHeatmapSection.kt
@@ -26,6 +26,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.rounded.CalendarMonth
+import androidx.compose.material.icons.rounded.ViewWeek
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -42,6 +44,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -52,6 +55,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -68,6 +72,7 @@ import com.anisync.android.R
 import com.anisync.android.domain.ActivityHistoryDay
 import com.anisync.android.presentation.components.HeaderLevel
 import com.anisync.android.presentation.components.SectionHeader
+import com.anisync.android.presentation.components.SegmentedTabGroup
 import kotlinx.coroutines.launch
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -82,25 +87,35 @@ import java.util.Locale
 // actually returned, bounded by these. MAX leaves headroom in case the API window grows.
 private const val MIN_WEEKS = 18
 private const val MAX_WEEKS = 53
-private const val DAYS_IN_WEEK = 7
+internal const val DAYS_IN_WEEK = 7
 private const val SECONDS_PER_DAY = 86_400L
 
+/** The two breakdowns the Activity History card can show. */
+private enum class ActivityPeriod(val labelRes: Int, val icon: ImageVector) {
+    Month(R.string.statistics_activity_period_month, Icons.Rounded.CalendarMonth),
+    Week(R.string.statistics_activity_period_week, Icons.Rounded.ViewWeek)
+}
+
 /**
- * GitHub-style activity calendar for an AniList profile. Each cell is a day; the color
- * intensity comes straight from AniList's `UserActivityHistory.level` (1-10), and tapping
- * a day reveals its date and activity count. Data is the account-wide
- * [ActivityHistoryDay] list sourced from the (deprecated) `User.stats.activityHistory`.
+ * Activity History for an AniList profile, in either of two breakdowns of the same
+ * [ActivityHistoryDay] list (sourced from the deprecated `User.stats.activityHistory`):
+ *
+ * - **Month** — the GitHub-style calendar. Each cell is a day, the colour intensity comes straight
+ *   from AniList's `level` (1-10), and tapping a day reveals its date and activity count.
+ * - **Week** — one Sunday-to-Saturday week at a time, each day a proportional bar, so days compare
+ *   against each other rather than against a colour ramp.
+ *
+ * Both read the same bucketed days, so switching costs no network call.
  */
 @Composable
-fun ActivityHeatmapSection(
+fun ActivityHistorySection(
     days: List<ActivityHistoryDay>,
     modifier: Modifier = Modifier
 ) {
     if (days.isEmpty()) return
 
-    val model = remember(days) { buildHeatmapModel(days) }
-    var selected by remember(days) { mutableStateOf<HeatmapCell?>(null) }
-    val dateFormatter = remember { DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM) }
+    val byDate = remember(days) { bucketActivityDays(days) }
+    var period by rememberSaveable { mutableStateOf(ActivityPeriod.Month) }
 
     Column(modifier = modifier) {
         SectionHeader(
@@ -118,187 +133,214 @@ fun ActivityHeatmapSection(
                 .fillMaxWidth()
                 .padding(horizontal = 10.dp)
         ) {
-            val emptyColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f)
-            val activeColor = MaterialTheme.colorScheme.primary
-            val ringColor = MaterialTheme.colorScheme.onSurface
-            val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
-            val textMeasurer = rememberTextMeasurer()
-            val monthStyle = TextStyle(color = labelColor, fontSize = 10.sp)
-
             Column(Modifier.padding(20.dp)) {
-                val sel = selected
-                val headline = if (sel != null) {
-                    pluralStringResource(
-                        R.plurals.statistics_activity_count, sel.amount, sel.amount
-                    ) + "  ·  " + sel.date.format(dateFormatter)
-                } else {
-                    stringResource(
-                        R.string.statistics_activity_summary,
-                        model.totalActivities,
-                        model.activeDays
-                    )
-                }
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        text = headline,
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.weight(1f)
-                    )
-                    val tooltipState = rememberTooltipState()
-                    val scope = rememberCoroutineScope()
-                    TooltipBox(
-                        positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
-                            TooltipAnchorPosition.Above
-                        ),
-                        tooltip = {
-                            PlainTooltip {
-                                Text(stringResource(R.string.statistics_activity_update_info))
-                            }
-                        },
-                        state = tooltipState
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.Info,
-                            contentDescription = stringResource(
-                                R.string.statistics_activity_update_info
-                            ),
-                            tint = labelColor,
-                            modifier = Modifier
-                                .clip(CircleShape)
-                                .clickable { scope.launch { tooltipState.show() } }
-                                .padding(2.dp)
-                                .size(16.dp)
-                        )
-                    }
-                }
+                SegmentedTabGroup(
+                    options = ActivityPeriod.entries,
+                    selected = period,
+                    onSelect = { period = it },
+                    label = { stringResource(it.labelRes) },
+                    icon = { it.icon },
+                    fillEqually = true
+                )
 
                 Spacer(Modifier.height(16.dp))
 
-                val cellDp = 13.dp
-                val gapDp = 4.dp
-                val monthRowDp = 16.dp
-                val gridWidth = (cellDp + gapDp) * model.weeks.size
-                val gridHeight = monthRowDp + (cellDp + gapDp) * DAYS_IN_WEEK
-
-                val scrollState = rememberScrollState()
-                // Start scrolled to the most recent week (right edge), like GitHub.
-                LaunchedEffect(model, scrollState.maxValue) {
-                    scrollState.scrollTo(scrollState.maxValue)
-                }
-
-                val a11y = stringResource(R.string.statistics_activity_a11y, model.totalActivities)
-                val selectedDate = sel?.date
-
-                Box(Modifier.fillMaxWidth()) {
-                  val fadeColor = MaterialTheme.colorScheme.surfaceContainer
-                  Box(
-                    Modifier
-                        .fillMaxWidth()
-                        .horizontalScroll(scrollState)
-                        .semantics { contentDescription = a11y }
-                  ) {
-                    Canvas(
-                        modifier = Modifier
-                            .size(width = gridWidth, height = gridHeight)
-                            .pointerInput(model) {
-                                val stridePx = cellDp.toPx() + gapDp.toPx()
-                                val monthPx = monthRowDp.toPx()
-                                detectTapGestures { offset ->
-                                    if (offset.y < monthPx) return@detectTapGestures
-                                    val w = (offset.x / stridePx).toInt()
-                                    val r = ((offset.y - monthPx) / stridePx).toInt()
-                                    val cell = model.weeks.getOrNull(w)?.getOrNull(r)
-                                    if (cell != null && !cell.afterData) {
-                                        selected = if (selected?.date == cell.date) null else cell
-                                    }
-                                }
-                            }
-                    ) {
-                        val cellPx = cellDp.toPx()
-                        val stridePx = cellPx + gapDp.toPx()
-                        val monthPx = monthRowDp.toPx()
-                        val corner = CornerRadius(cellPx * 0.28f, cellPx * 0.28f)
-
-                        model.monthLabels.forEach { (weekIndex, label) ->
-                            drawText(
-                                textMeasurer = textMeasurer,
-                                text = label,
-                                topLeft = Offset(weekIndex * stridePx, 0f),
-                                style = monthStyle
-                            )
-                        }
-
-                        for (w in model.weeks.indices) {
-                            val column = model.weeks[w]
-                            for (r in 0 until DAYS_IN_WEEK) {
-                                val cell = column[r]
-                                if (cell.afterData) continue
-                                val x = w * stridePx
-                                val y = monthPx + r * stridePx
-                                drawRoundRect(
-                                    color = heatCellColor(cell.level, emptyColor, activeColor),
-                                    topLeft = Offset(x, y),
-                                    size = Size(cellPx, cellPx),
-                                    cornerRadius = corner
-                                )
-                                if (selectedDate == cell.date) {
-                                    drawRoundRect(
-                                        color = ringColor,
-                                        topLeft = Offset(x, y),
-                                        size = Size(cellPx, cellPx),
-                                        cornerRadius = corner,
-                                        style = Stroke(width = 1.5.dp.toPx())
-                                    )
-                                }
-                            }
-                        }
-                    }
-                  }
-                  ScrollEdgeFade(
-                      visible = scrollState.canScrollBackward,
-                      atStart = true,
-                      color = fadeColor,
-                      height = gridHeight,
-                      modifier = Modifier.align(Alignment.CenterStart)
-                  )
-                  ScrollEdgeFade(
-                      visible = scrollState.canScrollForward,
-                      atStart = false,
-                      color = fadeColor,
-                      height = gridHeight,
-                      modifier = Modifier.align(Alignment.CenterEnd)
-                  )
-                }
-
-                Spacer(Modifier.height(16.dp))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
-                    Text(
-                        text = stringResource(R.string.statistics_activity_less),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = labelColor
-                    )
-                    listOf(0, 3, 6, 8, 10).forEach { level ->
-                        Box(
-                            Modifier
-                                .size(12.dp)
-                                .clip(RoundedCornerShape(3.dp))
-                                .background(heatCellColor(level, emptyColor, activeColor))
-                        )
-                    }
-                    Text(
-                        text = stringResource(R.string.statistics_activity_more),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = labelColor
-                    )
+                when (period) {
+                    ActivityPeriod.Month -> ActivityHeatmap(byDate)
+                    ActivityPeriod.Week -> ActivityWeekBreakdown(byDate)
                 }
             }
         }
+    }
+}
+
+/** The 48-hour-lag note. Both breakdowns carry it, because both render the same lagging data. */
+@Composable
+internal fun ActivityUpdateInfo(tint: Color) {
+    val tooltipState = rememberTooltipState()
+    val scope = rememberCoroutineScope()
+    TooltipBox(
+        positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
+            TooltipAnchorPosition.Above
+        ),
+        tooltip = {
+            PlainTooltip {
+                Text(stringResource(R.string.statistics_activity_update_info))
+            }
+        },
+        state = tooltipState
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Info,
+            contentDescription = stringResource(R.string.statistics_activity_update_info),
+            tint = tint,
+            modifier = Modifier
+                .clip(CircleShape)
+                .clickable { scope.launch { tooltipState.show() } }
+                .padding(2.dp)
+                .size(16.dp)
+        )
+    }
+}
+
+@Composable
+private fun ActivityHeatmap(byDate: Map<LocalDate, ActivityHistoryDay>) {
+    val model = remember(byDate) { buildHeatmapModel(byDate) }
+    var selected by remember(byDate) { mutableStateOf<HeatmapCell?>(null) }
+    val dateFormatter = remember { DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM) }
+
+    val emptyColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f)
+    val activeColor = MaterialTheme.colorScheme.primary
+    val ringColor = MaterialTheme.colorScheme.onSurface
+    val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val textMeasurer = rememberTextMeasurer()
+    val monthStyle = TextStyle(color = labelColor, fontSize = 10.sp)
+
+    val sel = selected
+    val headline = if (sel != null) {
+        pluralStringResource(
+            R.plurals.statistics_activity_count, sel.amount, sel.amount
+        ) + "  ·  " + sel.date.format(dateFormatter)
+    } else {
+        stringResource(
+            R.string.statistics_activity_summary,
+            model.totalActivities,
+            model.activeDays
+        )
+    }
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = headline,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f)
+        )
+        ActivityUpdateInfo(tint = labelColor)
+    }
+
+    Spacer(Modifier.height(16.dp))
+
+    val cellDp = 13.dp
+    val gapDp = 4.dp
+    val monthRowDp = 16.dp
+    val gridWidth = (cellDp + gapDp) * model.weeks.size
+    val gridHeight = monthRowDp + (cellDp + gapDp) * DAYS_IN_WEEK
+
+    val scrollState = rememberScrollState()
+    // Start scrolled to the most recent week (right edge), like GitHub.
+    LaunchedEffect(model, scrollState.maxValue) {
+        scrollState.scrollTo(scrollState.maxValue)
+    }
+
+    val a11y = stringResource(R.string.statistics_activity_a11y, model.totalActivities)
+    val selectedDate = sel?.date
+
+    Box(Modifier.fillMaxWidth()) {
+        val fadeColor = MaterialTheme.colorScheme.surfaceContainer
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .horizontalScroll(scrollState)
+                .semantics { contentDescription = a11y }
+        ) {
+            Canvas(
+                modifier = Modifier
+                    .size(width = gridWidth, height = gridHeight)
+                    .pointerInput(model) {
+                        val stridePx = cellDp.toPx() + gapDp.toPx()
+                        val monthPx = monthRowDp.toPx()
+                        detectTapGestures { offset ->
+                            if (offset.y < monthPx) return@detectTapGestures
+                            val w = (offset.x / stridePx).toInt()
+                            val r = ((offset.y - monthPx) / stridePx).toInt()
+                            val cell = model.weeks.getOrNull(w)?.getOrNull(r)
+                            if (cell != null && !cell.afterData) {
+                                selected = if (selected?.date == cell.date) null else cell
+                            }
+                        }
+                    }
+            ) {
+                val cellPx = cellDp.toPx()
+                val stridePx = cellPx + gapDp.toPx()
+                val monthPx = monthRowDp.toPx()
+                val corner = CornerRadius(cellPx * 0.28f, cellPx * 0.28f)
+
+                model.monthLabels.forEach { (weekIndex, label) ->
+                    drawText(
+                        textMeasurer = textMeasurer,
+                        text = label,
+                        topLeft = Offset(weekIndex * stridePx, 0f),
+                        style = monthStyle
+                    )
+                }
+
+                for (w in model.weeks.indices) {
+                    val column = model.weeks[w]
+                    for (r in 0 until DAYS_IN_WEEK) {
+                        val cell = column[r]
+                        if (cell.afterData) continue
+                        val x = w * stridePx
+                        val y = monthPx + r * stridePx
+                        drawRoundRect(
+                            color = heatCellColor(cell.level, emptyColor, activeColor),
+                            topLeft = Offset(x, y),
+                            size = Size(cellPx, cellPx),
+                            cornerRadius = corner
+                        )
+                        if (selectedDate == cell.date) {
+                            drawRoundRect(
+                                color = ringColor,
+                                topLeft = Offset(x, y),
+                                size = Size(cellPx, cellPx),
+                                cornerRadius = corner,
+                                style = Stroke(width = 1.5.dp.toPx())
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        ScrollEdgeFade(
+            visible = scrollState.canScrollBackward,
+            atStart = true,
+            color = fadeColor,
+            height = gridHeight,
+            modifier = Modifier.align(Alignment.CenterStart)
+        )
+        ScrollEdgeFade(
+            visible = scrollState.canScrollForward,
+            atStart = false,
+            color = fadeColor,
+            height = gridHeight,
+            modifier = Modifier.align(Alignment.CenterEnd)
+        )
+    }
+
+    Spacer(Modifier.height(16.dp))
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.statistics_activity_less),
+            style = MaterialTheme.typography.labelSmall,
+            color = labelColor
+        )
+        listOf(0, 3, 6, 8, 10).forEach { level ->
+            Box(
+                Modifier
+                    .size(12.dp)
+                    .clip(RoundedCornerShape(3.dp))
+                    .background(heatCellColor(level, emptyColor, activeColor))
+            )
+        }
+        Text(
+            text = stringResource(R.string.statistics_activity_more),
+            style = MaterialTheme.typography.labelSmall,
+            color = labelColor
+        )
     }
 }
 
@@ -357,7 +399,7 @@ private data class HeatmapCell(
 )
 
 private data class HeatmapModel(
-    /** [WEEK_COUNT] columns, each with [DAYS_IN_WEEK] cells (Sunday..Saturday). */
+    /** One column per week, each with [DAYS_IN_WEEK] cells (Sunday..Saturday). */
     val weeks: List<List<HeatmapCell>>,
     /** Week-column index -> short month name, emitted once per month change. */
     val monthLabels: List<Pair<Int, String>>,
@@ -365,16 +407,28 @@ private data class HeatmapModel(
     val activeDays: Int
 )
 
-private fun buildHeatmapModel(days: List<ActivityHistoryDay>): HeatmapModel {
-    // Day buckets are stamped at midnight in AniList's server zone (23:00 UTC during BST),
-    // so round to the nearest UTC day — truncating paints summer buckets one day early.
+/**
+ * Buckets AniList's timestamps into calendar days, keeping the busiest entry per day.
+ *
+ * Day buckets are stamped at midnight in AniList's server zone (23:00 UTC during BST),
+ * so round to the nearest UTC day — truncating paints summer buckets one day early.
+ * Both breakdowns share this, so a week's bars and the heatmap's cells cannot disagree.
+ */
+internal fun bucketActivityDays(
+    days: List<ActivityHistoryDay>
+): Map<LocalDate, ActivityHistoryDay> {
     val byDate = HashMap<LocalDate, ActivityHistoryDay>(days.size)
     for (day in days) {
-        val date = LocalDate.ofEpochDay(Math.floorDiv(day.date + SECONDS_PER_DAY / 2, SECONDS_PER_DAY))
+        val date = LocalDate.ofEpochDay(
+            Math.floorDiv(day.date + SECONDS_PER_DAY / 2, SECONDS_PER_DAY)
+        )
         val existing = byDate[date]
         if (existing == null || day.amount > existing.amount) byDate[date] = day
     }
+    return byDate
+}
 
+private fun buildHeatmapModel(byDate: Map<LocalDate, ActivityHistoryDay>): HeatmapModel {
     // Grid ends at the last day AniList has counted (stats lag ~48h) — padding out to
     // today draws empty cells the site doesn't show and reads as missing activity.
     val end = byDate.keys.max()
@@ -419,23 +473,23 @@ private fun buildHeatmapModel(days: List<ActivityHistoryDay>): HeatmapModel {
 }
 
 
-@Preview(showBackground = true, name = "ActivityHeatmap — light", widthDp = 360)
+@Preview(showBackground = true, name = "ActivityHistory — light", widthDp = 360)
 @Composable
-private fun ActivityHeatmapLightPreview() {
+private fun ActivityHistoryLightPreview() {
     StatPreviewSurface(isDark = false) {
-        ActivityHeatmapSection(days = previewActivityDays())
+        ActivityHistorySection(days = previewActivityDays())
     }
 }
 
-@Preview(showBackground = true, name = "ActivityHeatmap — dark", widthDp = 360)
+@Preview(showBackground = true, name = "ActivityHistory — dark", widthDp = 360)
 @Composable
-private fun ActivityHeatmapDarkPreview() {
+private fun ActivityHistoryDarkPreview() {
     StatPreviewSurface(isDark = true) {
-        ActivityHeatmapSection(days = previewActivityDays())
+        ActivityHistorySection(days = previewActivityDays())
     }
 }
 
-private fun previewActivityDays(): List<ActivityHistoryDay> {
+internal fun previewActivityDays(): List<ActivityHistoryDay> {
     val today = LocalDate.now()
     return (0 until 320).mapNotNull { i ->
         val amount = (i * 7 + i / 3) % 14

--- a/app/src/main/java/com/anisync/android/presentation/statistics/ActivityHeatmapSection.kt
+++ b/app/src/main/java/com/anisync/android/presentation/statistics/ActivityHeatmapSection.kt
@@ -111,6 +111,8 @@ private enum class ActivityPeriod(val labelRes: Int, val icon: ImageVector) {
 fun ActivityHistorySection(
     days: List<ActivityHistoryDay>,
     userId: Int,
+    onMediaClick: (Int) -> Unit = {},
+    onActivityClick: (Int) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     if (days.isEmpty()) return
@@ -148,7 +150,12 @@ fun ActivityHistorySection(
 
                 when (period) {
                     ActivityPeriod.Month -> ActivityHeatmap(byDate)
-                    ActivityPeriod.Week -> ActivityWeekBreakdown(byDate, userId)
+                    ActivityPeriod.Week -> ActivityWeekBreakdown(
+                        byDate = byDate,
+                        userId = userId,
+                        onMediaClick = onMediaClick,
+                        onActivityClick = onActivityClick
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/anisync/android/presentation/statistics/ActivityHeatmapSection.kt
+++ b/app/src/main/java/com/anisync/android/presentation/statistics/ActivityHeatmapSection.kt
@@ -110,6 +110,7 @@ private enum class ActivityPeriod(val labelRes: Int, val icon: ImageVector) {
 @Composable
 fun ActivityHistorySection(
     days: List<ActivityHistoryDay>,
+    userId: Int,
     modifier: Modifier = Modifier
 ) {
     if (days.isEmpty()) return
@@ -147,7 +148,7 @@ fun ActivityHistorySection(
 
                 when (period) {
                     ActivityPeriod.Month -> ActivityHeatmap(byDate)
-                    ActivityPeriod.Week -> ActivityWeekBreakdown(byDate)
+                    ActivityPeriod.Week -> ActivityWeekBreakdown(byDate, userId)
                 }
             }
         }
@@ -477,7 +478,7 @@ private fun buildHeatmapModel(byDate: Map<LocalDate, ActivityHistoryDay>): Heatm
 @Composable
 private fun ActivityHistoryLightPreview() {
     StatPreviewSurface(isDark = false) {
-        ActivityHistorySection(days = previewActivityDays())
+        ActivityHistorySection(days = previewActivityDays(), userId = 1)
     }
 }
 
@@ -485,7 +486,7 @@ private fun ActivityHistoryLightPreview() {
 @Composable
 private fun ActivityHistoryDarkPreview() {
     StatPreviewSurface(isDark = true) {
-        ActivityHistorySection(days = previewActivityDays())
+        ActivityHistorySection(days = previewActivityDays(), userId = 1)
     }
 }
 

--- a/app/src/main/java/com/anisync/android/presentation/statistics/ActivityWeekBreakdown.kt
+++ b/app/src/main/java/com/anisync/android/presentation/statistics/ActivityWeekBreakdown.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 
@@ -89,6 +90,7 @@ internal fun ActivityWeekBreakdown(byDate: Map<LocalDate, ActivityHistoryDay>, u
 
     val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
     val mutedColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+    val locale = LocalConfiguration.current.locales[0]
 
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -105,7 +107,7 @@ internal fun ActivityWeekBreakdown(byDate: Map<LocalDate, ActivityHistoryDay>, u
                     modifier = Modifier.weight(1f)
                 )
                 Text(
-                    text = stringResource(R.string.statistics_activity_per_day, week.perDayLabel()),
+                    text = stringResource(R.string.statistics_activity_per_day, week.perDayLabel(locale)),
                     style = MaterialTheme.typography.labelMedium,
                     color = mutedColor
                 )
@@ -155,7 +157,8 @@ private fun WeekNavigation(
     onPrevious: () -> Unit,
     onNext: () -> Unit
 ) {
-    val rangeFormatter = remember { DateTimeFormatter.ofPattern("MMM d", Locale.getDefault()) }
+    val locale = LocalConfiguration.current.locales[0]
+    val rangeFormatter = remember(locale) { DateTimeFormatter.ofPattern("MMM d", locale) }
 
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -229,17 +232,16 @@ private fun ActivityDayRow(day: ActivityDay, weekMax: Int, onClick: (() -> Unit)
         }
     )
 
+    val locale = LocalConfiguration.current.locales[0]
+    val fullDayName = day.date.dayOfWeek.getDisplayName(TextStyle.FULL, locale)
     val description = when (day.state) {
         DayDataState.Counted -> stringResource(
             R.string.a11y_activity_day,
-            day.date.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.getDefault()),
+            fullDayName,
             pluralStringResource(R.plurals.statistics_activity_count, day.amount, day.amount)
         )
-        DayDataState.Awaiting -> stringResource(
-            R.string.a11y_activity_day_awaiting,
-            day.date.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.getDefault())
-        )
-        DayDataState.Future -> day.date.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.getDefault())
+        DayDataState.Awaiting -> stringResource(R.string.a11y_activity_day_awaiting, fullDayName)
+        DayDataState.Future -> fullDayName
     }
 
     Row(
@@ -257,7 +259,7 @@ private fun ActivityDayRow(day: ActivityDay, weekMax: Int, onClick: (() -> Unit)
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
-            text = day.date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault()),
+            text = day.date.dayOfWeek.getDisplayName(TextStyle.SHORT, locale),
             style = MaterialTheme.typography.labelLarge,
             fontWeight = FontWeight.Bold,
             color = when {
@@ -336,6 +338,7 @@ private fun ActivityDayRow(day: ActivityDay, weekMax: Int, onClick: (() -> Unit)
 
 @Composable
 private fun WeekSummary(week: ActivityWeek) {
+    val locale = LocalConfiguration.current.locales[0]
     val busiest = week.busiest
     val stats = buildList {
         add(
@@ -343,7 +346,7 @@ private fun WeekSummary(week: ActivityWeek) {
                 busiest?.let {
                     stringResource(
                         R.string.statistics_activity_busiest_value,
-                        it.date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault()),
+                        it.date.dayOfWeek.getDisplayName(TextStyle.SHORT, locale),
                         it.amount
                     )
                 } ?: stringResource(R.string.statistics_activity_no_value)
@@ -441,10 +444,10 @@ internal data class ActivityWeek(
     val busiestAmount: Int get() = busiest?.amount ?: 0
 
     /** Averaged over counted days only — dividing by 7 understates a half-counted current week. */
-    fun perDayLabel(): String {
+    fun perDayLabel(locale: Locale): String {
         if (countedDays == 0) return "0"
         val perDay = total.toFloat() / countedDays
-        return String.format(Locale.getDefault(), "%.1f", perDay)
+        return String.format(locale, "%.1f", perDay)
     }
 }
 

--- a/app/src/main/java/com/anisync/android/presentation/statistics/ActivityWeekBreakdown.kt
+++ b/app/src/main/java/com/anisync/android/presentation/statistics/ActivityWeekBreakdown.kt
@@ -1,0 +1,489 @@
+package com.anisync.android.presentation.statistics
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.anisync.android.R
+import com.anisync.android.domain.ActivityHistoryDay
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.TextStyle
+import java.time.temporal.TemporalAdjusters
+import java.util.Locale
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+/**
+ * Past this width the bars stop growing and the block centres instead. A 900.dp-wide bar carries
+ * no more information than a 500.dp one, and the row's day label and count drift apart until they
+ * stop reading as one row.
+ */
+private val WeekContentMaxWidth = 560.dp
+
+private val BarHeight = 18.dp
+private val RowHeight = 32.dp
+
+/** Shortest bar drawn for a day with any activity, so a single activity is still visible. */
+private val MinBarWidth = 20.dp
+
+/** How much of AniList's window the user may page back through, mirroring the heatmap's cap. */
+private const val MAX_WEEKS_BACK = 52
+
+/**
+ * One Sunday-to-Saturday week of [ActivityHistoryDay] data, each day drawn as a bar proportional
+ * to the busiest day in that week.
+ *
+ * The interesting part is not the bars, it is the three states a day can be in. AniList recomputes
+ * `activityHistory` roughly every 48 hours, so the current week always ends in days that have no
+ * counts yet. Drawing those as zero would read as "you did nothing", so they are drawn as
+ * [DayDataState.Awaiting] instead, and days that have not happened yet as [DayDataState.Future].
+ */
+@Composable
+internal fun ActivityWeekBreakdown(byDate: Map<LocalDate, ActivityHistoryDay>) {
+    var weekOffset by rememberSaveable { mutableIntStateOf(0) }
+    val week = remember(byDate, weekOffset) { buildActivityWeek(byDate, weekOffset) }
+
+    val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val mutedColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Column(Modifier.widthIn(max = WeekContentMaxWidth)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = pluralStringResource(
+                        R.plurals.statistics_activity_count, week.total, week.total
+                    ),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f)
+                )
+                Text(
+                    text = stringResource(R.string.statistics_activity_per_day, week.perDayLabel()),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = mutedColor
+                )
+                Spacer(Modifier.width(10.dp))
+                ActivityUpdateInfo(tint = labelColor)
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            WeekNavigation(
+                week = week,
+                onPrevious = { weekOffset -= 1 },
+                onNext = { weekOffset += 1 }
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            week.days.forEach { day ->
+                ActivityDayRow(day = day, weekMax = week.busiestAmount)
+                Spacer(Modifier.height(4.dp))
+            }
+
+            Spacer(Modifier.height(12.dp))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+            Spacer(Modifier.height(12.dp))
+
+            WeekSummary(week)
+        }
+    }
+}
+
+@Composable
+private fun WeekNavigation(
+    week: ActivityWeek,
+    onPrevious: () -> Unit,
+    onNext: () -> Unit
+) {
+    val rangeFormatter = remember { DateTimeFormatter.ofPattern("MMM d", Locale.getDefault()) }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        FilledTonalIconButton(
+            onClick = onPrevious,
+            enabled = week.canGoBack,
+            colors = IconButtonDefaults.filledTonalIconButtonColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+            )
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowLeft,
+                contentDescription = stringResource(R.string.cd_activity_week_previous)
+            )
+        }
+
+        Column(
+            modifier = Modifier.weight(1f),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = stringResource(
+                    R.string.statistics_activity_week_range,
+                    week.start.format(rangeFormatter),
+                    week.start.plusDays(6).format(rangeFormatter)
+                ),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = when (week.offset) {
+                    0 -> stringResource(R.string.statistics_activity_week_current)
+                    -1 -> stringResource(R.string.statistics_activity_week_previous)
+                    else -> pluralStringResource(
+                        R.plurals.statistics_activity_weeks_ago,
+                        abs(week.offset),
+                        abs(week.offset)
+                    )
+                },
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+            )
+        }
+
+        FilledTonalIconButton(
+            onClick = onNext,
+            enabled = week.canGoForward,
+            colors = IconButtonDefaults.filledTonalIconButtonColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+            )
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                contentDescription = stringResource(R.string.cd_activity_week_next)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ActivityDayRow(day: ActivityDay, weekMax: Int) {
+    val counted = day.state == DayDataState.Counted
+    val muted = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+    val trackColor = MaterialTheme.colorScheme.onSurface.copy(
+        alpha = when (day.state) {
+            DayDataState.Counted -> 0.08f
+            DayDataState.Awaiting -> 0.06f
+            DayDataState.Future -> 0.04f
+        }
+    )
+
+    val description = when (day.state) {
+        DayDataState.Counted -> stringResource(
+            R.string.a11y_activity_day,
+            day.date.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.getDefault()),
+            pluralStringResource(R.plurals.statistics_activity_count, day.amount, day.amount)
+        )
+        DayDataState.Awaiting -> stringResource(
+            R.string.a11y_activity_day_awaiting,
+            day.date.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.getDefault())
+        )
+        DayDataState.Future -> day.date.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.getDefault())
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(RowHeight)
+            .clip(RoundedCornerShape(12.dp))
+            .then(
+                if (day.isToday) Modifier.background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                else Modifier
+            )
+            .padding(horizontal = if (day.isToday) 8.dp else 0.dp)
+            .clearAndSetSemantics { contentDescription = description },
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = day.date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault()),
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            color = when {
+                day.isToday -> MaterialTheme.colorScheme.primary
+                day.state == DayDataState.Future -> muted
+                else -> MaterialTheme.colorScheme.onSurfaceVariant
+            },
+            modifier = Modifier.width(36.dp)
+        )
+        Text(
+            text = day.date.dayOfMonth.toString(),
+            style = MaterialTheme.typography.labelMedium,
+            color = muted,
+            modifier = Modifier.width(24.dp)
+        )
+
+        BoxWithConstraints(
+            modifier = Modifier
+                .weight(1f)
+                .height(BarHeight)
+                .clip(CircleShape)
+                .background(trackColor),
+            contentAlignment = Alignment.CenterStart
+        ) {
+            if (counted && day.amount > 0) {
+                val fraction = day.amount.toFloat() / weekMax.coerceAtLeast(1)
+                Box(
+                    Modifier
+                        .width((maxWidth * fraction).coerceAtLeast(MinBarWidth))
+                        .fillMaxHeight()
+                        .clip(CircleShape)
+                        .background(
+                            MaterialTheme.colorScheme.primary.copy(
+                                alpha = 0.35f + 0.65f * fraction
+                            )
+                        )
+                )
+            } else if (day.state == DayDataState.Awaiting) {
+                Text(
+                    text = if (day.isToday) stringResource(R.string.statistics_activity_today_pending)
+                    else stringResource(R.string.statistics_activity_awaiting_inline),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = muted,
+                    modifier = Modifier.padding(start = 12.dp)
+                )
+            }
+        }
+
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = when (day.state) {
+                DayDataState.Counted -> day.amount.toString()
+                DayDataState.Awaiting -> stringResource(R.string.statistics_activity_no_value)
+                DayDataState.Future -> ""
+            },
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.End,
+            color = if (counted && day.amount > 0) MaterialTheme.colorScheme.onSurface else muted,
+            modifier = Modifier.width(32.dp)
+        )
+    }
+}
+
+@Composable
+private fun WeekSummary(week: ActivityWeek) {
+    val busiest = week.busiest
+    val stats = buildList {
+        add(
+            stringResource(R.string.statistics_activity_busiest_day) to (
+                busiest?.let {
+                    stringResource(
+                        R.string.statistics_activity_busiest_value,
+                        it.date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault()),
+                        it.amount
+                    )
+                } ?: stringResource(R.string.statistics_activity_no_value)
+                )
+        )
+        if (week.awaitingDays > 0) {
+            add(
+                stringResource(R.string.statistics_activity_days_counted) to stringResource(
+                    R.string.statistics_activity_day_ratio, week.countedDays, DAYS_IN_WEEK
+                )
+            )
+            add(
+                stringResource(R.string.statistics_activity_awaiting) to pluralStringResource(
+                    R.plurals.statistics_activity_days, week.awaitingDays, week.awaitingDays
+                )
+            )
+        } else {
+            add(
+                stringResource(R.string.statistics_activity_active_days) to stringResource(
+                    R.string.statistics_activity_day_ratio, week.activeDays, DAYS_IN_WEEK
+                )
+            )
+            add(
+                stringResource(R.string.statistics_activity_vs_previous) to when {
+                    week.changePercent == null -> stringResource(R.string.statistics_activity_no_value)
+                    week.changePercent >= 0 -> stringResource(
+                        R.string.statistics_activity_percent_up, week.changePercent
+                    )
+                    else -> stringResource(
+                        R.string.statistics_activity_percent_down, abs(week.changePercent)
+                    )
+                }
+            )
+        }
+    }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        stats.forEach { (label, value) ->
+            Column(
+                modifier = Modifier.weight(1f),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                    textAlign = TextAlign.Center
+                )
+                Spacer(Modifier.size(2.dp))
+                Text(
+                    text = value,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}
+
+/** Whether AniList has actually counted a day yet, which is not the same as the day being empty. */
+internal enum class DayDataState { Counted, Awaiting, Future }
+
+internal data class ActivityDay(
+    val date: LocalDate,
+    val amount: Int,
+    val state: DayDataState,
+    val isToday: Boolean
+)
+
+internal data class ActivityWeek(
+    val start: LocalDate,
+    /** 0 = the week containing today, negative = further back. */
+    val offset: Int,
+    val days: List<ActivityDay>,
+    val total: Int,
+    val countedDays: Int,
+    val activeDays: Int,
+    val awaitingDays: Int,
+    val busiest: ActivityDay?,
+    /** Percent change against the previous week, or null when that week is not fully counted. */
+    val changePercent: Int?,
+    val canGoBack: Boolean,
+    val canGoForward: Boolean
+) {
+    val busiestAmount: Int get() = busiest?.amount ?: 0
+
+    /** Averaged over counted days only — dividing by 7 understates a half-counted current week. */
+    fun perDayLabel(): String {
+        if (countedDays == 0) return "0"
+        val perDay = total.toFloat() / countedDays
+        return String.format(Locale.getDefault(), "%.1f", perDay)
+    }
+}
+
+internal fun buildActivityWeek(
+    byDate: Map<LocalDate, ActivityHistoryDay>,
+    offset: Int,
+    today: LocalDate = LocalDate.now()
+): ActivityWeek {
+    val lastCounted = byDate.keys.maxOrNull() ?: today
+    val earliestStart = (byDate.keys.minOrNull() ?: today)
+        .with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY))
+    val currentStart = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY))
+    val start = currentStart.plusWeeks(offset.toLong())
+
+    val days = (0 until DAYS_IN_WEEK).map { index ->
+        val date = start.plusDays(index.toLong())
+        val state = when {
+            date.isAfter(today) -> DayDataState.Future
+            date.isAfter(lastCounted) -> DayDataState.Awaiting
+            else -> DayDataState.Counted
+        }
+        ActivityDay(
+            date = date,
+            amount = if (state == DayDataState.Counted) byDate[date]?.amount ?: 0 else 0,
+            state = state,
+            isToday = date == today
+        )
+    }
+
+    val counted = days.filter { it.state == DayDataState.Counted }
+    val previousTotal = previousWeekTotal(byDate, start, lastCounted)
+    val total = counted.sumOf { it.amount }
+
+    return ActivityWeek(
+        start = start,
+        offset = offset,
+        days = days,
+        total = total,
+        countedDays = counted.size,
+        activeDays = counted.count { it.amount > 0 },
+        awaitingDays = days.count { it.state == DayDataState.Awaiting },
+        busiest = counted.filter { it.amount > 0 }.maxByOrNull { it.amount },
+        changePercent = when {
+            previousTotal == null || previousTotal == 0 -> null
+            else -> (((total - previousTotal) * 100f) / previousTotal).roundToInt()
+        },
+        canGoBack = start.isAfter(earliestStart) && offset > -MAX_WEEKS_BACK,
+        canGoForward = offset < 0
+    )
+}
+
+/** Null when the previous week is not fully counted, so a partial week never skews the comparison. */
+private fun previousWeekTotal(
+    byDate: Map<LocalDate, ActivityHistoryDay>,
+    start: LocalDate,
+    lastCounted: LocalDate
+): Int? {
+    val previousStart = start.minusWeeks(1)
+    if (previousStart.plusDays((DAYS_IN_WEEK - 1).toLong()).isAfter(lastCounted)) return null
+    return (0 until DAYS_IN_WEEK).sumOf { byDate[previousStart.plusDays(it.toLong())]?.amount ?: 0 }
+}
+
+@Preview(showBackground = true, name = "ActivityWeek — dark", widthDp = 360)
+@Composable
+private fun ActivityWeekDarkPreview() {
+    StatPreviewSurface(isDark = true) {
+        ActivityWeekBreakdown(bucketActivityDays(previewActivityDays()))
+    }
+}
+
+@Preview(showBackground = true, name = "ActivityWeek — tablet width", widthDp = 800)
+@Composable
+private fun ActivityWeekWidePreview() {
+    StatPreviewSurface(isDark = true) {
+        ActivityWeekBreakdown(bucketActivityDays(previewActivityDays()))
+    }
+}

--- a/app/src/main/java/com/anisync/android/presentation/statistics/ActivityWeekBreakdown.kt
+++ b/app/src/main/java/com/anisync/android/presentation/statistics/ActivityWeekBreakdown.kt
@@ -1,6 +1,7 @@
 package com.anisync.android.presentation.statistics
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -28,6 +29,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -36,8 +38,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.clearAndSetSemantics
+
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -79,8 +82,9 @@ private const val MAX_WEEKS_BACK = 52
  * [DayDataState.Awaiting] instead, and days that have not happened yet as [DayDataState.Future].
  */
 @Composable
-internal fun ActivityWeekBreakdown(byDate: Map<LocalDate, ActivityHistoryDay>) {
+internal fun ActivityWeekBreakdown(byDate: Map<LocalDate, ActivityHistoryDay>, userId: Int) {
     var weekOffset by rememberSaveable { mutableIntStateOf(0) }
+    var openDay by remember { mutableStateOf<LocalDate?>(null) }
     val week = remember(byDate, weekOffset) { buildActivityWeek(byDate, weekOffset) }
 
     val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
@@ -120,7 +124,11 @@ internal fun ActivityWeekBreakdown(byDate: Map<LocalDate, ActivityHistoryDay>) {
             Spacer(Modifier.height(12.dp))
 
             week.days.forEach { day ->
-                ActivityDayRow(day = day, weekMax = week.busiestAmount)
+                ActivityDayRow(
+                    day = day,
+                    weekMax = week.busiestAmount,
+                    onClick = if (day.amount > 0) ({ openDay = day.date }) else null
+                )
                 Spacer(Modifier.height(4.dp))
             }
 
@@ -130,6 +138,14 @@ internal fun ActivityWeekBreakdown(byDate: Map<LocalDate, ActivityHistoryDay>) {
 
             WeekSummary(week)
         }
+    }
+
+    openDay?.let { date ->
+        ActivityDaySheet(
+            userId = userId,
+            date = date,
+            onDismiss = { openDay = null }
+        )
     }
 }
 
@@ -202,7 +218,7 @@ private fun WeekNavigation(
 }
 
 @Composable
-private fun ActivityDayRow(day: ActivityDay, weekMax: Int) {
+private fun ActivityDayRow(day: ActivityDay, weekMax: Int, onClick: (() -> Unit)?) {
     val counted = day.state == DayDataState.Counted
     val muted = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
     val trackColor = MaterialTheme.colorScheme.onSurface.copy(
@@ -235,8 +251,9 @@ private fun ActivityDayRow(day: ActivityDay, weekMax: Int) {
                 if (day.isToday) Modifier.background(MaterialTheme.colorScheme.surfaceContainerHigh)
                 else Modifier
             )
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
             .padding(horizontal = if (day.isToday) 8.dp else 0.dp)
-            .clearAndSetSemantics { contentDescription = description },
+            .semantics(mergeDescendants = true) { contentDescription = description },
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
@@ -302,6 +319,18 @@ private fun ActivityDayRow(day: ActivityDay, weekMax: Int) {
             color = if (counted && day.amount > 0) MaterialTheme.colorScheme.onSurface else muted,
             modifier = Modifier.width(32.dp)
         )
+
+        // Only days with something to show advertise a tap.
+        if (onClick != null) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                contentDescription = null,
+                tint = muted,
+                modifier = Modifier.size(16.dp)
+            )
+        } else {
+            Spacer(Modifier.width(16.dp))
+        }
     }
 }
 
@@ -476,7 +505,7 @@ private fun previousWeekTotal(
 @Composable
 private fun ActivityWeekDarkPreview() {
     StatPreviewSurface(isDark = true) {
-        ActivityWeekBreakdown(bucketActivityDays(previewActivityDays()))
+        ActivityWeekBreakdown(bucketActivityDays(previewActivityDays()), userId = 1)
     }
 }
 
@@ -484,6 +513,6 @@ private fun ActivityWeekDarkPreview() {
 @Composable
 private fun ActivityWeekWidePreview() {
     StatPreviewSurface(isDark = true) {
-        ActivityWeekBreakdown(bucketActivityDays(previewActivityDays()))
+        ActivityWeekBreakdown(bucketActivityDays(previewActivityDays()), userId = 1)
     }
 }

--- a/app/src/main/java/com/anisync/android/presentation/statistics/ActivityWeekBreakdown.kt
+++ b/app/src/main/java/com/anisync/android/presentation/statistics/ActivityWeekBreakdown.kt
@@ -84,7 +84,7 @@ private const val MAX_WEEKS_BACK = 52
 @Composable
 internal fun ActivityWeekBreakdown(byDate: Map<LocalDate, ActivityHistoryDay>, userId: Int) {
     var weekOffset by rememberSaveable { mutableIntStateOf(0) }
-    var openDay by remember { mutableStateOf<LocalDate?>(null) }
+    var openDay by remember { mutableStateOf<ActivityDay?>(null) }
     val week = remember(byDate, weekOffset) { buildActivityWeek(byDate, weekOffset) }
 
     val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
@@ -127,7 +127,7 @@ internal fun ActivityWeekBreakdown(byDate: Map<LocalDate, ActivityHistoryDay>, u
                 ActivityDayRow(
                     day = day,
                     weekMax = week.busiestAmount,
-                    onClick = if (day.amount > 0) ({ openDay = day.date }) else null
+                    onClick = if (day.amount > 0) ({ openDay = day }) else null
                 )
                 Spacer(Modifier.height(4.dp))
             }
@@ -140,10 +140,10 @@ internal fun ActivityWeekBreakdown(byDate: Map<LocalDate, ActivityHistoryDay>, u
         }
     }
 
-    openDay?.let { date ->
+    openDay?.let { day ->
         ActivityDaySheet(
             userId = userId,
-            date = date,
+            day = day,
             onDismiss = { openDay = null }
         )
     }
@@ -414,7 +414,13 @@ internal data class ActivityDay(
     val date: LocalDate,
     val amount: Int,
     val state: DayDataState,
-    val isToday: Boolean
+    val isToday: Boolean,
+    /**
+     * AniList's own bucket timestamp for the day, which is midnight in *its* zone rather than in
+     * UTC. The day sheet queries from here, so the list it opens covers the same hours AniList
+     * counted into the bar.
+     */
+    val epochSeconds: Long?
 )
 
 internal data class ActivityWeek(
@@ -460,11 +466,13 @@ internal fun buildActivityWeek(
             date.isAfter(lastCounted) -> DayDataState.Awaiting
             else -> DayDataState.Counted
         }
+        val entry = byDate[date]
         ActivityDay(
             date = date,
-            amount = if (state == DayDataState.Counted) byDate[date]?.amount ?: 0 else 0,
+            amount = if (state == DayDataState.Counted) entry?.amount ?: 0 else 0,
             state = state,
-            isToday = date == today
+            isToday = date == today,
+            epochSeconds = entry?.date
         )
     }
 

--- a/app/src/main/java/com/anisync/android/presentation/statistics/ActivityWeekBreakdown.kt
+++ b/app/src/main/java/com/anisync/android/presentation/statistics/ActivityWeekBreakdown.kt
@@ -83,7 +83,12 @@ private const val MAX_WEEKS_BACK = 52
  * [DayDataState.Awaiting] instead, and days that have not happened yet as [DayDataState.Future].
  */
 @Composable
-internal fun ActivityWeekBreakdown(byDate: Map<LocalDate, ActivityHistoryDay>, userId: Int) {
+internal fun ActivityWeekBreakdown(
+    byDate: Map<LocalDate, ActivityHistoryDay>,
+    userId: Int,
+    onMediaClick: (Int) -> Unit,
+    onActivityClick: (Int) -> Unit
+) {
     var weekOffset by rememberSaveable { mutableIntStateOf(0) }
     var openDay by remember { mutableStateOf<ActivityDay?>(null) }
     val week = remember(byDate, weekOffset) { buildActivityWeek(byDate, weekOffset) }
@@ -146,7 +151,14 @@ internal fun ActivityWeekBreakdown(byDate: Map<LocalDate, ActivityHistoryDay>, u
         ActivityDaySheet(
             userId = userId,
             day = day,
-            onDismiss = { openDay = null }
+            onDismiss = { openDay = null },
+            onOpenActivity = { activity ->
+                // The sheet is a dead end otherwise: a row names something the user then has to go
+                // and find. Close first, so returning does not land back on top of the sheet.
+                openDay = null
+                val mediaId = activity.mediaId
+                if (mediaId != null) onMediaClick(mediaId) else onActivityClick(activity.id)
+            }
         )
     }
 }
@@ -516,7 +528,12 @@ private fun previousWeekTotal(
 @Composable
 private fun ActivityWeekDarkPreview() {
     StatPreviewSurface(isDark = true) {
-        ActivityWeekBreakdown(bucketActivityDays(previewActivityDays()), userId = 1)
+        ActivityWeekBreakdown(
+            byDate = bucketActivityDays(previewActivityDays()),
+            userId = 1,
+            onMediaClick = {},
+            onActivityClick = {}
+        )
     }
 }
 
@@ -524,6 +541,11 @@ private fun ActivityWeekDarkPreview() {
 @Composable
 private fun ActivityWeekWidePreview() {
     StatPreviewSurface(isDark = true) {
-        ActivityWeekBreakdown(bucketActivityDays(previewActivityDays()), userId = 1)
+        ActivityWeekBreakdown(
+            byDate = bucketActivityDays(previewActivityDays()),
+            userId = 1,
+            onMediaClick = {},
+            onActivityClick = {}
+        )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -952,6 +952,8 @@
         <item quantity="one">%d day</item>
         <item quantity="other">%d days</item>
     </plurals>
+    <string name="statistics_activity_day_empty">AniList counted activity on this day, but none of it is in the activity feed any more.</string>
+    <string name="statistics_activity_day_status">Activity</string>
     <string name="cd_activity_week_previous">Previous week</string>
     <string name="cd_activity_week_next">Next week</string>
     <string name="a11y_activity_day">%1$s: %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -954,6 +954,7 @@
     </plurals>
     <string name="statistics_activity_day_empty">AniList counted activity on this day, but none of it is in the activity feed any more.</string>
     <string name="statistics_activity_day_status">Activity</string>
+    <string name="statistics_activity_day_posted">Posted a status</string>
     <string name="cd_activity_week_previous">Previous week</string>
     <string name="cd_activity_week_next">Next week</string>
     <string name="a11y_activity_day">%1$s: %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -925,6 +925,38 @@
         <item quantity="other">%d activities</item>
     </plurals>
 
+    <!-- Activity history: week breakdown -->
+    <string name="statistics_activity_period_month">Month</string>
+    <string name="statistics_activity_period_week">Week</string>
+    <string name="statistics_activity_week_range">%1$s – %2$s</string>
+    <string name="statistics_activity_week_current">This week</string>
+    <string name="statistics_activity_week_previous">Last week</string>
+    <string name="statistics_activity_per_day">%1$s / day</string>
+    <string name="statistics_activity_busiest_day">Busiest day</string>
+    <string name="statistics_activity_busiest_value">%1$s · %2$d</string>
+    <string name="statistics_activity_active_days">Active days</string>
+    <string name="statistics_activity_days_counted">Days counted</string>
+    <string name="statistics_activity_awaiting">Awaiting stats</string>
+    <string name="statistics_activity_awaiting_inline">Awaiting AniList stats</string>
+    <string name="statistics_activity_today_pending">Today · not counted yet</string>
+    <string name="statistics_activity_vs_previous">vs last week</string>
+    <string name="statistics_activity_day_ratio">%1$d of %2$d</string>
+    <string name="statistics_activity_percent_up">+%1$d%%</string>
+    <string name="statistics_activity_percent_down">-%1$d%%</string>
+    <string name="statistics_activity_no_value">—</string>
+    <plurals name="statistics_activity_weeks_ago">
+        <item quantity="one">%d week ago</item>
+        <item quantity="other">%d weeks ago</item>
+    </plurals>
+    <plurals name="statistics_activity_days">
+        <item quantity="one">%d day</item>
+        <item quantity="other">%d days</item>
+    </plurals>
+    <string name="cd_activity_week_previous">Previous week</string>
+    <string name="cd_activity_week_next">Next week</string>
+    <string name="a11y_activity_day">%1$s: %2$s</string>
+    <string name="a11y_activity_day_awaiting">%1$s: not counted yet</string>
+
     <!-- Accessibility: Statistics -->
     <string name="a11y_stat_card">%1$s: %2$s</string>
     <string name="a11y_score_bar">Score %1$d: %2$d entries</string>

--- a/app/src/test/java/com/anisync/android/presentation/statistics/ActivityWeekTest.kt
+++ b/app/src/test/java/com/anisync/android/presentation/statistics/ActivityWeekTest.kt
@@ -8,6 +8,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.LocalDate
 import java.time.ZoneOffset
+import java.util.Locale
 
 class ActivityWeekTest {
 
@@ -136,6 +137,6 @@ class ActivityWeekTest {
 
         assertEquals(19, week.total)
         assertEquals(3, week.countedDays)
-        assertEquals("6.3", week.perDayLabel().replace(',', '.'))
+        assertEquals("6.3", week.perDayLabel(Locale.US))
     }
 }

--- a/app/src/test/java/com/anisync/android/presentation/statistics/ActivityWeekTest.kt
+++ b/app/src/test/java/com/anisync/android/presentation/statistics/ActivityWeekTest.kt
@@ -1,0 +1,141 @@
+package com.anisync.android.presentation.statistics
+
+import com.anisync.android.domain.ActivityHistoryDay
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+class ActivityWeekTest {
+
+    /** A Thursday, so the current week runs Sun 9 August to Sat 15 August. */
+    private val today: LocalDate = LocalDate.of(2026, 8, 13)
+
+    private fun day(date: LocalDate, amount: Int): ActivityHistoryDay = ActivityHistoryDay(
+        // AniList stamps a day at midnight in its own zone, which lands the day before in UTC.
+        date = date.minusDays(1).atStartOfDay(ZoneOffset.UTC).plusHours(23).toEpochSecond(),
+        amount = amount,
+        level = amount.coerceIn(1, 10)
+    )
+
+    private fun history(vararg entries: Pair<LocalDate, Int>): Map<LocalDate, ActivityHistoryDay> =
+        bucketActivityDays(entries.map { (date, amount) -> day(date, amount) })
+
+    @Test
+    fun `days past the last counted day are awaiting rather than empty`() {
+        val byDate = history(
+            LocalDate.of(2026, 8, 9) to 6,
+            LocalDate.of(2026, 8, 10) to 3,
+            LocalDate.of(2026, 8, 11) to 10
+        )
+
+        val week = buildActivityWeek(byDate, offset = 0, today = today)
+
+        assertEquals(LocalDate.of(2026, 8, 9), week.start)
+        assertEquals(
+            listOf(
+                DayDataState.Counted,
+                DayDataState.Counted,
+                DayDataState.Counted,
+                DayDataState.Awaiting,
+                DayDataState.Awaiting,
+                DayDataState.Future,
+                DayDataState.Future
+            ),
+            week.days.map { it.state }
+        )
+        assertEquals(19, week.total)
+        assertEquals(3, week.countedDays)
+        assertEquals(2, week.awaitingDays)
+        assertEquals(LocalDate.of(2026, 8, 11), week.busiest?.date)
+    }
+
+    @Test
+    fun `a counted day with no entry is zero, not awaiting`() {
+        val byDate = history(
+            LocalDate.of(2026, 8, 2) to 5,
+            LocalDate.of(2026, 8, 4) to 8,
+            LocalDate.of(2026, 8, 11) to 1
+        )
+
+        val week = buildActivityWeek(byDate, offset = -1, today = today)
+
+        assertEquals(LocalDate.of(2026, 8, 2), week.start)
+        assertTrue(week.days.all { it.state == DayDataState.Counted })
+        assertEquals(0, week.days[1].amount)
+        assertEquals(2, week.activeDays)
+        assertEquals(13, week.total)
+    }
+
+    @Test
+    fun `the day carries AniList's own bucket timestamp so the sheet can query it`() {
+        val date = LocalDate.of(2026, 8, 10)
+        val byDate = history(date to 2, LocalDate.of(2026, 8, 11) to 1)
+
+        val week = buildActivityWeek(byDate, offset = 0, today = today)
+        val monday = week.days.single { it.date == date }
+
+        assertEquals(day(date, 2).date, monday.epochSeconds)
+        assertNull(week.days.single { it.date == LocalDate.of(2026, 8, 12) }.epochSeconds)
+    }
+
+    @Test
+    fun `the previous week comparison is skipped while that week is still partly uncounted`() {
+        val byDate = history(
+            LocalDate.of(2026, 8, 9) to 6,
+            LocalDate.of(2026, 8, 11) to 4
+        )
+
+        assertNull(buildActivityWeek(byDate, offset = 0, today = today).changePercent)
+    }
+
+    @Test
+    fun `a fully counted previous week gives a percent change`() {
+        val byDate = history(
+            LocalDate.of(2026, 7, 26) to 4,
+            LocalDate.of(2026, 7, 28) to 6,
+            LocalDate.of(2026, 8, 2) to 8,
+            LocalDate.of(2026, 8, 4) to 7,
+            LocalDate.of(2026, 8, 11) to 1
+        )
+
+        val week = buildActivityWeek(byDate, offset = -1, today = today)
+
+        assertEquals(15, week.total)
+        assertEquals(50, week.changePercent)
+    }
+
+    @Test
+    fun `paging stops at the current week and at the oldest data AniList returned`() {
+        val byDate = history(
+            LocalDate.of(2026, 8, 2) to 5,
+            LocalDate.of(2026, 8, 11) to 1
+        )
+
+        val current = buildActivityWeek(byDate, offset = 0, today = today)
+        assertFalse(current.canGoForward)
+        assertTrue(current.canGoBack)
+
+        val oldest = buildActivityWeek(byDate, offset = -1, today = today)
+        assertFalse(oldest.canGoBack)
+        assertTrue(oldest.canGoForward)
+    }
+
+    @Test
+    fun `the daily average divides by counted days, not by seven`() {
+        val byDate = history(
+            LocalDate.of(2026, 8, 9) to 6,
+            LocalDate.of(2026, 8, 10) to 3,
+            LocalDate.of(2026, 8, 11) to 10
+        )
+
+        val week = buildActivityWeek(byDate, offset = 0, today = today)
+
+        assertEquals(19, week.total)
+        assertEquals(3, week.countedDays)
+        assertEquals("6.3", week.perDayLabel().replace(',', '.'))
+    }
+}

--- a/app/src/test/java/com/anisync/android/presentation/statistics/StatusExcerptTest.kt
+++ b/app/src/test/java/com/anisync/android/presentation/statistics/StatusExcerptTest.kt
@@ -1,0 +1,56 @@
+package com.anisync.android.presentation.statistics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class StatusExcerptTest {
+
+    @Test
+    fun `plain text keeps its first line`() {
+        assertEquals(
+            "Finally cleared the backlog",
+            statusExcerpt("Finally cleared the backlog\nand started something new")
+        )
+    }
+
+    @Test
+    fun `an image embed is skipped in favour of the words under it`() {
+        assertEquals(
+            "Manga challenge, day 4",
+            statusExcerpt("~~~img320(https://i.ibb.co/abc/CHALLENGE.gif)~~~\nManga challenge, day 4")
+        )
+    }
+
+    @Test
+    fun `a post that is only an embed has no excerpt`() {
+        assertNull(statusExcerpt("~~~img320(https://i.ibb.co/abc/CHALLENGE.gif)~~~"))
+        assertNull(statusExcerpt("youtube(https://youtu.be/abcdefg)"))
+    }
+
+    @Test
+    fun `a link keeps its label and drops the address`() {
+        assertEquals("Read my review here", statusExcerpt("[Read my review here](https://anilist.co/review/1)"))
+    }
+
+    @Test
+    fun `a bare address is not a title`() {
+        assertEquals("Watch this", statusExcerpt("https://example.com/very/long/path Watch this"))
+    }
+
+    @Test
+    fun `html from the rendered field is stripped`() {
+        assertEquals("Hi there", statusExcerpt("<p>Hi there</p>"))
+    }
+
+    @Test
+    fun `markdown emphasis does not leak into the title`() {
+        assertEquals("Spoilers ahead", statusExcerpt("## __Spoilers ahead__"))
+    }
+
+    @Test
+    fun `nothing in, nothing out`() {
+        assertNull(statusExcerpt(null))
+        assertNull(statusExcerpt("   \n  "))
+    }
+}


### PR DESCRIPTION
Closes #111.

Activity History could only be read as the contribution calendar, where colour is a
relative level and only one tapped day shows a number. This adds a Week breakdown
beside it, and lets a day be opened to see what actually happened.

### What changed

- The card in Profile > Overview and Profile > Stats gains a Month / Week toggle.
  Month is the calendar exactly as it was.
- Week shows one Sunday to Saturday week, each day a bar measured against the busiest
  day of that same week, with the day, date and count on the row.
- Arrows page one week at a time. Forward stops at the week containing today, back
  stops at the oldest week AniList still returns, roughly six months.
- Under the week: the busiest day, how many days carried activity, and the change
  against the previous fully counted week.
- Tapping a day with activity opens a sheet listing that day's entries.

### The day sheet

Every row keeps one skeleton, leading slot, title, a line of meta, time, so a day that
mixes kinds still scans as a single list. Only the parts that carry meaning change:

- Anime and manga list updates show the cover, what was watched or read with its
  number, and AniList's blue or orange tag.
- A status the user wrote has no media, so it gets its own tile and the post's opening
  line becomes the title. Image embeds, links and markdown are stripped first, and a
  post that is nothing but an image falls back to naming the kind.
- Media with no cover art keeps the slot and shows the media kind, so rows stay
  aligned.
- Rows are tappable. A list update opens the media, a written status opens the post.

### Day states

AniList recomputes activityHistory roughly every 48 hours, so the current week always
ends in days that have no count yet. Those are drawn as waiting on AniList, today is
highlighted and labelled, and days later in the week are dimmed and empty. Drawing
them as zero would read as days where nothing happened.

### Where the numbers come from

- The calendar and the bars read the same data that already arrives with the profile,
  so switching between Month and Week costs no request.
- Opening a day is one request, for that day only, bounded by AniList's own day
  timestamp so the list covers the hours the bar counted rather than a local calendar
  day.
- A bar's number and the sheet's list can differ. The bar is AniList's tally of
  everything that counted that day, the list is the user's own list, status and text
  activity.
