### PR TITLE
feat(details): add openings and endings from AnimeThemes

### DIFF
--- a/app/schemas/com.anisync.android.data.local.AppDatabase/24.json
+++ b/app/schemas/com.anisync.android.data.local.AppDatabase/24.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 24,
-    "identityHash": "a2b926d195cb0dba10a270083b52ba3d",
+    "identityHash": "a55e5375124506b769921e867170e6fe",
     "entities": [
       {
         "tableName": "library_entries",
@@ -1036,13 +1036,18 @@
       },
       {
         "tableName": "media_themes",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`mediaId` INTEGER NOT NULL, `themes` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, PRIMARY KEY(`mediaId`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`mediaId` INTEGER NOT NULL, `animeSlug` TEXT, `themes` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, PRIMARY KEY(`mediaId`))",
         "fields": [
           {
             "fieldPath": "mediaId",
             "columnName": "mediaId",
             "affinity": "INTEGER",
             "notNull": true
+          },
+          {
+            "fieldPath": "animeSlug",
+            "columnName": "animeSlug",
+            "affinity": "TEXT"
           },
           {
             "fieldPath": "themes",
@@ -1067,7 +1072,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a2b926d195cb0dba10a270083b52ba3d')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a55e5375124506b769921e867170e6fe')"
     ]
   }
 }

--- a/app/schemas/com.anisync.android.data.local.AppDatabase/24.json
+++ b/app/schemas/com.anisync.android.data.local.AppDatabase/24.json
@@ -1,0 +1,1073 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 24,
+    "identityHash": "a2b926d195cb0dba10a270083b52ba3d",
+    "entities": [
+      {
+        "tableName": "library_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL DEFAULT 0, `mediaId` INTEGER NOT NULL, `titleRomaji` TEXT, `titleEnglish` TEXT, `titleNative` TEXT, `titleUserPreferred` TEXT NOT NULL, `coverUrl` TEXT, `coverMedium` TEXT DEFAULT NULL, `coverLarge` TEXT DEFAULT NULL, `coverExtraLarge` TEXT DEFAULT NULL, `progress` INTEGER NOT NULL, `totalEpisodes` INTEGER, `totalChapters` INTEGER, `totalVolumes` INTEGER, `mediaType` TEXT, `status` TEXT NOT NULL, `nextAiringEpisode` INTEGER, `timeUntilAiring` INTEGER, `mediaStatus` TEXT, `nextAiringEpisodeTime` INTEGER, `score` REAL, `rewatches` INTEGER NOT NULL, `notes` TEXT, `startedAt` INTEGER, `completedAt` INTEGER, `updatedAt` INTEGER, `createdAt` INTEGER, `mediaStartDate` INTEGER, `customLists` TEXT NOT NULL DEFAULT '[]', `isPrivate` INTEGER NOT NULL DEFAULT 0, `hiddenFromStatusLists` INTEGER NOT NULL DEFAULT 0, `lastUpdated` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "mediaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleRomaji",
+            "columnName": "titleRomaji",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "titleEnglish",
+            "columnName": "titleEnglish",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "titleNative",
+            "columnName": "titleNative",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "titleUserPreferred",
+            "columnName": "titleUserPreferred",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverMedium",
+            "columnName": "coverMedium",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "coverLarge",
+            "columnName": "coverLarge",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "coverExtraLarge",
+            "columnName": "coverExtraLarge",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalEpisodes",
+            "columnName": "totalEpisodes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalChapters",
+            "columnName": "totalChapters",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalVolumes",
+            "columnName": "totalVolumes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextAiringEpisode",
+            "columnName": "nextAiringEpisode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timeUntilAiring",
+            "columnName": "timeUntilAiring",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mediaStatus",
+            "columnName": "mediaStatus",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nextAiringEpisodeTime",
+            "columnName": "nextAiringEpisodeTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "rewatches",
+            "columnName": "rewatches",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mediaStartDate",
+            "columnName": "mediaStartDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "customLists",
+            "columnName": "customLists",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "isPrivate",
+            "columnName": "isPrivate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hiddenFromStatusLists",
+            "columnName": "hiddenFromStatusLists",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_entries_ownerId",
+            "unique": false,
+            "columnNames": [
+              "ownerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_ownerId` ON `${TABLE_NAME}` (`ownerId`)"
+          },
+          {
+            "name": "index_library_entries_ownerId_mediaType",
+            "unique": false,
+            "columnNames": [
+              "ownerId",
+              "mediaType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_ownerId_mediaType` ON `${TABLE_NAME}` (`ownerId`, `mediaType`)"
+          },
+          {
+            "name": "index_library_entries_mediaType",
+            "unique": false,
+            "columnNames": [
+              "mediaType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_mediaType` ON `${TABLE_NAME}` (`mediaType`)"
+          },
+          {
+            "name": "index_library_entries_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_library_entries_mediaType_status",
+            "unique": false,
+            "columnNames": [
+              "mediaType",
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_mediaType_status` ON `${TABLE_NAME}` (`mediaType`, `status`)"
+          },
+          {
+            "name": "index_library_entries_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          },
+          {
+            "name": "index_library_entries_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_library_entries_timeUntilAiring",
+            "unique": false,
+            "columnNames": [
+              "timeUntilAiring"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_timeUntilAiring` ON `${TABLE_NAME}` (`timeUntilAiring`)"
+          },
+          {
+            "name": "index_library_entries_score",
+            "unique": false,
+            "columnNames": [
+              "score"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_score` ON `${TABLE_NAME}` (`score`)"
+          },
+          {
+            "name": "index_library_entries_progress",
+            "unique": false,
+            "columnNames": [
+              "progress"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_progress` ON `${TABLE_NAME}` (`progress`)"
+          },
+          {
+            "name": "index_library_entries_mediaStartDate",
+            "unique": false,
+            "columnNames": [
+              "mediaStartDate"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_entries_mediaStartDate` ON `${TABLE_NAME}` (`mediaStartDate`)"
+          }
+        ]
+      },
+      {
+        "tableName": "media_details",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `titleRomaji` TEXT, `titleEnglish` TEXT, `titleNative` TEXT, `titleUserPreferred` TEXT NOT NULL, `coverUrl` TEXT, `coverMedium` TEXT DEFAULT NULL, `coverLarge` TEXT DEFAULT NULL, `coverExtraLarge` TEXT DEFAULT NULL, `coverColor` TEXT DEFAULT NULL, `bannerUrl` TEXT, `description` TEXT NOT NULL, `score` INTEGER, `meanScore` INTEGER DEFAULT NULL, `popularity` INTEGER DEFAULT NULL, `favourites` INTEGER DEFAULT NULL, `episodes` INTEGER, `nextAiringEpisode` INTEGER, `nextAiringEpisodeTime` INTEGER, `nextAiringTimeUntil` INTEGER DEFAULT NULL, `chapters` INTEGER, `volumes` INTEGER, `mediaType` TEXT, `status` TEXT NOT NULL, `format` TEXT, `genres` TEXT NOT NULL, `synonyms` TEXT NOT NULL DEFAULT '[]', `hashtags` TEXT NOT NULL DEFAULT '[]', `rankings` TEXT NOT NULL DEFAULT '[]', `source` TEXT, `studio` TEXT, `studioId` INTEGER DEFAULT NULL, `studios` TEXT NOT NULL DEFAULT '[]', `producers` TEXT NOT NULL DEFAULT '[]', `year` INTEGER, `startDate` TEXT, `endDate` TEXT, `season` TEXT, `seasonYear` INTEGER, `duration` INTEGER, `tags` TEXT NOT NULL, `trailer` TEXT, `listEntryId` INTEGER, `listStatus` TEXT, `listProgress` INTEGER, `listNotes` TEXT, `listEntryPrivate` INTEGER, `listEntryHiddenFromStatusLists` INTEGER, `characters` TEXT NOT NULL, `staff` TEXT NOT NULL DEFAULT '[]', `relations` TEXT NOT NULL, `externalLinks` TEXT NOT NULL, `recommendations` TEXT NOT NULL DEFAULT '[]', `reviews` TEXT NOT NULL DEFAULT '[]', `isFavourite` INTEGER NOT NULL, `isRecommendationBlocked` INTEGER DEFAULT NULL, `isReviewBlocked` INTEGER DEFAULT NULL, `lastUpdated` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleRomaji",
+            "columnName": "titleRomaji",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "titleEnglish",
+            "columnName": "titleEnglish",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "titleNative",
+            "columnName": "titleNative",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "titleUserPreferred",
+            "columnName": "titleUserPreferred",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverMedium",
+            "columnName": "coverMedium",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "coverLarge",
+            "columnName": "coverLarge",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "coverExtraLarge",
+            "columnName": "coverExtraLarge",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "coverColor",
+            "columnName": "coverColor",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "bannerUrl",
+            "columnName": "bannerUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "meanScore",
+            "columnName": "meanScore",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "popularity",
+            "columnName": "popularity",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "favourites",
+            "columnName": "favourites",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "episodes",
+            "columnName": "episodes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "nextAiringEpisode",
+            "columnName": "nextAiringEpisode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "nextAiringEpisodeTime",
+            "columnName": "nextAiringEpisodeTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "nextAiringTimeUntil",
+            "columnName": "nextAiringTimeUntil",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "chapters",
+            "columnName": "chapters",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "volumes",
+            "columnName": "volumes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "synonyms",
+            "columnName": "synonyms",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "hashtags",
+            "columnName": "hashtags",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "rankings",
+            "columnName": "rankings",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "studio",
+            "columnName": "studio",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "studioId",
+            "columnName": "studioId",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "studios",
+            "columnName": "studios",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "producers",
+            "columnName": "producers",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "season",
+            "columnName": "season",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonYear",
+            "columnName": "seasonYear",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trailer",
+            "columnName": "trailer",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "listEntryId",
+            "columnName": "listEntryId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "listStatus",
+            "columnName": "listStatus",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "listProgress",
+            "columnName": "listProgress",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "listNotes",
+            "columnName": "listNotes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "listEntryPrivate",
+            "columnName": "listEntryPrivate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "listEntryHiddenFromStatusLists",
+            "columnName": "listEntryHiddenFromStatusLists",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "characters",
+            "columnName": "characters",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "staff",
+            "columnName": "staff",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "relations",
+            "columnName": "relations",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "externalLinks",
+            "columnName": "externalLinks",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recommendations",
+            "columnName": "recommendations",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "reviews",
+            "columnName": "reviews",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "isFavourite",
+            "columnName": "isFavourite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRecommendationBlocked",
+            "columnName": "isRecommendationBlocked",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "isReviewBlocked",
+            "columnName": "isReviewBlocked",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `avatarUrl` TEXT, `bannerUrl` TEXT, `about` TEXT, `activeAt` INTEGER, `animeCount` INTEGER NOT NULL, `daysWatched` REAL NOT NULL, `mangaCount` INTEGER NOT NULL, `chaptersRead` INTEGER NOT NULL, `meanScore` REAL NOT NULL, `animeStatusCounts` TEXT NOT NULL, `favoriteAnime` TEXT NOT NULL, `activities` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL, `topGenres` TEXT NOT NULL DEFAULT '[]', `favoriteMangaOverview` TEXT NOT NULL DEFAULT '[]', `favoriteCharactersOverview` TEXT NOT NULL DEFAULT '[]', `favoriteStaffOverview` TEXT NOT NULL DEFAULT '[]', `favoriteStudiosOverview` TEXT NOT NULL DEFAULT '[]', `donatorTier` INTEGER NOT NULL DEFAULT 0, `donatorBadge` TEXT DEFAULT '', `moderatorRoles` TEXT NOT NULL DEFAULT '[]', `createdAt` INTEGER DEFAULT 0, `aboutMarkdown` TEXT DEFAULT '', PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bannerUrl",
+            "columnName": "bannerUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "about",
+            "columnName": "about",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "activeAt",
+            "columnName": "activeAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "animeCount",
+            "columnName": "animeCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "daysWatched",
+            "columnName": "daysWatched",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaCount",
+            "columnName": "mangaCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersRead",
+            "columnName": "chaptersRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meanScore",
+            "columnName": "meanScore",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "animeStatusCounts",
+            "columnName": "animeStatusCounts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoriteAnime",
+            "columnName": "favoriteAnime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activities",
+            "columnName": "activities",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topGenres",
+            "columnName": "topGenres",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "favoriteMangaOverview",
+            "columnName": "favoriteMangaOverview",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "favoriteCharactersOverview",
+            "columnName": "favoriteCharactersOverview",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "favoriteStaffOverview",
+            "columnName": "favoriteStaffOverview",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "favoriteStudiosOverview",
+            "columnName": "favoriteStudiosOverview",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "donatorTier",
+            "columnName": "donatorTier",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "donatorBadge",
+            "columnName": "donatorBadge",
+            "affinity": "TEXT",
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "moderatorRoles",
+            "columnName": "moderatorRoles",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "aboutMarkdown",
+            "columnName": "aboutMarkdown",
+            "affinity": "TEXT",
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "airing_schedule",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, `mediaId` INTEGER NOT NULL, `airingAt` INTEGER NOT NULL, `episode` INTEGER NOT NULL, `titleUserPreferred` TEXT NOT NULL, `coverUrl` TEXT, `format` TEXT, `isWatching` INTEGER NOT NULL, `streamingSeriesUrl` TEXT, PRIMARY KEY(`id`, `ownerId`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "mediaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "airingAt",
+            "columnName": "airingAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episode",
+            "columnName": "episode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleUserPreferred",
+            "columnName": "titleUserPreferred",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isWatching",
+            "columnName": "isWatching",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamingSeriesUrl",
+            "columnName": "streamingSeriesUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "ownerId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_airing_schedule_ownerId_airingAt",
+            "unique": false,
+            "columnNames": [
+              "ownerId",
+              "airingAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_airing_schedule_ownerId_airingAt` ON `${TABLE_NAME}` (`ownerId`, `airingAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "trending_media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `titleUserPreferred` TEXT NOT NULL, `coverUrl` TEXT, `averageScore` INTEGER, `rank` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleUserPreferred",
+            "columnName": "titleUserPreferred",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "averageScore",
+            "columnName": "averageScore",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rank",
+            "columnName": "rank",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "saved_forum_threads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`threadId` INTEGER NOT NULL, `title` TEXT NOT NULL, `authorName` TEXT NOT NULL, `authorAvatarUrl` TEXT, `replyCount` INTEGER NOT NULL, `viewCount` INTEGER NOT NULL, `likeCount` INTEGER NOT NULL, `isLiked` INTEGER NOT NULL DEFAULT 0, `isLocked` INTEGER NOT NULL DEFAULT 0, `repliedAt` INTEGER, `replyUserName` TEXT, `replyUserAvatarUrl` TEXT, `categories` TEXT NOT NULL DEFAULT '[]', `mediaTitle` TEXT, `mediaCoverUrl` TEXT, `savedAt` INTEGER NOT NULL, PRIMARY KEY(`threadId`))",
+        "fields": [
+          {
+            "fieldPath": "threadId",
+            "columnName": "threadId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorName",
+            "columnName": "authorName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorAvatarUrl",
+            "columnName": "authorAvatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "replyCount",
+            "columnName": "replyCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewCount",
+            "columnName": "viewCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "likeCount",
+            "columnName": "likeCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isLiked",
+            "columnName": "isLiked",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isLocked",
+            "columnName": "isLocked",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "repliedAt",
+            "columnName": "repliedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "replyUserName",
+            "columnName": "replyUserName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "replyUserAvatarUrl",
+            "columnName": "replyUserAvatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "categories",
+            "columnName": "categories",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "mediaTitle",
+            "columnName": "mediaTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaCoverUrl",
+            "columnName": "mediaCoverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "threadId"
+          ]
+        }
+      },
+      {
+        "tableName": "media_themes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`mediaId` INTEGER NOT NULL, `themes` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, PRIMARY KEY(`mediaId`))",
+        "fields": [
+          {
+            "fieldPath": "mediaId",
+            "columnName": "mediaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "themes",
+            "columnName": "themes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "mediaId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a2b926d195cb0dba10a270083b52ba3d')"
+    ]
+  }
+}

--- a/app/src/main/java/com/anisync/android/data/MediaThemesRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/MediaThemesRepositoryImpl.kt
@@ -1,0 +1,65 @@
+package com.anisync.android.data
+
+import com.anisync.android.data.local.dao.MediaThemesDao
+import com.anisync.android.data.local.entity.MediaThemesEntity
+import com.anisync.android.data.network.AnimeThemesApi
+import com.anisync.android.data.network.AnimeThemesException
+import com.anisync.android.domain.MediaTheme
+import com.anisync.android.domain.MediaThemesRepository
+import com.anisync.android.domain.Result
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Room-backed openings and endings, refreshed from AnimeThemes.
+ *
+ * Themes change about as often as a show gets a new season, so the cache is kept for a
+ * week. A title AnimeThemes has never heard of is cached the same way, as an empty list,
+ * because "not listed" is an answer worth remembering.
+ */
+@Singleton
+class MediaThemesRepositoryImpl @Inject constructor(
+    private val api: AnimeThemesApi,
+    private val dao: MediaThemesDao
+) : MediaThemesRepository {
+
+    override fun observeThemes(mediaId: Int): Flow<List<MediaTheme>?> =
+        dao.observe(mediaId).map { it?.themes }
+
+    override suspend fun refreshThemes(mediaId: Int): Result<List<MediaTheme>> = try {
+        val themes = api.getThemes(mediaId)
+        dao.upsert(
+            MediaThemesEntity(
+                mediaId = mediaId,
+                themes = themes,
+                fetchedAt = System.currentTimeMillis()
+            )
+        )
+        Result.Success(themes)
+    } catch (e: AnimeThemesException.RateLimited) {
+        Result.Error(
+            message = "AnimeThemes is rate limiting requests. Try again shortly.",
+            code = 429,
+            countdownSeconds = e.retryAfterSeconds,
+            exception = e
+        )
+    } catch (e: AnimeThemesException.Network) {
+        Result.Error("No connection to AnimeThemes.", exception = e)
+    } catch (e: AnimeThemesException.Http) {
+        Result.Error("AnimeThemes returned an error (${e.statusCode}).", code = e.statusCode, exception = e)
+    } catch (e: Exception) {
+        Result.Error("Could not read the AnimeThemes response.", exception = e)
+    }
+
+    override suspend fun isStale(mediaId: Int): Boolean {
+        val cached = dao.get(mediaId) ?: return true
+        return System.currentTimeMillis() - cached.fetchedAt > CACHE_TTL_MS
+    }
+
+    private companion object {
+        val CACHE_TTL_MS = TimeUnit.DAYS.toMillis(7)
+    }
+}

--- a/app/src/main/java/com/anisync/android/data/MediaThemesRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/MediaThemesRepositoryImpl.kt
@@ -4,7 +4,7 @@ import com.anisync.android.data.local.dao.MediaThemesDao
 import com.anisync.android.data.local.entity.MediaThemesEntity
 import com.anisync.android.data.network.AnimeThemesApi
 import com.anisync.android.data.network.AnimeThemesException
-import com.anisync.android.domain.MediaTheme
+import com.anisync.android.domain.MediaThemes
 import com.anisync.android.domain.MediaThemesRepository
 import com.anisync.android.domain.Result
 import kotlinx.coroutines.flow.Flow
@@ -26,19 +26,22 @@ class MediaThemesRepositoryImpl @Inject constructor(
     private val dao: MediaThemesDao
 ) : MediaThemesRepository {
 
-    override fun observeThemes(mediaId: Int): Flow<List<MediaTheme>?> =
-        dao.observe(mediaId).map { it?.themes }
+    override fun observeThemes(mediaId: Int): Flow<MediaThemes?> =
+        dao.observe(mediaId).map { entity ->
+            entity?.let { MediaThemes(animeSlug = it.animeSlug, themes = it.themes) }
+        }
 
-    override suspend fun refreshThemes(mediaId: Int): Result<List<MediaTheme>> = try {
-        val themes = api.getThemes(mediaId)
+    override suspend fun refreshThemes(mediaId: Int): Result<MediaThemes> = try {
+        val lookup = api.getThemes(mediaId)
         dao.upsert(
             MediaThemesEntity(
                 mediaId = mediaId,
-                themes = themes,
+                animeSlug = lookup.animeSlug,
+                themes = lookup.themes,
                 fetchedAt = System.currentTimeMillis()
             )
         )
-        Result.Success(themes)
+        Result.Success(lookup)
     } catch (e: AnimeThemesException.RateLimited) {
         Result.Error(
             message = "AnimeThemes is rate limiting requests. Try again shortly.",

--- a/app/src/main/java/com/anisync/android/data/MediaThemesRepositoryImpl.kt
+++ b/app/src/main/java/com/anisync/android/data/MediaThemesRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.anisync.android.data.local.dao.MediaThemesDao
 import com.anisync.android.data.local.entity.MediaThemesEntity
 import com.anisync.android.data.network.AnimeThemesApi
 import com.anisync.android.data.network.AnimeThemesException
+import com.anisync.android.domain.MediaTheme
 import com.anisync.android.domain.MediaThemes
 import com.anisync.android.domain.MediaThemesRepository
 import com.anisync.android.domain.Result
@@ -28,7 +29,7 @@ class MediaThemesRepositoryImpl @Inject constructor(
 
     override fun observeThemes(mediaId: Int): Flow<MediaThemes?> =
         dao.observe(mediaId).map { entity ->
-            entity?.let { MediaThemes(animeSlug = it.animeSlug, themes = it.themes) }
+            entity?.let { MediaThemes(animeSlug = it.animeSlug, themes = it.themes.inShowOrder()) }
         }
 
     override suspend fun refreshThemes(mediaId: Int): Result<MediaThemes> = try {
@@ -37,11 +38,11 @@ class MediaThemesRepositoryImpl @Inject constructor(
             MediaThemesEntity(
                 mediaId = mediaId,
                 animeSlug = lookup.animeSlug,
-                themes = lookup.themes,
+                themes = lookup.themes.inShowOrder(),
                 fetchedAt = System.currentTimeMillis()
             )
         )
-        Result.Success(lookup)
+        Result.Success(lookup.copy(themes = lookup.themes.inShowOrder()))
     } catch (e: AnimeThemesException.RateLimited) {
         Result.Error(
             message = "AnimeThemes is rate limiting requests. Try again shortly.",
@@ -56,6 +57,15 @@ class MediaThemesRepositoryImpl @Inject constructor(
     } catch (e: Exception) {
         Result.Error("Could not read the AnimeThemes response.", exception = e)
     }
+
+    /**
+     * Openings first, then endings, each by their own number. AnimeThemes returns them in the
+     * order they were added, which interleaves the two once a show gets a second cour, and the
+     * rail has no group headings to explain that away. Applied on read as well as on write so a
+     * row cached before this stops being wrong without a refetch.
+     */
+    private fun List<MediaTheme>.inShowOrder(): List<MediaTheme> =
+        sortedWith(compareBy({ it.type.ordinal }, { it.sequence ?: Int.MAX_VALUE }, { it.slug }))
 
     override suspend fun isStale(mediaId: Int): Boolean {
         val cached = dao.get(mediaId) ?: return true

--- a/app/src/main/java/com/anisync/android/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/anisync/android/data/local/AppDatabase.kt
@@ -10,6 +10,7 @@ import com.anisync.android.data.local.dao.UserProfileDao
 import com.anisync.android.data.local.entity.AiringScheduleEntity
 import com.anisync.android.data.local.entity.LibraryEntryEntity
 import com.anisync.android.data.local.entity.MediaDetailsEntity
+import com.anisync.android.data.local.entity.MediaThemesEntity
 import com.anisync.android.data.local.entity.SavedForumThreadEntity
 import com.anisync.android.data.local.entity.TrendingEntity
 import com.anisync.android.data.local.entity.UserProfileEntity
@@ -19,6 +20,12 @@ import com.anisync.android.data.local.entity.UserProfileEntity
  *
  * Version History:
  * ─────────────────────────────────────────────────────────────────────────────
+ * v24 (Aug 2026):
+ *   - Added media_themes table for the AnimeThemes openings and endings lookup:
+ *     • mediaId, themes (JSON blob), fetchedAt
+ *     An empty themes list is stored deliberately, recording that AnimeThemes does
+ *     not list the title so the page stops asking. Auto-migration, new table only.
+ *
  * v23 (Aug 2026):
  *   - airing_schedule is now account scoped:
  *     • ownerId joined the primary key, matching library_entries since v18, so a
@@ -101,9 +108,10 @@ import com.anisync.android.data.local.entity.UserProfileEntity
         UserProfileEntity::class,
         AiringScheduleEntity::class,
         TrendingEntity::class,
-        SavedForumThreadEntity::class
+        SavedForumThreadEntity::class,
+        MediaThemesEntity::class
     ],
-    version = 23,
+    version = 24,
     exportSchema = true,
     autoMigrations = [
         androidx.room.AutoMigration(from = 2, to = 3),
@@ -124,7 +132,8 @@ import com.anisync.android.data.local.entity.UserProfileEntity
         androidx.room.AutoMigration(from = 18, to = 19),
         androidx.room.AutoMigration(from = 19, to = 20),
         androidx.room.AutoMigration(from = 20, to = 21),
-        androidx.room.AutoMigration(from = 21, to = 22)
+        androidx.room.AutoMigration(from = 21, to = 22),
+        androidx.room.AutoMigration(from = 23, to = 24)
     ]
 )
 @TypeConverters(Converters::class)
@@ -135,4 +144,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun airingScheduleDao(): com.anisync.android.data.local.dao.AiringScheduleDao
     abstract fun trendingDao(): com.anisync.android.data.local.dao.TrendingDao
     abstract fun savedForumThreadDao(): SavedForumThreadDao
+    abstract fun mediaThemesDao(): com.anisync.android.data.local.dao.MediaThemesDao
 }

--- a/app/src/main/java/com/anisync/android/data/local/Converters.kt
+++ b/app/src/main/java/com/anisync/android/data/local/Converters.kt
@@ -8,6 +8,7 @@ import com.anisync.android.domain.ForumCategory
 import com.anisync.android.domain.LibraryEntry
 import com.anisync.android.domain.LibraryStatus
 import com.anisync.android.domain.MediaReview
+import com.anisync.android.domain.MediaTheme
 import com.anisync.android.domain.RecommendedMedia
 import com.anisync.android.domain.RelatedMedia
 import com.anisync.android.domain.StudioInfo
@@ -214,4 +215,14 @@ class Converters {
 
     @TypeConverter
     fun toStudioRefList(list: List<StudioRef>): String = json.encodeToString(list)
+
+    @TypeConverter
+    fun fromMediaThemeList(value: String): List<MediaTheme> = try {
+        json.decodeFromString(value)
+    } catch (e: Exception) {
+        emptyList()
+    }
+
+    @TypeConverter
+    fun toMediaThemeList(list: List<MediaTheme>): String = json.encodeToString(list)
 }

--- a/app/src/main/java/com/anisync/android/data/local/dao/MediaThemesDao.kt
+++ b/app/src/main/java/com/anisync/android/data/local/dao/MediaThemesDao.kt
@@ -1,0 +1,20 @@
+package com.anisync.android.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.anisync.android.data.local.entity.MediaThemesEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface MediaThemesDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: MediaThemesEntity)
+
+    @Query("SELECT * FROM media_themes WHERE mediaId = :mediaId")
+    fun observe(mediaId: Int): Flow<MediaThemesEntity?>
+
+    @Query("SELECT * FROM media_themes WHERE mediaId = :mediaId")
+    suspend fun get(mediaId: Int): MediaThemesEntity?
+}

--- a/app/src/main/java/com/anisync/android/data/local/entity/MediaThemesEntity.kt
+++ b/app/src/main/java/com/anisync/android/data/local/entity/MediaThemesEntity.kt
@@ -1,0 +1,21 @@
+package com.anisync.android.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.anisync.android.domain.MediaTheme
+
+/**
+ * Cached AnimeThemes lookup for one title.
+ *
+ * The themes are stored as one JSON blob rather than three tables. They are read whole,
+ * written whole, and never queried across titles, so relational storage would buy nothing.
+ *
+ * An empty [themes] list is a real answer, not a missing one: it records that AnimeThemes
+ * does not list the title, which stops every visit re-asking.
+ */
+@Entity(tableName = "media_themes")
+data class MediaThemesEntity(
+    @PrimaryKey val mediaId: Int,
+    val themes: List<MediaTheme>,
+    val fetchedAt: Long
+)

--- a/app/src/main/java/com/anisync/android/data/local/entity/MediaThemesEntity.kt
+++ b/app/src/main/java/com/anisync/android/data/local/entity/MediaThemesEntity.kt
@@ -16,6 +16,7 @@ import com.anisync.android.domain.MediaTheme
 @Entity(tableName = "media_themes")
 data class MediaThemesEntity(
     @PrimaryKey val mediaId: Int,
+    val animeSlug: String?,
     val themes: List<MediaTheme>,
     val fetchedAt: Long
 )

--- a/app/src/main/java/com/anisync/android/data/network/AnimeThemesApi.kt
+++ b/app/src/main/java/com/anisync/android/data/network/AnimeThemesApi.kt
@@ -2,6 +2,7 @@ package com.anisync.android.data.network
 
 import com.anisync.android.BuildConfig
 import com.anisync.android.domain.MediaTheme
+import com.anisync.android.domain.MediaThemes
 import com.anisync.android.domain.ThemeType
 import com.anisync.android.domain.ThemeVersion
 import com.anisync.android.domain.ThemeVideo
@@ -44,12 +45,12 @@ class AnimeThemesApi @Inject constructor() {
     private val json = Json { ignoreUnknownKeys = true }
 
     /**
-     * Every theme AnimeThemes lists for the AniList title [anilistId], or an empty list
-     * when the title is not in their database.
+     * Every theme AnimeThemes lists for the AniList title [anilistId]. An empty result means
+     * the title is not in their database, which is a real answer rather than a failure.
      */
-    suspend fun getThemes(anilistId: Int): List<MediaTheme> = withContext(Dispatchers.IO) {
-        val slug = resolveSlug(anilistId) ?: return@withContext emptyList()
-        fetchThemes(slug)
+    suspend fun getThemes(anilistId: Int): MediaThemes = withContext(Dispatchers.IO) {
+        val slug = resolveSlug(anilistId) ?: return@withContext MediaThemes()
+        MediaThemes(animeSlug = slug, themes = fetchThemes(slug))
     }
 
     private fun resolveSlug(anilistId: Int): String? {

--- a/app/src/main/java/com/anisync/android/data/network/AnimeThemesApi.kt
+++ b/app/src/main/java/com/anisync/android/data/network/AnimeThemesApi.kt
@@ -1,0 +1,240 @@
+package com.anisync.android.data.network
+
+import com.anisync.android.BuildConfig
+import com.anisync.android.domain.MediaTheme
+import com.anisync.android.domain.ThemeType
+import com.anisync.android.domain.ThemeVersion
+import com.anisync.android.domain.ThemeVideo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Read-only client for the AnimeThemes API, the source of a title's openings and endings.
+ *
+ * Two requests, because the API refuses a nested include deep enough to do it in one:
+ * the AniList id resolves to an AnimeThemes slug through `/resource`, then `/anime/{slug}`
+ * returns the themes. Both are anonymous, so there is no key to ship and nothing to
+ * refresh. Sparse fieldsets keep the second response to what the UI actually draws.
+ *
+ * Failures surface as [AnimeThemesException] so the repository can tell a rate limit
+ * apart from a title that simply is not listed.
+ */
+@Singleton
+class AnimeThemesApi @Inject constructor() {
+
+    private val client: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .retryOnConnectionFailure(true)
+            .build()
+    }
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /**
+     * Every theme AnimeThemes lists for the AniList title [anilistId], or an empty list
+     * when the title is not in their database.
+     */
+    suspend fun getThemes(anilistId: Int): List<MediaTheme> = withContext(Dispatchers.IO) {
+        val slug = resolveSlug(anilistId) ?: return@withContext emptyList()
+        fetchThemes(slug)
+    }
+
+    private fun resolveSlug(anilistId: Int): String? {
+        val url = BASE_URL.newBuilder()
+            .addPathSegment("resource")
+            .addQueryParameter("filter[site]", "AniList")
+            .addQueryParameter("filter[external_id]", anilistId.toString())
+            .addQueryParameter("include", "anime")
+            .addQueryParameter("fields[resource]", "id")
+            .addQueryParameter("fields[anime]", "slug")
+            .build()
+
+        val body = get(url)
+        val response = json.decodeFromString<ResourceListDto>(body)
+        return response.resources
+            .firstNotNullOfOrNull { resource -> resource.anime.firstNotNullOfOrNull { it.slug } }
+    }
+
+    private fun fetchThemes(slug: String): List<MediaTheme> {
+        val url = BASE_URL.newBuilder()
+            .addPathSegment("anime")
+            .addPathSegment(slug)
+            .addQueryParameter(
+                "include",
+                "animethemes.song.artists,animethemes.animethemeentries.videos"
+            )
+            .addQueryParameter("fields[anime]", "id,slug")
+            .addQueryParameter("fields[animetheme]", "id,type,sequence,slug")
+            .addQueryParameter("fields[song]", "id,title")
+            .addQueryParameter("fields[artist]", "name")
+            .addQueryParameter("fields[animethemeentry]", "id,version,episodes,notes,spoiler,nsfw")
+            .addQueryParameter("fields[video]", "id,link,resolution,nc,subbed,lyrics,source")
+            .build()
+
+        val body = get(url)
+        val response = json.decodeFromString<AnimeEnvelopeDto>(body)
+        return response.anime?.themes.orEmpty().mapNotNull { it.toDomain() }
+    }
+
+    private fun get(url: HttpUrl): String {
+        val request = Request.Builder()
+            .url(url)
+            .header("Accept", "application/json")
+            .header("User-Agent", USER_AGENT)
+            .build()
+
+        val response = try {
+            client.newCall(request).execute()
+        } catch (e: IOException) {
+            throw AnimeThemesException.Network(e)
+        }
+
+        response.use {
+            if (!it.isSuccessful) {
+                if (it.code == HTTP_TOO_MANY_REQUESTS) {
+                    val retryAfter = it.header("Retry-After")?.toLongOrNull()
+                    throw AnimeThemesException.RateLimited(retryAfter)
+                }
+                throw AnimeThemesException.Http(it.code)
+            }
+            return it.body?.string() ?: throw AnimeThemesException.Http(it.code)
+        }
+    }
+
+    companion object {
+        private val BASE_URL = "https://api.animethemes.moe".toHttpUrl()
+        private const val CONNECT_TIMEOUT_SECONDS = 15L
+        private const val READ_TIMEOUT_SECONDS = 20L
+        private const val HTTP_TOO_MANY_REQUESTS = 429
+        private val USER_AGENT =
+            "AniSync/${BuildConfig.VERSION_NAME} (+https://github.com/Marco-9456/AniSync)"
+    }
+}
+
+/** What the AnimeThemes lookup can fail with, kept apart so a rate limit can be retried. */
+sealed class AnimeThemesException(message: String, cause: Throwable? = null) :
+    Exception(message, cause) {
+
+    class Network(cause: Throwable) : AnimeThemesException("AnimeThemes unreachable", cause)
+
+    class RateLimited(val retryAfterSeconds: Long?) :
+        AnimeThemesException("AnimeThemes rate limit reached")
+
+    class Http(val statusCode: Int) : AnimeThemesException("AnimeThemes returned $statusCode")
+}
+
+// --- Wire format ---
+
+@Serializable
+private data class ResourceListDto(val resources: List<ResourceDto> = emptyList())
+
+@Serializable
+private data class ResourceDto(val anime: List<AnimeRefDto> = emptyList())
+
+@Serializable
+private data class AnimeRefDto(val slug: String? = null)
+
+@Serializable
+private data class AnimeEnvelopeDto(val anime: AnimeDto? = null)
+
+@Serializable
+private data class AnimeDto(
+    @SerialName("animethemes") val themes: List<ThemeDto> = emptyList()
+)
+
+@Serializable
+private data class ThemeDto(
+    val id: Int,
+    val type: String? = null,
+    val sequence: Int? = null,
+    val slug: String? = null,
+    val song: SongDto? = null,
+    @SerialName("animethemeentries") val entries: List<EntryDto> = emptyList()
+)
+
+@Serializable
+private data class SongDto(
+    val title: String? = null,
+    val artists: List<ArtistDto> = emptyList()
+)
+
+@Serializable
+private data class ArtistDto(val name: String? = null)
+
+@Serializable
+private data class EntryDto(
+    val id: Int,
+    val version: Int? = null,
+    val episodes: String? = null,
+    val notes: String? = null,
+    val spoiler: Boolean = false,
+    val nsfw: Boolean = false,
+    val videos: List<VideoDto> = emptyList()
+)
+
+@Serializable
+private data class VideoDto(
+    val id: Int,
+    val link: String? = null,
+    val resolution: Int? = null,
+    val nc: Boolean = false,
+    val subbed: Boolean = false,
+    val lyrics: Boolean = false,
+    val source: String? = null
+)
+
+private fun ThemeDto.toDomain(): MediaTheme? {
+    val themeType = when (type?.uppercase()) {
+        "OP" -> ThemeType.OP
+        "ED" -> ThemeType.ED
+        else -> return null
+    }
+    val versions = entries.map { it.toDomain() }.filter { it.videos.isNotEmpty() }
+    if (versions.isEmpty()) return null
+
+    return MediaTheme(
+        id = id,
+        type = themeType,
+        sequence = sequence,
+        slug = slug ?: (themeType.name + (sequence ?: 1)),
+        songTitle = song?.title?.takeIf { it.isNotBlank() },
+        artists = song?.artists.orEmpty().mapNotNull { it.name?.takeIf(String::isNotBlank) },
+        versions = versions
+    )
+}
+
+private fun EntryDto.toDomain(): ThemeVersion = ThemeVersion(
+    id = id,
+    version = version ?: 1,
+    rawEpisodes = episodes,
+    notes = notes?.takeIf { it.isNotBlank() },
+    spoiler = spoiler,
+    nsfw = nsfw,
+    videos = videos.mapNotNull { it.toDomain() }
+)
+
+private fun VideoDto.toDomain(): ThemeVideo? {
+    val href = link?.takeIf { it.isNotBlank() } ?: return null
+    return ThemeVideo(
+        id = id,
+        url = href,
+        resolution = resolution,
+        creditless = nc,
+        subbed = subbed,
+        lyrics = lyrics,
+        source = source?.takeIf { it.isNotBlank() }
+    )
+}

--- a/app/src/main/java/com/anisync/android/di/DatabaseModule.kt
+++ b/app/src/main/java/com/anisync/android/di/DatabaseModule.kt
@@ -75,4 +75,9 @@ object DatabaseModule {
     fun provideSavedForumThreadDao(database: AppDatabase): SavedForumThreadDao {
         return database.savedForumThreadDao()
     }
+
+    @Provides
+    fun provideMediaThemesDao(database: AppDatabase): com.anisync.android.data.local.dao.MediaThemesDao {
+        return database.mediaThemesDao()
+    }
 }

--- a/app/src/main/java/com/anisync/android/di/RepositoryModule.kt
+++ b/app/src/main/java/com/anisync/android/di/RepositoryModule.kt
@@ -8,6 +8,7 @@ import com.anisync.android.data.FeedRepositoryImpl
 import com.anisync.android.data.ForumRepositoryImpl
 import com.anisync.android.data.LibraryRepositoryImpl
 import com.anisync.android.data.LinkPreviewProviderImpl
+import com.anisync.android.data.MediaThemesRepositoryImpl
 import com.anisync.android.data.NotificationRepositoryImpl
 import com.anisync.android.data.ProfileRepositoryImpl
 import com.anisync.android.data.SearchRepositoryImpl
@@ -22,6 +23,7 @@ import com.anisync.android.domain.FeedRepository
 import com.anisync.android.domain.ForumRepository
 import com.anisync.android.domain.LibraryRepository
 import com.anisync.android.domain.LinkPreviewProvider
+import com.anisync.android.domain.MediaThemesRepository
 import com.anisync.android.domain.NotificationRepository
 import com.anisync.android.domain.PreferencesRepository
 import com.anisync.android.domain.ProfileRepository
@@ -106,4 +108,9 @@ abstract class RepositoryModule {
     abstract fun bindUserOptionsRepository(
         impl: UserOptionsRepositoryImpl
     ): UserOptionsRepository
+
+    @Binds
+    abstract fun bindMediaThemesRepository(
+        impl: MediaThemesRepositoryImpl
+    ): MediaThemesRepository
 }

--- a/app/src/main/java/com/anisync/android/domain/MediaDetails.kt
+++ b/app/src/main/java/com/anisync/android/domain/MediaDetails.kt
@@ -149,6 +149,21 @@ data class NextAiringEpisode(
     val timeUntilAiring: Int    // seconds, snapshot at fetch time (fallback only)
 )
 
+/**
+ * Episodes to measure a theme's coverage against.
+ *
+ * AniList leaves [MediaDetails.episodes] null for a show that is still airing, which would
+ * cost every long-running series its episode bar. How many have aired is still knowable:
+ * the next episode number, minus the one that has not arrived. The denominator grows week
+ * to week, which is honest rather than misleading, and the scale label says what it used.
+ */
+val MediaDetails.coverageEpisodeCount: Int?
+    get() = coverageEpisodeCount(episodes, nextAiringEpisode?.episode)
+
+/** The rule behind [coverageEpisodeCount], kept separate so it can be tested on its own. */
+fun coverageEpisodeCount(episodes: Int?, nextAiringEpisode: Int?): Int? =
+    episodes ?: nextAiringEpisode?.minus(1)?.takeIf { it > 0 }
+
 @Serializable
 data class StaffInfo(
     val id: Int,

--- a/app/src/main/java/com/anisync/android/domain/MediaTheme.kt
+++ b/app/src/main/java/com/anisync/android/domain/MediaTheme.kt
@@ -1,0 +1,156 @@
+package com.anisync.android.domain
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Opening and ending themes for a title, sourced from AnimeThemes.
+ *
+ * The shape mirrors the API's three levels rather than flattening them, because the
+ * middle one carries real information the UI needs:
+ *
+ * - [MediaTheme] is the slot a show credits, "OP1" or "ED2".
+ * - [ThemeVersion] is one cut of it, with its own episode range. A theme that changes
+ *   part way through a run is two versions, not two themes.
+ * - [ThemeVideo] is a file, with several usually available per version (creditless or
+ *   not, disc or broadcast, different resolutions).
+ */
+@Serializable
+data class MediaTheme(
+    val id: Int,
+    val type: ThemeType,
+    val sequence: Int?,
+    val slug: String,
+    val songTitle: String?,
+    val artists: List<String>,
+    val versions: List<ThemeVersion>
+) {
+    /** Every episode this theme plays over, across all of its versions. */
+    val episodeSpans: List<EpisodeSpan>
+        get() = mergeEpisodeSpans(versions.flatMap { it.episodeSpans })
+
+    /** True when no version carries usable episode information. */
+    val hasEpisodeData: Boolean
+        get() = episodeSpans.isNotEmpty()
+
+    /** True when any version is flagged as spoiling its episode placement. */
+    val isSpoiler: Boolean
+        get() = versions.any { it.spoiler }
+
+    val isAdult: Boolean
+        get() = versions.any { it.nsfw }
+
+    /** The video shown first: creditless and highest resolution when one exists. */
+    val preferredVideo: ThemeVideo?
+        get() = versions.firstOrNull()?.preferredVideo
+}
+
+@Serializable
+enum class ThemeType { OP, ED }
+
+@Serializable
+data class ThemeVersion(
+    val id: Int,
+    val version: Int,
+    val rawEpisodes: String?,
+    val notes: String?,
+    val spoiler: Boolean,
+    val nsfw: Boolean,
+    val videos: List<ThemeVideo>
+) {
+    val episodeSpans: List<EpisodeSpan>
+        get() = parseEpisodeSpans(rawEpisodes)
+
+    val preferredVideo: ThemeVideo?
+        get() = videos.minWithOrNull(
+            compareByDescending<ThemeVideo> { it.creditless }
+                .thenByDescending { it.resolution ?: 0 }
+        )
+}
+
+@Serializable
+data class ThemeVideo(
+    val id: Int,
+    val url: String,
+    val resolution: Int?,
+    val creditless: Boolean,
+    val subbed: Boolean,
+    val lyrics: Boolean,
+    val source: String?
+)
+
+/**
+ * A run of episodes. [end] is null for a range the API left open, written "13-",
+ * which means the theme was still playing when the entry was recorded.
+ */
+@Serializable
+data class EpisodeSpan(val start: Int, val end: Int?) {
+    val isOpen: Boolean get() = end == null
+
+    fun contains(episode: Int): Boolean = episode >= start && (end == null || episode <= end)
+
+    /** Length in episodes, needing [totalEpisodes] to close an open range. */
+    fun length(totalEpisodes: Int?): Int {
+        val last = end ?: totalEpisodes ?: return 0
+        return (last - start + 1).coerceAtLeast(0)
+    }
+}
+
+/**
+ * Reads AnimeThemes' `episodes` field, which is free text rather than numbers:
+ * "1-13", "14-22, 24", "5", "13-" for an open range, and null or "None" when the
+ * range was never recorded. Anything unparseable is dropped rather than guessed at.
+ */
+fun parseEpisodeSpans(raw: String?): List<EpisodeSpan> {
+    if (raw.isNullOrBlank() || raw.equals("None", ignoreCase = true)) return emptyList()
+
+    val spans = raw.split(',').mapNotNull { part ->
+        val piece = part.trim()
+        if (piece.isEmpty()) return@mapNotNull null
+        val dash = piece.indexOf('-')
+        when {
+            dash < 0 -> piece.toIntOrNull()?.let { EpisodeSpan(it, it) }
+            dash == piece.lastIndex -> piece.dropLast(1).trim().toIntOrNull()?.let { EpisodeSpan(it, null) }
+            else -> {
+                val start = piece.substring(0, dash).trim().toIntOrNull()
+                val end = piece.substring(dash + 1).trim().toIntOrNull()
+                if (start != null && end != null && end >= start) EpisodeSpan(start, end) else null
+            }
+        }
+    }
+    return mergeEpisodeSpans(spans)
+}
+
+/** Sorts spans and joins the ones that touch, so a bar never draws the same episode twice. */
+fun mergeEpisodeSpans(spans: List<EpisodeSpan>): List<EpisodeSpan> {
+    if (spans.size < 2) return spans
+    val sorted = spans.sortedWith(compareBy({ it.start }, { it.end ?: Int.MAX_VALUE }))
+    val merged = mutableListOf(sorted.first())
+    for (span in sorted.drop(1)) {
+        val last = merged.last()
+        if (last.end == null) break
+        if (span.start <= last.end + 1) {
+            merged[merged.lastIndex] = EpisodeSpan(
+                start = last.start,
+                end = if (span.end == null) null else maxOf(last.end, span.end)
+            )
+        } else {
+            merged.add(span)
+        }
+    }
+    return merged
+}
+
+/** Renders spans the way the API writes them, "14–22, 24", with an en dash. */
+fun formatEpisodeSpans(spans: List<EpisodeSpan>): String = spans.joinToString(", ") { span ->
+    when {
+        span.end == null -> "${span.start}+"
+        span.end == span.start -> "${span.start}"
+        else -> "${span.start}–${span.end}"
+    }
+}
+
+/** How many episodes the spans cover, capped at [totalEpisodes] when it is known. */
+fun countCoveredEpisodes(spans: List<EpisodeSpan>, totalEpisodes: Int?): Int {
+    val covered = spans.sumOf { it.length(totalEpisodes) }
+    return if (totalEpisodes != null) covered.coerceAtMost(totalEpisodes) else covered
+}

--- a/app/src/main/java/com/anisync/android/domain/MediaTheme.kt
+++ b/app/src/main/java/com/anisync/android/domain/MediaTheme.kt
@@ -44,6 +44,16 @@ data class MediaTheme(
         get() = versions.firstOrNull()?.preferredVideo
 }
 
+/**
+ * A whole lookup: the themes plus the AnimeThemes slug they came from, which is what the
+ * "open on AnimeThemes" links are built out of.
+ */
+@Serializable
+data class MediaThemes(
+    val animeSlug: String? = null,
+    val themes: List<MediaTheme> = emptyList()
+)
+
 @Serializable
 enum class ThemeType { OP, ED }
 

--- a/app/src/main/java/com/anisync/android/domain/MediaTheme.kt
+++ b/app/src/main/java/com/anisync/android/domain/MediaTheme.kt
@@ -42,6 +42,17 @@ data class MediaTheme(
     /** The video shown first: creditless and highest resolution when one exists. */
     val preferredVideo: ThemeVideo?
         get() = versions.firstOrNull()?.preferredVideo
+
+    /**
+     * What the slug carries beyond the plain "OP1" form, "EN" for a dub or "EN4Kids" for an
+     * edit. One Piece lists OP1 and OP1-EN as separate themes with the same number, so dropping
+     * this would leave two rows both calling themselves Opening 1.
+     */
+    val qualifier: String?
+        get() {
+            val canonical = type.name + (sequence ?: 1)
+            return slug.removePrefix(canonical).trim('-', ' ').takeIf { it.isNotEmpty() }
+        }
 }
 
 /**
@@ -74,6 +85,8 @@ data class ThemeVersion(
         get() = videos.minWithOrNull(
             compareByDescending<ThemeVideo> { it.creditless }
                 .thenByDescending { it.resolution ?: 0 }
+                .thenBy { it.lyrics }
+                .thenBy { it.subbed }
         )
 }
 

--- a/app/src/main/java/com/anisync/android/domain/MediaThemesRepository.kt
+++ b/app/src/main/java/com/anisync/android/domain/MediaThemesRepository.kt
@@ -1,0 +1,24 @@
+package com.anisync.android.domain
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Openings and endings for a title, looked up on AnimeThemes by AniList id.
+ *
+ * Room is the source of truth so a cached page paints its themes offline, and
+ * [refreshThemes] is the only thing that touches the network.
+ */
+interface MediaThemesRepository {
+
+    /** Cached themes for [mediaId]. Emits null until a lookup has been stored. */
+    fun observeThemes(mediaId: Int): Flow<List<MediaTheme>?>
+
+    /**
+     * Fetches from AnimeThemes and stores the answer, including an empty one, so a
+     * title with no themes is not looked up again on every visit.
+     */
+    suspend fun refreshThemes(mediaId: Int): Result<List<MediaTheme>>
+
+    /** True when the stored answer is missing or old enough to be worth refetching. */
+    suspend fun isStale(mediaId: Int): Boolean
+}

--- a/app/src/main/java/com/anisync/android/domain/MediaThemesRepository.kt
+++ b/app/src/main/java/com/anisync/android/domain/MediaThemesRepository.kt
@@ -11,13 +11,13 @@ import kotlinx.coroutines.flow.Flow
 interface MediaThemesRepository {
 
     /** Cached themes for [mediaId]. Emits null until a lookup has been stored. */
-    fun observeThemes(mediaId: Int): Flow<List<MediaTheme>?>
+    fun observeThemes(mediaId: Int): Flow<MediaThemes?>
 
     /**
      * Fetches from AnimeThemes and stores the answer, including an empty one, so a
      * title with no themes is not looked up again on every visit.
      */
-    suspend fun refreshThemes(mediaId: Int): Result<List<MediaTheme>>
+    suspend fun refreshThemes(mediaId: Int): Result<MediaThemes>
 
     /** True when the stored answer is missing or old enough to be worth refetching. */
     suspend fun isStale(mediaId: Int): Boolean

--- a/app/src/main/java/com/anisync/android/presentation/components/ExoPlayerCache.kt
+++ b/app/src/main/java/com/anisync/android/presentation/components/ExoPlayerCache.kt
@@ -69,7 +69,10 @@ class ExoPlayerCache internal constructor(private val context: Context) {
 }
 
 /**
- * Builds a prepared, muted, looping [ExoPlayer] for an inline video [url].
+ * Builds a prepared [ExoPlayer] for an inline video [url], muted and looping by default.
+ *
+ * A theme song wants the opposite of an embedded clip, so [muted], [loop] and [autoPlay]
+ * are overridable: the openings and endings sheet opens with sound and plays once.
  *
  * Single source of truth so the cached ([ExoPlayerCache]) and self-managed ([VideoPlayer])
  * paths can't drift. Two things make user-embedded clips actually play instead of erroring:
@@ -82,7 +85,13 @@ class ExoPlayerCache internal constructor(private val context: Context) {
  *    (i.e. when scrolled near), not when its surface finally attaches.
  */
 @OptIn(UnstableApi::class)
-internal fun buildVideoExoPlayer(context: Context, url: String): ExoPlayer {
+internal fun buildVideoExoPlayer(
+    context: Context,
+    url: String,
+    muted: Boolean = true,
+    loop: Boolean = true,
+    autoPlay: Boolean = false
+): ExoPlayer {
     val loadControl = DefaultLoadControl.Builder()
         .setBufferDurationsMs(
             1500, // minBufferMs: minimum buffered before playback starts
@@ -105,9 +114,9 @@ internal fun buildVideoExoPlayer(context: Context, url: String): ExoPlayer {
         .setMediaSourceFactory(DefaultMediaSourceFactory(dataSourceFactory))
         .build().apply {
             setMediaItem(MediaItem.fromUri(url))
-            repeatMode = Player.REPEAT_MODE_ONE
-            volume = 0f
-            playWhenReady = false
+            repeatMode = if (loop) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
+            volume = if (muted) 0f else 1f
+            playWhenReady = autoPlay
             prepare()
         }
 }

--- a/app/src/main/java/com/anisync/android/presentation/components/FullscreenPlayerActivity.kt
+++ b/app/src/main/java/com/anisync/android/presentation/components/FullscreenPlayerActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.graphics.Color
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -115,6 +116,7 @@ private fun FullscreenVideoContent(
     aspectRatio: Float,
     onClose: () -> Unit
 ) {
+    val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
 
     var isMuted by remember { mutableStateOf(player.volume == 0f) }
@@ -143,7 +145,7 @@ private fun FullscreenVideoContent(
 
             override fun onPlayerError(error: PlaybackException) {
                 playerState = PlayerState.Error
-                errorMessage = playbackErrorMessage(error)
+                errorMessage = playbackErrorMessage(context, error)
             }
         }
         player.addListener(listener)

--- a/app/src/main/java/com/anisync/android/presentation/components/VideoPlayer.kt
+++ b/app/src/main/java/com/anisync/android/presentation/components/VideoPlayer.kt
@@ -1,5 +1,6 @@
 package com.anisync.android.presentation.components
 
+import android.content.Context
 import android.content.Intent
 import android.view.LayoutInflater
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -78,6 +79,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
+import androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException
 import androidx.media3.common.Player
 import androidx.media3.common.VideoSize
 import androidx.media3.common.util.UnstableApi
@@ -194,7 +196,7 @@ fun VideoPlayer(
                     error
                 )
                 playerState = PlayerState.Error
-                errorMessage = playbackErrorMessage(error)
+                errorMessage = playbackErrorMessage(context, error)
             }
         }
 
@@ -334,18 +336,53 @@ internal fun mapPlaybackState(playbackState: Int, current: PlayerState): PlayerS
 }
 
 /** Friendly, user-facing copy for a playback failure. */
-internal fun playbackErrorMessage(error: PlaybackException): String = when (error.errorCode) {
-    PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
-    PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT ->
-        "Network error — check your connection"
-    PlaybackException.ERROR_CODE_IO_FILE_NOT_FOUND,
-    PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS ->
-        "This video is no longer available"
-    PlaybackException.ERROR_CODE_DECODER_INIT_FAILED,
-    PlaybackException.ERROR_CODE_DECODING_FAILED ->
-        "Unsupported video format"
-    else -> "Unable to play this video"
+internal fun playbackErrorMessage(context: Context, error: PlaybackException): String {
+    val status = error.httpStatusCode()
+    val messageRes = when {
+        status == HTTP_TOO_MANY_REQUESTS -> R.string.player_error_rate_limited
+        status != null && status >= 500 -> R.string.player_error_server
+        status == HTTP_NOT_FOUND || status == HTTP_GONE -> R.string.player_error_missing
+
+        else -> when (error.errorCode) {
+            PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
+            PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT ->
+                R.string.player_error_network
+
+            PlaybackException.ERROR_CODE_IO_FILE_NOT_FOUND -> R.string.player_error_missing
+
+            // The host answered with something that is not video, which in practice is an
+            // error page from a struggling CDN rather than a dead file.
+            PlaybackException.ERROR_CODE_IO_INVALID_HTTP_CONTENT_TYPE,
+            PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS -> R.string.player_error_server
+
+            PlaybackException.ERROR_CODE_DECODER_INIT_FAILED,
+            PlaybackException.ERROR_CODE_DECODING_FAILED -> R.string.player_error_format
+
+            else -> R.string.player_error_generic
+        }
+    }
+    return context.getString(messageRes)
 }
+
+/**
+ * The HTTP status behind a playback failure, when there was one.
+ *
+ * Media3 reports a 503 and a 404 under codes that read alike, so the status is what separates
+ * "the host is down, wait" from "this file is gone, do not bother waiting". It sits on the
+ * cause chain rather than the exception itself.
+ */
+private fun PlaybackException.httpStatusCode(): Int? {
+    var cause: Throwable? = this
+    while (cause != null) {
+        if (cause is InvalidResponseCodeException) return cause.responseCode
+        cause = cause.cause
+    }
+    return null
+}
+
+private const val HTTP_TOO_MANY_REQUESTS = 429
+private const val HTTP_NOT_FOUND = 404
+private const val HTTP_GONE = 410
 
 /**
  * The native video surface. [active] hands the shared [exoPlayer] to exactly one surface at a time

--- a/app/src/main/java/com/anisync/android/presentation/components/VideoPlayer.kt
+++ b/app/src/main/java/com/anisync/android/presentation/components/VideoPlayer.kt
@@ -14,7 +14,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -71,6 +74,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -459,42 +463,63 @@ internal fun PlayerStatusVisuals(
                     .background(MaterialTheme.colorScheme.surfaceContainerHighest),
                 contentAlignment = Alignment.Center
             ) {
+                // The player is locked to the clip's aspect ratio, so this column has to fit a
+                // box it does not control. It scrolls rather than clipping, which is what used
+                // to cut the retry button in half once a message ran to two lines.
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center,
-                    modifier = Modifier.padding(24.dp)
+                    modifier = Modifier
+                        .verticalScroll(rememberScrollState())
+                        .padding(horizontal = 20.dp, vertical = 14.dp)
                 ) {
                     Surface(
                         shape = CircleShape,
                         color = MaterialTheme.colorScheme.errorContainer,
-                        modifier = Modifier.size(56.dp)
+                        modifier = Modifier.size(44.dp)
                     ) {
                         Box(contentAlignment = Alignment.Center) {
                             Icon(
                                 imageVector = Icons.Rounded.BrokenImage,
                                 contentDescription = null,
                                 tint = MaterialTheme.colorScheme.onErrorContainer,
-                                modifier = Modifier.size(28.dp)
+                                modifier = Modifier.size(22.dp)
                             )
                         }
                     }
 
-                    Spacer(Modifier.height(16.dp))
+                    Spacer(Modifier.height(10.dp))
 
                     Text(
-                        text = errorMessage ?: "Unable to play this video",
-                        style = MaterialTheme.typography.bodyMedium,
+                        text = errorMessage ?: stringResource(R.string.player_error_generic),
+                        style = MaterialTheme.typography.bodySmall,
                         fontWeight = FontWeight.Medium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        textAlign = TextAlign.Center
+                        textAlign = TextAlign.Center,
+                        maxLines = 3,
+                        overflow = TextOverflow.Ellipsis
                     )
 
-                    Spacer(Modifier.height(16.dp))
+                    Spacer(Modifier.height(10.dp))
 
-                    FilledTonalButton(onClick = onRetry, shape = RoundedCornerShape(100)) {
-                        Icon(imageVector = Icons.Default.Refresh, contentDescription = null, modifier = Modifier.size(18.dp))
-                        Spacer(Modifier.size(8.dp))
-                        Text(text = stringResource(R.string.retry), fontWeight = FontWeight.SemiBold)
+                    FilledTonalButton(
+                        onClick = onRetry,
+                        shape = RoundedCornerShape(100),
+                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Refresh,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(Modifier.size(6.dp))
+                        Text(
+                            text = stringResource(R.string.retry),
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            softWrap = false
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/anisync/android/presentation/components/VideoPlayer.kt
+++ b/app/src/main/java/com/anisync/android/presentation/components/VideoPlayer.kt
@@ -137,12 +137,15 @@ private const val CONTROLS_HIDE_DELAY_MS = 3000L
 fun VideoPlayer(
     url: String,
     modifier: Modifier = Modifier,
-    playerCache: ExoPlayerCache? = LocalExoPlayerCache.current
+    playerCache: ExoPlayerCache? = LocalExoPlayerCache.current,
+    startMuted: Boolean = true,
+    loop: Boolean = true,
+    autoPlay: Boolean = false
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
 
-    var isMuted by remember { mutableStateOf(true) }
+    var isMuted by remember { mutableStateOf(startMuted) }
     var isPlaying by remember { mutableStateOf(false) }
     var positionMs by remember { mutableLongStateOf(0L) }
     var durationMs by remember { mutableLongStateOf(0L) }
@@ -161,7 +164,7 @@ fun VideoPlayer(
     val exoPlayer = if (playerCache != null) {
         remember(url) { playerCache.getOrCreate(url) }
     } else {
-        remember(url) { buildVideoExoPlayer(context.applicationContext, url) }
+        remember(url) { buildVideoExoPlayer(context.applicationContext, url, startMuted, loop, autoPlay) }
     }
 
     DisposableEffect(exoPlayer) {

--- a/app/src/main/java/com/anisync/android/presentation/components/VideoPlayer.kt
+++ b/app/src/main/java/com/anisync/android/presentation/components/VideoPlayer.kt
@@ -283,7 +283,9 @@ fun VideoPlayer(
             .fillMaxWidth()
             .aspectRatio(displayAspect)
             .clip(RoundedCornerShape(24.dp))
-            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+            // Black, not a surface tint: any letterboxing a clip's aspect leaves should read as
+            // part of the picture rather than a pale frame around it.
+            .background(Color.Black)
     ) {
         if (playerState != PlayerState.Error) {
             PlayerSurface(

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
@@ -1254,6 +1254,7 @@ fun DetailsPageContent(
                                     themes = themesState.themes,
                                     isLoading = themesState.isLoading || awaitingThemes,
                                     errorMessage = themesState.errorMessage,
+                                    retryAfterSeconds = themesState.retryAfterSeconds,
                                     coverUrl = details.bannerUrl ?: details.coverUrl,
                                     totalEpisodes = details.coverageEpisodeCount,
                                     onSeeAllClick = onThemesSeeAllClick,

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
@@ -1242,12 +1242,16 @@ fun DetailsPageContent(
 
                     // Openings & Endings (AnimeThemes)
                     item(key = "media_themes") {
-                        if (themesState.themes.isNotEmpty() || themesState.isLoading || themesState.errorMessage != null) {
+                        // Anime only, and the skeleton holds the space until the lookup answers so
+                        // the sections below it do not jump once it does.
+                        val awaitingThemes = !themesState.hasLoaded &&
+                            details.type == com.anisync.android.type.MediaType.ANIME
+                        if (themesState.themes.isNotEmpty() || awaitingThemes || themesState.errorMessage != null) {
                             Column {
                                 Spacer(modifier = Modifier.height(dimensionResource(R.dimen.spacing_large)))
                                 MediaThemesSection(
                                     themes = themesState.themes,
-                                    isLoading = themesState.isLoading,
+                                    isLoading = themesState.isLoading || awaitingThemes,
                                     errorMessage = themesState.errorMessage,
                                     coverUrl = details.bannerUrl ?: details.coverUrl,
                                     totalEpisodes = details.episodes,

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
@@ -129,6 +129,7 @@ import com.anisync.android.data.TitleLanguage
 import com.anisync.android.domain.ForumThread
 import com.anisync.android.domain.LibraryStatus
 import com.anisync.android.domain.MediaDetails
+import com.anisync.android.domain.coverageEpisodeCount
 import com.anisync.android.domain.MediaFollowingEntry
 import com.anisync.android.domain.url
 import com.anisync.android.presentation.components.AnimatedFavoriteButton
@@ -677,7 +678,7 @@ fun MediaDetailsScreen(
                                     onThemesSeeAllClick(
                                         state.details.id,
                                         state.details.getTitle(titleLanguage),
-                                        state.details.episodes,
+                                        state.details.coverageEpisodeCount,
                                         state.details.bannerUrl ?: state.details.coverUrl
                                     )
                                 },
@@ -1254,7 +1255,7 @@ fun DetailsPageContent(
                                     isLoading = themesState.isLoading || awaitingThemes,
                                     errorMessage = themesState.errorMessage,
                                     coverUrl = details.bannerUrl ?: details.coverUrl,
-                                    totalEpisodes = details.episodes,
+                                    totalEpisodes = details.coverageEpisodeCount,
                                     onSeeAllClick = onThemesSeeAllClick,
                                     onThemeClick = { openThemeSheet = it },
                                     onRetryClick = onRetryThemes
@@ -1624,7 +1625,7 @@ fun DetailsPageContent(
     openThemeSheet?.let { theme ->
         ThemeSheet(
             theme = theme,
-            totalEpisodes = details.episodes,
+            totalEpisodes = details.coverageEpisodeCount,
             animeSlug = themesState.animeSlug,
             onDismiss = { openThemeSheet = null }
         )

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
@@ -145,6 +145,8 @@ import com.anisync.android.presentation.details.components.ContentMetadataSectio
 import com.anisync.android.presentation.details.components.DetailsSkeletonContent
 import com.anisync.android.presentation.details.components.ExpandableSynopsis
 import com.anisync.android.presentation.details.components.ExternalLinksSection
+import com.anisync.android.presentation.details.components.MediaThemesSection
+import com.anisync.android.presentation.details.components.ThemeSheet
 import com.anisync.android.presentation.details.components.FollowingListSheet
 import com.anisync.android.presentation.settings.components.SettingsPickerSheet
 import com.anisync.android.presentation.details.components.FollowingRow
@@ -188,6 +190,7 @@ fun MediaDetailsScreen(
     onStudioClick: (Int) -> Unit = {},
     onRelatedSeeAllClick: (Int, String) -> Unit = { _, _ -> },
     onRecommendationsSeeAllClick: (Int, String) -> Unit = { _, _ -> },
+    onThemesSeeAllClick: (Int, String) -> Unit = { _, _ -> },
     onWriteReviewClick: (Int, String) -> Unit = { _, _ -> },
     onReviewClick: (Int) -> Unit = {},
     onDiscussionClick: (threadId: Int, threadTitle: String) -> Unit = { _, _ -> },
@@ -209,6 +212,7 @@ fun MediaDetailsScreen(
     val following by viewModel.following.collectAsStateWithLifecycle()
     val hasMoreFollowing by viewModel.hasMoreFollowing.collectAsStateWithLifecycle()
     val discussions by viewModel.discussions.collectAsStateWithLifecycle()
+    val themesState by viewModel.themes.collectAsStateWithLifecycle()
     val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
     val cast by viewModel.cast.collectAsStateWithLifecycle()
     val staff by viewModel.staff.collectAsStateWithLifecycle()
@@ -662,6 +666,16 @@ fun MediaDetailsScreen(
                                         state.details.getTitle(titleLanguage)
                                     )
                                 },
+                                onThemesSeeAllClick = {
+                                    shouldKeepChromeOverlayForReturn = true
+                                    hasObservedDetailsReEnter = false
+                                    onThemesSeeAllClick(
+                                        state.details.id,
+                                        state.details.getTitle(titleLanguage)
+                                    )
+                                },
+                                themesState = themesState,
+                                onRetryThemes = viewModel::retryThemes,
                                 onWriteReviewClick = {
                                     onWriteReviewClick(
                                         state.details.id,
@@ -961,6 +975,9 @@ fun DetailsPageContent(
     onStudioClick: (Int) -> Unit,
     onRelatedSeeAllClick: () -> Unit,
     onRecommendationsSeeAllClick: () -> Unit,
+    onThemesSeeAllClick: () -> Unit,
+    themesState: MediaThemesState,
+    onRetryThemes: () -> Unit,
     onWriteReviewClick: () -> Unit,
     onReviewClick: (Int) -> Unit,
     onEditNotes: () -> Unit,
@@ -1011,6 +1028,7 @@ fun DetailsPageContent(
 
     var showAllReviewsSheet by remember { mutableStateOf(false) }
     var showAllFollowingSheet by remember { mutableStateOf(false) }
+    var openThemeSheet by remember { mutableStateOf<com.anisync.android.domain.MediaTheme?>(null) }
     var showRecommendSheet by remember { mutableStateOf(false) }
 
     val displayStaff = remember(details.staff) {
@@ -1210,6 +1228,25 @@ fun DetailsPageContent(
                                 ExternalLinksSection(
                                     externalLinks = details.externalLinks,
                                     mediaType = details.type
+                                )
+                            }
+                        }
+                    }
+
+                    // Openings & Endings (AnimeThemes)
+                    item(key = "media_themes") {
+                        if (themesState.themes.isNotEmpty() || themesState.isLoading || themesState.errorMessage != null) {
+                            Column {
+                                Spacer(modifier = Modifier.height(dimensionResource(R.dimen.spacing_large)))
+                                MediaThemesSection(
+                                    themes = themesState.themes,
+                                    isLoading = themesState.isLoading,
+                                    errorMessage = themesState.errorMessage,
+                                    coverUrl = details.bannerUrl ?: details.coverUrl,
+                                    totalEpisodes = details.episodes,
+                                    onSeeAllClick = onThemesSeeAllClick,
+                                    onThemeClick = { openThemeSheet = it },
+                                    onRetryClick = onRetryThemes
                                 )
                             }
                         }
@@ -1570,6 +1607,15 @@ fun DetailsPageContent(
             itemLabel = { it.label },
             onSelect = { staffSort = it; onStaffSortChange(it.apiSort); showStaffSortSheet = false },
             onDismiss = { showStaffSortSheet = false }
+        )
+    }
+
+    openThemeSheet?.let { theme ->
+        ThemeSheet(
+            theme = theme,
+            totalEpisodes = details.episodes,
+            animeSlug = themesState.animeSlug,
+            onDismiss = { openThemeSheet = null }
         )
     }
 

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsScreen.kt
@@ -190,7 +190,7 @@ fun MediaDetailsScreen(
     onStudioClick: (Int) -> Unit = {},
     onRelatedSeeAllClick: (Int, String) -> Unit = { _, _ -> },
     onRecommendationsSeeAllClick: (Int, String) -> Unit = { _, _ -> },
-    onThemesSeeAllClick: (Int, String) -> Unit = { _, _ -> },
+    onThemesSeeAllClick: (mediaId: Int, mediaTitle: String, totalEpisodes: Int?, coverUrl: String?) -> Unit = { _, _, _, _ -> },
     onWriteReviewClick: (Int, String) -> Unit = { _, _ -> },
     onReviewClick: (Int) -> Unit = {},
     onDiscussionClick: (threadId: Int, threadTitle: String) -> Unit = { _, _ -> },
@@ -199,6 +199,7 @@ fun MediaDetailsScreen(
     onUserClick: (String) -> Unit = {},
     navigationIcon: ImageVector = Icons.AutoMirrored.Filled.ArrowBack,
     viewModel: MediaDetailsViewModel = hiltViewModel(),
+    themesViewModel: MediaThemesViewModel = hiltViewModel(),
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedVisibilityScope
 ) {
@@ -212,12 +213,16 @@ fun MediaDetailsScreen(
     val following by viewModel.following.collectAsStateWithLifecycle()
     val hasMoreFollowing by viewModel.hasMoreFollowing.collectAsStateWithLifecycle()
     val discussions by viewModel.discussions.collectAsStateWithLifecycle()
-    val themesState by viewModel.themes.collectAsStateWithLifecycle()
+    val themesState by themesViewModel.state.collectAsStateWithLifecycle()
     val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
     val cast by viewModel.cast.collectAsStateWithLifecycle()
     val staff by viewModel.staff.collectAsStateWithLifecycle()
     val mediaStats by viewModel.stats.collectAsStateWithLifecycle()
     val pullToRefreshState = rememberPullToRefreshState()
+
+    // AnimeThemes only carries anime, so the lookup waits until the page says which it is.
+    val isAnime = (uiState as? DetailsUiState.Success)?.details?.type == com.anisync.android.type.MediaType.ANIME
+    LaunchedEffect(isAnime) { themesViewModel.start(isAnime) }
 
     val spatialSpec = AppMotion.rememberSpatialSpec()
     val containerKey = TransitionKeys.container(sourceScreen, mediaId)
@@ -671,11 +676,13 @@ fun MediaDetailsScreen(
                                     hasObservedDetailsReEnter = false
                                     onThemesSeeAllClick(
                                         state.details.id,
-                                        state.details.getTitle(titleLanguage)
+                                        state.details.getTitle(titleLanguage),
+                                        state.details.episodes,
+                                        state.details.bannerUrl ?: state.details.coverUrl
                                     )
                                 },
                                 themesState = themesState,
-                                onRetryThemes = viewModel::retryThemes,
+                                onRetryThemes = themesViewModel::retry,
                                 onWriteReviewClick = {
                                     onWriteReviewClick(
                                         state.details.id,

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsUiState.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsUiState.kt
@@ -20,5 +20,7 @@ data class MediaThemesState(
     val themes: List<MediaTheme> = emptyList(),
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
+    /** Seconds AnimeThemes asked us to wait, from a 429's Retry-After. Null for other failures. */
+    val retryAfterSeconds: Long? = null,
     val hasLoaded: Boolean = false
 )

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsUiState.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsUiState.kt
@@ -1,9 +1,24 @@
 package com.anisync.android.presentation.details
 
 import com.anisync.android.domain.MediaDetails
+import com.anisync.android.domain.MediaTheme
 
 sealed interface DetailsUiState {
     data object Loading : DetailsUiState
     data class Success(val details: MediaDetails) : DetailsUiState
     data class Error(val message: String) : DetailsUiState
 }
+
+/**
+ * Openings and endings, loaded separately from the AniList page they sit on.
+ *
+ * [hasLoaded] tells an empty list from one that has not arrived yet, which is what decides
+ * between drawing the skeleton rail and drawing no section at all.
+ */
+data class MediaThemesState(
+    val animeSlug: String? = null,
+    val themes: List<MediaTheme> = emptyList(),
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
+    val hasLoaded: Boolean = false
+)

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsViewModel.kt
@@ -16,6 +16,7 @@ import com.anisync.android.domain.LibraryRepository
 import com.anisync.android.domain.LibraryStatus
 import com.anisync.android.domain.MediaDetails
 import com.anisync.android.domain.MediaFollowingEntry
+import com.anisync.android.domain.MediaThemesRepository
 import com.anisync.android.domain.Result
 import com.anisync.android.domain.ScoreFormat
 import com.anisync.android.util.ShareUtils
@@ -27,6 +28,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -46,6 +49,7 @@ class MediaDetailsViewModel @Inject constructor(
     private val toastManager: com.anisync.android.presentation.components.alert.ToastManager,
     private val forumRepository: ForumRepository,
     private val discoverSearchLauncher: com.anisync.android.domain.DiscoverSearchLauncher,
+    private val mediaThemesRepository: MediaThemesRepository,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -72,6 +76,9 @@ class MediaDetailsViewModel @Inject constructor(
     val hasMoreFollowing: StateFlow<Boolean> = _hasMoreFollowing.asStateFlow()
 
     /** Forum threads that have this media as a `mediaCategory` (Discussions section). */
+    private val _themes = MutableStateFlow(MediaThemesState())
+    val themes: StateFlow<MediaThemesState> = _themes.asStateFlow()
+
     private val _discussions = MutableStateFlow<List<ForumThread>>(emptyList())
     val discussions: StateFlow<List<ForumThread>> = _discussions.asStateFlow()
 
@@ -161,7 +168,63 @@ class MediaDetailsViewModel @Inject constructor(
         refreshIfStale()
         loadFollowingPreview()
         loadDiscussionsPreview()
+        loadThemes()
     }
+
+    /**
+     * Openings and endings from AnimeThemes, which is a different service on a different
+     * schedule to AniList. It waits for the details to say the title is anime, so a manga
+     * page never spends a request, and it never blocks the page: the section draws its own
+     * skeleton and the rest of the screen is already on screen by the time this lands.
+     */
+    private fun loadThemes() {
+        viewModelScope.launch {
+            val details = uiState.filterIsInstance<DetailsUiState.Success>().first().details
+            if (details.type != com.anisync.android.type.MediaType.ANIME) return@launch
+
+            launch {
+                mediaThemesRepository.observeThemes(mediaId).collect { cached ->
+                    if (cached == null) return@collect
+                    _themes.update {
+                        it.copy(
+                            animeSlug = cached.animeSlug,
+                            themes = cached.themes.filterAdult(),
+                            hasLoaded = true
+                        )
+                    }
+                }
+            }
+
+            if (mediaThemesRepository.isStale(mediaId)) fetchThemes()
+            else _themes.update { it.copy(hasLoaded = true) }
+        }
+    }
+
+    private fun fetchThemes() {
+        viewModelScope.launch {
+            _themes.update { it.copy(isLoading = true, errorMessage = null) }
+            when (val result = mediaThemesRepository.refreshThemes(mediaId)) {
+                is Result.Success -> _themes.update {
+                    it.copy(
+                        animeSlug = result.data.animeSlug,
+                        themes = result.data.themes.filterAdult(),
+                        isLoading = false,
+                        hasLoaded = true
+                    )
+                }
+
+                is Result.Error -> _themes.update {
+                    it.copy(isLoading = false, hasLoaded = true, errorMessage = result.message)
+                }
+            }
+        }
+    }
+
+    /** Retry after a failed AnimeThemes lookup, from the notice inside the section. */
+    fun retryThemes() = fetchThemes()
+
+    private fun List<com.anisync.android.domain.MediaTheme>.filterAdult() =
+        if (appSettings.showAdultContent.value) this else filterNot { it.isAdult }
 
     /**
      * Background revalidation on entry. Does not drive the PTR spinner and never blocks the cache

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaDetailsViewModel.kt
@@ -16,7 +16,6 @@ import com.anisync.android.domain.LibraryRepository
 import com.anisync.android.domain.LibraryStatus
 import com.anisync.android.domain.MediaDetails
 import com.anisync.android.domain.MediaFollowingEntry
-import com.anisync.android.domain.MediaThemesRepository
 import com.anisync.android.domain.Result
 import com.anisync.android.domain.ScoreFormat
 import com.anisync.android.util.ShareUtils
@@ -28,8 +27,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -49,7 +46,6 @@ class MediaDetailsViewModel @Inject constructor(
     private val toastManager: com.anisync.android.presentation.components.alert.ToastManager,
     private val forumRepository: ForumRepository,
     private val discoverSearchLauncher: com.anisync.android.domain.DiscoverSearchLauncher,
-    private val mediaThemesRepository: MediaThemesRepository,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -76,9 +72,6 @@ class MediaDetailsViewModel @Inject constructor(
     val hasMoreFollowing: StateFlow<Boolean> = _hasMoreFollowing.asStateFlow()
 
     /** Forum threads that have this media as a `mediaCategory` (Discussions section). */
-    private val _themes = MutableStateFlow(MediaThemesState())
-    val themes: StateFlow<MediaThemesState> = _themes.asStateFlow()
-
     private val _discussions = MutableStateFlow<List<ForumThread>>(emptyList())
     val discussions: StateFlow<List<ForumThread>> = _discussions.asStateFlow()
 
@@ -168,63 +161,7 @@ class MediaDetailsViewModel @Inject constructor(
         refreshIfStale()
         loadFollowingPreview()
         loadDiscussionsPreview()
-        loadThemes()
     }
-
-    /**
-     * Openings and endings from AnimeThemes, which is a different service on a different
-     * schedule to AniList. It waits for the details to say the title is anime, so a manga
-     * page never spends a request, and it never blocks the page: the section draws its own
-     * skeleton and the rest of the screen is already on screen by the time this lands.
-     */
-    private fun loadThemes() {
-        viewModelScope.launch {
-            val details = uiState.filterIsInstance<DetailsUiState.Success>().first().details
-            if (details.type != com.anisync.android.type.MediaType.ANIME) return@launch
-
-            launch {
-                mediaThemesRepository.observeThemes(mediaId).collect { cached ->
-                    if (cached == null) return@collect
-                    _themes.update {
-                        it.copy(
-                            animeSlug = cached.animeSlug,
-                            themes = cached.themes.filterAdult(),
-                            hasLoaded = true
-                        )
-                    }
-                }
-            }
-
-            if (mediaThemesRepository.isStale(mediaId)) fetchThemes()
-            else _themes.update { it.copy(hasLoaded = true) }
-        }
-    }
-
-    private fun fetchThemes() {
-        viewModelScope.launch {
-            _themes.update { it.copy(isLoading = true, errorMessage = null) }
-            when (val result = mediaThemesRepository.refreshThemes(mediaId)) {
-                is Result.Success -> _themes.update {
-                    it.copy(
-                        animeSlug = result.data.animeSlug,
-                        themes = result.data.themes.filterAdult(),
-                        isLoading = false,
-                        hasLoaded = true
-                    )
-                }
-
-                is Result.Error -> _themes.update {
-                    it.copy(isLoading = false, hasLoaded = true, errorMessage = result.message)
-                }
-            }
-        }
-    }
-
-    /** Retry after a failed AnimeThemes lookup, from the notice inside the section. */
-    fun retryThemes() = fetchThemes()
-
-    private fun List<com.anisync.android.domain.MediaTheme>.filterAdult() =
-        if (appSettings.showAdultContent.value) this else filterNot { it.isAdult }
 
     /**
      * Background revalidation on entry. Does not drive the PTR spinner and never blocks the cache

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaThemesScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaThemesScreen.kt
@@ -45,6 +45,7 @@ import com.anisync.android.domain.MediaTheme
 import com.anisync.android.domain.ThemeType
 import com.anisync.android.presentation.components.AppCircularProgressIndicator
 import com.anisync.android.presentation.components.CollapsingTopBarScaffold
+import com.anisync.android.presentation.components.SegmentedTabGroup
 import com.anisync.android.presentation.details.components.ThemeRow
 import com.anisync.android.presentation.details.components.ThemeSheet
 import com.anisync.android.presentation.util.bouncyClickable
@@ -282,53 +283,17 @@ private fun ThemeFilterRow(
 ) {
     if (!hasOpenings || !hasEndings) return
 
-    Surface(
-        color = MaterialTheme.colorScheme.surfaceContainerLow,
-        shape = RoundedCornerShape(50),
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-            modifier = Modifier.padding(4.dp)
-        ) {
-            ThemeFilter.entries.forEach { option ->
-                val isSelected = option == selected
-                Surface(
-                    color = if (isSelected) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.surfaceContainer
-                    },
-                    shape = RoundedCornerShape(50),
-                    modifier = Modifier
-                        .weight(1f)
-                        .clip(RoundedCornerShape(50))
-                        .bouncyClickable(
-                            onClick = { onSelect(option) },
-                            clipShape = RoundedCornerShape(50)
-                        )
-                ) {
-                    Box(
-                        contentAlignment = Alignment.Center,
-                        modifier = Modifier.padding(vertical = 9.dp)
-                    ) {
-                        Text(
-                            text = when (option) {
-                                ThemeFilter.All -> stringResource(R.string.themes_filter_all)
-                                ThemeFilter.Openings -> stringResource(R.string.themes_group_openings)
-                                ThemeFilter.Endings -> stringResource(R.string.themes_group_endings)
-                            },
-                            style = MaterialTheme.typography.labelLarge,
-                            fontWeight = FontWeight.Bold,
-                            color = if (isSelected) {
-                                MaterialTheme.colorScheme.onPrimary
-                            } else {
-                                MaterialTheme.colorScheme.onSurfaceVariant
-                            }
-                        )
-                    }
-                }
+    SegmentedTabGroup(
+        options = ThemeFilter.entries,
+        selected = selected,
+        onSelect = onSelect,
+        label = {
+            when (it) {
+                ThemeFilter.All -> stringResource(R.string.themes_filter_all)
+                ThemeFilter.Openings -> stringResource(R.string.themes_group_openings)
+                ThemeFilter.Endings -> stringResource(R.string.themes_group_endings)
             }
-        }
-    }
+        },
+        fillEqually = true
+    )
 }

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaThemesScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaThemesScreen.kt
@@ -83,6 +83,7 @@ fun MediaThemesScreen(
 
     val openingsLabel = stringResource(R.string.themes_group_openings)
     val endingsLabel = stringResource(R.string.themes_group_endings)
+    val scaleLabel = totalEpisodes?.let { stringResource(R.string.themes_episode_scale, it) }
 
     CollapsingTopBarScaffold(
         title = stringResource(R.string.section_themes),
@@ -91,7 +92,7 @@ fun MediaThemesScreen(
     ) { topContentPadding ->
         if (themesState.themes.isEmpty()) {
             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                if (themesState.isLoading) {
+                if (themesState.isLoading || !themesState.hasLoaded) {
                     AppCircularProgressIndicator()
                 } else {
                     Text(
@@ -135,6 +136,7 @@ fun MediaThemesScreen(
             if (filter != ThemeFilter.Endings && openings.isNotEmpty()) {
                 themeGroup(
                     label = openingsLabel,
+                    scaleLabel = scaleLabel,
                     themes = openings,
                     totalEpisodes = totalEpisodes,
                     coverUrl = coverUrl,
@@ -147,6 +149,7 @@ fun MediaThemesScreen(
             if (filter != ThemeFilter.Openings && endings.isNotEmpty()) {
                 themeGroup(
                     label = endingsLabel,
+                    scaleLabel = scaleLabel,
                     themes = endings,
                     totalEpisodes = totalEpisodes,
                     coverUrl = coverUrl,
@@ -231,6 +234,7 @@ fun MediaThemesScreen(
 
 private fun androidx.compose.foundation.lazy.LazyListScope.themeGroup(
     label: String,
+    scaleLabel: String?,
     themes: List<MediaTheme>,
     totalEpisodes: Int?,
     coverUrl: String?,
@@ -240,11 +244,22 @@ private fun androidx.compose.foundation.lazy.LazyListScope.themeGroup(
 ) {
     item(key = "label_$label") {
         Spacer(Modifier.height(4.dp))
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.weight(1f)
+            )
+            // Every bar below shares this scale, which is what makes the stack readable.
+            if (scaleLabel != null) {
+                Text(
+                    text = scaleLabel,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                )
+            }
+        }
     }
     items(themes, key = { it.id }) { theme ->
         ThemeRow(

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaThemesScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaThemesScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -61,16 +62,15 @@ private enum class ThemeFilter { All, Openings, Endings }
 @Composable
 fun MediaThemesScreen(
     mediaTitle: String,
+    totalEpisodes: Int?,
+    coverUrl: String?,
     onBackClick: () -> Unit,
-    viewModel: MediaDetailsViewModel = hiltViewModel()
+    viewModel: MediaThemesViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
-    val themesState by viewModel.themes.collectAsStateWithLifecycle()
-    val detailsState by viewModel.uiState.collectAsStateWithLifecycle()
+    val themesState by viewModel.state.collectAsStateWithLifecycle()
 
-    val details = (detailsState as? DetailsUiState.Success)?.details
-    val totalEpisodes = details?.episodes
-    val coverUrl = details?.bannerUrl ?: details?.coverUrl
+    LaunchedEffect(Unit) { viewModel.start(isAnime = true) }
 
     var filter by rememberSaveable { mutableStateOf(ThemeFilter.All) }
     var openTheme by remember { mutableStateOf<MediaTheme?>(null) }

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaThemesScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaThemesScreen.kt
@@ -75,7 +75,6 @@ fun MediaThemesScreen(
 
     var filter by rememberSaveable { mutableStateOf(ThemeFilter.All) }
     var openTheme by remember { mutableStateOf<MediaTheme?>(null) }
-    var revealedSpoilers by remember { mutableStateOf(emptySet<Int>()) }
 
     val listState = rememberLazyListState()
 
@@ -141,8 +140,6 @@ fun MediaThemesScreen(
                     themes = openings,
                     totalEpisodes = totalEpisodes,
                     coverUrl = coverUrl,
-                    revealedSpoilers = revealedSpoilers,
-                    onRevealSpoiler = { revealedSpoilers = revealedSpoilers + it },
                     onThemeClick = { openTheme = it }
                 )
             }
@@ -154,8 +151,6 @@ fun MediaThemesScreen(
                     themes = endings,
                     totalEpisodes = totalEpisodes,
                     coverUrl = coverUrl,
-                    revealedSpoilers = revealedSpoilers,
-                    onRevealSpoiler = { revealedSpoilers = revealedSpoilers + it },
                     onThemeClick = { openTheme = it }
                 )
             }
@@ -239,8 +234,6 @@ private fun androidx.compose.foundation.lazy.LazyListScope.themeGroup(
     themes: List<MediaTheme>,
     totalEpisodes: Int?,
     coverUrl: String?,
-    revealedSpoilers: Set<Int>,
-    onRevealSpoiler: (Int) -> Unit,
     onThemeClick: (MediaTheme) -> Unit
 ) {
     item(key = "label_$label") {
@@ -267,9 +260,7 @@ private fun androidx.compose.foundation.lazy.LazyListScope.themeGroup(
             theme = theme,
             coverUrl = coverUrl,
             totalEpisodes = totalEpisodes,
-            isSpoilerRevealed = theme.id in revealedSpoilers,
-            onClick = { onThemeClick(theme) },
-            onRevealSpoiler = { onRevealSpoiler(theme.id) }
+            onClick = { onThemeClick(theme) }
         )
     }
 }

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaThemesScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaThemesScreen.kt
@@ -1,0 +1,319 @@
+package com.anisync.android.presentation.details
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.anisync.android.R
+import com.anisync.android.domain.MediaTheme
+import com.anisync.android.domain.ThemeType
+import com.anisync.android.presentation.components.AppCircularProgressIndicator
+import com.anisync.android.presentation.components.CollapsingTopBarScaffold
+import com.anisync.android.presentation.details.components.ThemeRow
+import com.anisync.android.presentation.details.components.ThemeSheet
+import com.anisync.android.presentation.util.bouncyClickable
+
+private enum class ThemeFilter { All, Openings, Endings }
+
+/**
+ * Every opening and ending for a title, stacked so the bars share one scale.
+ *
+ * This is the screen behind the section arrow. The rail on the media page is deliberately
+ * short and horizontal, which is fine for four themes and useless for seventy, so the
+ * comparison view lives here where the rows can align and the filter can cut the list down.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MediaThemesScreen(
+    mediaTitle: String,
+    onBackClick: () -> Unit,
+    viewModel: MediaDetailsViewModel = hiltViewModel()
+) {
+    val context = LocalContext.current
+    val themesState by viewModel.themes.collectAsStateWithLifecycle()
+    val detailsState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val details = (detailsState as? DetailsUiState.Success)?.details
+    val totalEpisodes = details?.episodes
+    val coverUrl = details?.bannerUrl ?: details?.coverUrl
+
+    var filter by rememberSaveable { mutableStateOf(ThemeFilter.All) }
+    var openTheme by remember { mutableStateOf<MediaTheme?>(null) }
+    var revealedSpoilers by remember { mutableStateOf(emptySet<Int>()) }
+
+    val listState = rememberLazyListState()
+
+    val openings = remember(themesState.themes) { themesState.themes.filter { it.type == ThemeType.OP } }
+    val endings = remember(themesState.themes) { themesState.themes.filter { it.type == ThemeType.ED } }
+
+    val openingsLabel = stringResource(R.string.themes_group_openings)
+    val endingsLabel = stringResource(R.string.themes_group_endings)
+
+    CollapsingTopBarScaffold(
+        title = stringResource(R.string.section_themes),
+        onBackClick = onBackClick,
+        scrollableState = listState
+    ) { topContentPadding ->
+        if (themesState.themes.isEmpty()) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                if (themesState.isLoading) {
+                    AppCircularProgressIndicator()
+                } else {
+                    Text(
+                        text = stringResource(R.string.themes_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            return@CollapsingTopBarScaffold
+        }
+
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(
+                top = topContentPadding,
+                bottom = dimensionResource(R.dimen.spacing_extra_large),
+                start = dimensionResource(R.dimen.spacing_large),
+                end = dimensionResource(R.dimen.spacing_large)
+            ),
+            verticalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.spacing_small))
+        ) {
+            item(key = "subtitle") {
+                Text(
+                    text = mediaTitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            item(key = "filter") {
+                ThemeFilterRow(
+                    selected = filter,
+                    hasOpenings = openings.isNotEmpty(),
+                    hasEndings = endings.isNotEmpty(),
+                    onSelect = { filter = it }
+                )
+            }
+
+            if (filter != ThemeFilter.Endings && openings.isNotEmpty()) {
+                themeGroup(
+                    label = openingsLabel,
+                    themes = openings,
+                    totalEpisodes = totalEpisodes,
+                    coverUrl = coverUrl,
+                    revealedSpoilers = revealedSpoilers,
+                    onRevealSpoiler = { revealedSpoilers = revealedSpoilers + it },
+                    onThemeClick = { openTheme = it }
+                )
+            }
+
+            if (filter != ThemeFilter.Openings && endings.isNotEmpty()) {
+                themeGroup(
+                    label = endingsLabel,
+                    themes = endings,
+                    totalEpisodes = totalEpisodes,
+                    coverUrl = coverUrl,
+                    revealedSpoilers = revealedSpoilers,
+                    onRevealSpoiler = { revealedSpoilers = revealedSpoilers + it },
+                    onThemeClick = { openTheme = it }
+                )
+            }
+
+            item(key = "footer") {
+                Spacer(Modifier.height(dimensionResource(R.dimen.spacing_small)))
+                val slug = themesState.animeSlug
+                Surface(
+                    color = MaterialTheme.colorScheme.surfaceContainer,
+                    shape = RoundedCornerShape(16.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(16.dp))
+                        .bouncyClickable(
+                            onClick = {
+                                val url = if (slug != null) {
+                                    "https://animethemes.moe/anime/$slug"
+                                } else {
+                                    "https://animethemes.moe"
+                                }
+                                runCatching {
+                                    context.startActivity(
+                                        android.content.Intent(
+                                            android.content.Intent.ACTION_VIEW,
+                                            android.net.Uri.parse(url)
+                                        )
+                                    )
+                                }
+                            },
+                            clipShape = RoundedCornerShape(16.dp)
+                        )
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(dimensionResource(R.dimen.spacing_medium))
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Link,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(20.dp)
+                        )
+                        Spacer(Modifier.width(dimensionResource(R.dimen.spacing_normal)))
+                        Text(
+                            text = stringResource(R.string.themes_open_source),
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    text = stringResource(R.string.themes_attribution),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                )
+            }
+        }
+    }
+
+    openTheme?.let { theme ->
+        ThemeSheet(
+            theme = theme,
+            totalEpisodes = totalEpisodes,
+            animeSlug = themesState.animeSlug,
+            onDismiss = { openTheme = null }
+        )
+    }
+}
+
+private fun androidx.compose.foundation.lazy.LazyListScope.themeGroup(
+    label: String,
+    themes: List<MediaTheme>,
+    totalEpisodes: Int?,
+    coverUrl: String?,
+    revealedSpoilers: Set<Int>,
+    onRevealSpoiler: (Int) -> Unit,
+    onThemeClick: (MediaTheme) -> Unit
+) {
+    item(key = "label_$label") {
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+    items(themes, key = { it.id }) { theme ->
+        ThemeRow(
+            theme = theme,
+            coverUrl = coverUrl,
+            totalEpisodes = totalEpisodes,
+            isSpoilerRevealed = theme.id in revealedSpoilers,
+            onClick = { onThemeClick(theme) },
+            onRevealSpoiler = { onRevealSpoiler(theme.id) }
+        )
+    }
+}
+
+@Composable
+private fun ThemeFilterRow(
+    selected: ThemeFilter,
+    hasOpenings: Boolean,
+    hasEndings: Boolean,
+    onSelect: (ThemeFilter) -> Unit
+) {
+    if (!hasOpenings || !hasEndings) return
+
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        shape = RoundedCornerShape(50),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            modifier = Modifier.padding(4.dp)
+        ) {
+            ThemeFilter.entries.forEach { option ->
+                val isSelected = option == selected
+                Surface(
+                    color = if (isSelected) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.surfaceContainer
+                    },
+                    shape = RoundedCornerShape(50),
+                    modifier = Modifier
+                        .weight(1f)
+                        .clip(RoundedCornerShape(50))
+                        .bouncyClickable(
+                            onClick = { onSelect(option) },
+                            clipShape = RoundedCornerShape(50)
+                        )
+                ) {
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier.padding(vertical = 9.dp)
+                    ) {
+                        Text(
+                            text = when (option) {
+                                ThemeFilter.All -> stringResource(R.string.themes_filter_all)
+                                ThemeFilter.Openings -> stringResource(R.string.themes_group_openings)
+                                ThemeFilter.Endings -> stringResource(R.string.themes_group_endings)
+                            },
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.Bold,
+                            color = if (isSelected) {
+                                MaterialTheme.colorScheme.onPrimary
+                            } else {
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaThemesViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaThemesViewModel.kt
@@ -1,0 +1,93 @@
+package com.anisync.android.presentation.details
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.anisync.android.data.AppSettings
+import com.anisync.android.domain.MediaTheme
+import com.anisync.android.domain.MediaThemesRepository
+import com.anisync.android.domain.Result
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Openings and endings for one title, owned separately from the media details it sits under.
+ *
+ * Its own ViewModel rather than another flow on [MediaDetailsViewModel] because the full list
+ * is a route of its own: sharing the details ViewModel there would build a second copy of it,
+ * re-check the media details cache and fetch the discussion and following previews, all to
+ * draw a list that was already in Room.
+ *
+ * [start] is called with what the page knows about the title, so a manga page never spends a
+ * request on a service that only carries anime.
+ */
+@HiltViewModel
+class MediaThemesViewModel @Inject constructor(
+    private val repository: MediaThemesRepository,
+    private val appSettings: AppSettings,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val mediaId: Int = checkNotNull(savedStateHandle["mediaId"]) {
+        "Media ID is required for MediaThemesViewModel"
+    }
+
+    private val _state = MutableStateFlow(MediaThemesState())
+    val state: StateFlow<MediaThemesState> = _state.asStateFlow()
+
+    private var started = false
+
+    /** Begins the lookup once, and only for anime. Safe to call on every recomposition. */
+    fun start(isAnime: Boolean) {
+        if (started || !isAnime) return
+        started = true
+
+        viewModelScope.launch {
+            repository.observeThemes(mediaId).collect { cached ->
+                if (cached == null) return@collect
+                _state.update {
+                    it.copy(
+                        animeSlug = cached.animeSlug,
+                        themes = cached.themes.filterAdult(),
+                        hasLoaded = true
+                    )
+                }
+            }
+        }
+
+        viewModelScope.launch {
+            if (repository.isStale(mediaId)) fetch() else _state.update { it.copy(hasLoaded = true) }
+        }
+    }
+
+    /** Retry from the notice the section shows when the lookup failed. */
+    fun retry() {
+        viewModelScope.launch { fetch() }
+    }
+
+    private suspend fun fetch() {
+        _state.update { it.copy(isLoading = true, errorMessage = null) }
+        when (val result = repository.refreshThemes(mediaId)) {
+            is Result.Success -> _state.update {
+                it.copy(
+                    animeSlug = result.data.animeSlug,
+                    themes = result.data.themes.filterAdult(),
+                    isLoading = false,
+                    hasLoaded = true
+                )
+            }
+
+            is Result.Error -> _state.update {
+                it.copy(isLoading = false, hasLoaded = true, errorMessage = result.message)
+            }
+        }
+    }
+
+    private fun List<MediaTheme>.filterAdult(): List<MediaTheme> =
+        if (appSettings.showAdultContent.value) this else filterNot { it.isAdult }
+}

--- a/app/src/main/java/com/anisync/android/presentation/details/MediaThemesViewModel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/MediaThemesViewModel.kt
@@ -71,7 +71,7 @@ class MediaThemesViewModel @Inject constructor(
     }
 
     private suspend fun fetch() {
-        _state.update { it.copy(isLoading = true, errorMessage = null) }
+        _state.update { it.copy(isLoading = true, errorMessage = null, retryAfterSeconds = null) }
         when (val result = repository.refreshThemes(mediaId)) {
             is Result.Success -> _state.update {
                 it.copy(
@@ -83,7 +83,12 @@ class MediaThemesViewModel @Inject constructor(
             }
 
             is Result.Error -> _state.update {
-                it.copy(isLoading = false, hasLoaded = true, errorMessage = result.message)
+                it.copy(
+                    isLoading = false,
+                    hasLoaded = true,
+                    errorMessage = result.message,
+                    retryAfterSeconds = result.countdownSeconds
+                )
             }
         }
     }

--- a/app/src/main/java/com/anisync/android/presentation/details/components/MediaThemesComponents.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/components/MediaThemesComponents.kt
@@ -247,11 +247,14 @@ fun ThemeTile(
         stringResource(R.string.themes_episodes, coverageLabel)
     }
 
+    // The ripple is rounded at the top to match the artwork and left square at the bottom, so
+    // the corner curve does not bite the first and last mark off the episode bar.
+    val rippleShape = RoundedCornerShape(topStart = 14.dp, topEnd = 14.dp)
+
     Column(
         modifier = modifier
             .width(TILE_WIDTH)
-            .clip(RoundedCornerShape(14.dp))
-            .bouncyClickable(onClick = onClick, clipShape = RoundedCornerShape(14.dp))
+            .bouncyClickable(onClick = onClick, clipShape = rippleShape)
             .semantics { contentDescription = "${theme.slug}. $description" }
     ) {
         ThemeArtwork(

--- a/app/src/main/java/com/anisync/android/presentation/details/components/MediaThemesComponents.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/components/MediaThemesComponents.kt
@@ -85,12 +85,7 @@ fun EpisodeCoverageBar(
     modifier: Modifier = Modifier,
     height: Dp = 6.dp,
     coveredColor: Color = MaterialTheme.colorScheme.primary,
-    trackColor: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.14f),
-    /**
-     * Whether no spans means the theme plays over everything. True for an entry AnimeThemes never
-     * gave a range, false when the range is merely being withheld behind a spoiler tap.
-     */
-    emptyMeansAll: Boolean = true
+    trackColor: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.14f)
 ) {
     val total = totalEpisodes ?: return
     if (total <= 0) return
@@ -103,8 +98,7 @@ fun EpisodeCoverageBar(
         val radius = CornerRadius(size.height / 2f, size.height / 2f)
 
         if (spans.isEmpty()) {
-            val fill = if (emptyMeansAll) coveredColor.copy(alpha = 0.4f) else trackColor
-            drawRoundRect(color = fill, cornerRadius = radius)
+            drawRoundRect(color = coveredColor.copy(alpha = 0.4f), cornerRadius = radius)
             return@Canvas
         }
 
@@ -173,7 +167,10 @@ private fun ThemeArtwork(
     type: ThemeType,
     cornerRadius: Dp,
     playGlyphSize: Dp,
-    modifier: Modifier = Modifier
+    isSpoiler: Boolean,
+    modifier: Modifier = Modifier,
+    /** False in the full list, where the row already carries a play button the glyph would sit under. */
+    showPlayGlyph: Boolean = true
 ) {
     val tint = if (type == ThemeType.OP) {
         MaterialTheme.colorScheme.primary
@@ -205,20 +202,41 @@ private fun ThemeArtwork(
                 .background(tint.copy(alpha = 0.34f))
         )
 
-        Box(
-            modifier = Modifier
-                .align(Alignment.Center)
-                .size(playGlyphSize)
-                .clip(CircleShape)
-                .background(Color.Black.copy(alpha = 0.5f)),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = Icons.Default.PlayArrow,
-                contentDescription = null,
-                tint = Color.White,
-                modifier = Modifier.size(playGlyphSize * 0.55f)
-            )
+        if (showPlayGlyph) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .size(playGlyphSize)
+                    .clip(CircleShape)
+                    .background(Color.Black.copy(alpha = 0.5f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.PlayArrow,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(playGlyphSize * 0.55f)
+                )
+            }
+        }
+
+        if (isSpoiler) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(6.dp)
+                    .size(18.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.error),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.VisibilityOff,
+                    contentDescription = stringResource(R.string.cd_theme_spoiler),
+                    tint = MaterialTheme.colorScheme.onError,
+                    modifier = Modifier.size(11.dp)
+                )
+            }
         }
 
         Surface(
@@ -253,7 +271,7 @@ fun ThemeTile(
 ) {
     val spans = remember(theme) { theme.episodeSpans }
     val coverageLabel = remember(spans) { formatEpisodeSpans(spans) }
-    val description = if (theme.isSpoiler || spans.isEmpty()) {
+    val description = if (spans.isEmpty()) {
         theme.songTitle.orEmpty()
     } else {
         pluralStringResource(R.plurals.themes_episodes, episodeQuantity(spans), coverageLabel)
@@ -275,6 +293,7 @@ fun ThemeTile(
             type = theme.type,
             cornerRadius = 14.dp,
             playGlyphSize = 30.dp,
+            isSpoiler = theme.isSpoiler,
             modifier = Modifier
                 .width(TILE_WIDTH)
                 .height(TILE_ART_HEIGHT)
@@ -288,23 +307,22 @@ fun ThemeTile(
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
-        if (theme.artists.isNotEmpty()) {
-            Text(
-                text = theme.artists.joinToString(", "),
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
+        // Always drawn, even with no artist recorded. An absent line would make this tile
+        // shorter than its neighbours, and a LazyRow takes its height from the tallest visible
+        // item, so the whole section would resize as it scrolled.
+        Text(
+            text = theme.artists.joinToString(", "),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
         Spacer(Modifier.height(8.dp))
-        if (!theme.isSpoiler) {
-            EpisodeCoverageBar(
-                spans = spans,
-                totalEpisodes = totalEpisodes,
-                height = 5.dp
-            )
-        }
+        EpisodeCoverageBar(
+            spans = spans,
+            totalEpisodes = totalEpisodes,
+            height = 5.dp
+        )
     }
 }
 
@@ -314,13 +332,10 @@ fun ThemeRow(
     theme: MediaTheme,
     coverUrl: String?,
     totalEpisodes: Int?,
-    isSpoilerRevealed: Boolean,
     onClick: () -> Unit,
-    onRevealSpoiler: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val spans = remember(theme) { theme.episodeSpans }
-    val hideEpisodes = theme.isSpoiler && !isSpoilerRevealed
 
     Surface(
         color = MaterialTheme.colorScheme.surfaceContainer,
@@ -338,6 +353,8 @@ fun ThemeRow(
                     type = theme.type,
                     cornerRadius = 10.dp,
                     playGlyphSize = 26.dp,
+                    isSpoiler = theme.isSpoiler,
+                    showPlayGlyph = false,
                     modifier = Modifier
                         .width(ROW_ART_WIDTH)
                         .height(ROW_ART_HEIGHT)
@@ -361,45 +378,19 @@ fun ThemeRow(
                             overflow = TextOverflow.Ellipsis
                         )
                     }
-                    if (hideEpisodes) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.bouncyClickable(onClick = onRevealSpoiler)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.VisibilityOff,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.size(14.dp)
-                            )
-                            Spacer(Modifier.width(6.dp))
-                            Text(
-                                text = stringResource(R.string.themes_spoiler_hidden),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.weight(1f, fill = false)
-                            )
-                            Spacer(Modifier.width(8.dp))
-                            // Never wraps: a broken "Revea/l" reads as a rendering fault.
-                            Text(
-                                text = stringResource(R.string.themes_spoiler_reveal),
-                                style = MaterialTheme.typography.bodySmall,
-                                fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.primary,
-                                maxLines = 1,
-                                softWrap = false
-                            )
-                        }
-                    } else {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
                             text = themeCoverageLabel(theme, spans),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.75f),
                             maxLines = 2,
-                            overflow = TextOverflow.Ellipsis
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f, fill = false)
                         )
+                        if (theme.isSpoiler) {
+                            Spacer(Modifier.width(8.dp))
+                            SpoilerTag()
+                        }
                     }
                 }
                 Spacer(Modifier.width(12.dp))
@@ -420,10 +411,9 @@ fun ThemeRow(
             }
             Spacer(Modifier.height(10.dp))
             EpisodeCoverageBar(
-                spans = if (hideEpisodes) emptyList() else spans,
+                spans = spans,
                 totalEpisodes = totalEpisodes,
-                height = 6.dp,
-                emptyMeansAll = !hideEpisodes
+                height = 6.dp
             )
         }
     }
@@ -618,6 +608,43 @@ fun themeCoverageLabel(theme: MediaTheme, spans: List<EpisodeSpan>): String {
         range + "  ·  " + pluralStringResource(R.plurals.themes_versions_count, versions, versions)
     } else {
         range
+    }
+}
+
+/**
+ * Marks a theme AnimeThemes flagged as spoiling the show.
+ *
+ * A warning, not a cover. What spoils is the theme itself, its visuals and often its lyrics,
+ * so hiding the episode range would withhold the one thing that is safe to read.
+ */
+@Composable
+fun SpoilerTag(modifier: Modifier = Modifier) {
+    Surface(
+        color = Color.Transparent,
+        shape = RoundedCornerShape(50),
+        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.error),
+        modifier = modifier
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.VisibilityOff,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(12.dp)
+            )
+            Spacer(Modifier.width(5.dp))
+            Text(
+                text = stringResource(R.string.themes_spoiler_tag),
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.error,
+                maxLines = 1,
+                softWrap = false
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/anisync/android/presentation/details/components/MediaThemesComponents.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/components/MediaThemesComponents.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -167,7 +166,6 @@ private fun ThemeArtwork(
     type: ThemeType,
     cornerRadius: Dp,
     playGlyphSize: Dp,
-    isSpoiler: Boolean,
     modifier: Modifier = Modifier,
     /** False in the full list, where the row already carries a play button the glyph would sit under. */
     showPlayGlyph: Boolean = true
@@ -216,25 +214,6 @@ private fun ThemeArtwork(
                     contentDescription = null,
                     tint = Color.White,
                     modifier = Modifier.size(playGlyphSize * 0.55f)
-                )
-            }
-        }
-
-        if (isSpoiler) {
-            Box(
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(6.dp)
-                    .size(18.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.error),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    imageVector = Icons.Default.VisibilityOff,
-                    contentDescription = stringResource(R.string.cd_theme_spoiler),
-                    tint = MaterialTheme.colorScheme.onError,
-                    modifier = Modifier.size(11.dp)
                 )
             }
         }
@@ -293,7 +272,6 @@ fun ThemeTile(
             type = theme.type,
             cornerRadius = 14.dp,
             playGlyphSize = 30.dp,
-            isSpoiler = theme.isSpoiler,
             modifier = Modifier
                 .width(TILE_WIDTH)
                 .height(TILE_ART_HEIGHT)
@@ -353,7 +331,6 @@ fun ThemeRow(
                     type = theme.type,
                     cornerRadius = 10.dp,
                     playGlyphSize = 26.dp,
-                    isSpoiler = theme.isSpoiler,
                     showPlayGlyph = false,
                     modifier = Modifier
                         .width(ROW_ART_WIDTH)
@@ -615,36 +592,26 @@ fun themeCoverageLabel(theme: MediaTheme, spans: List<EpisodeSpan>): String {
  * Marks a theme AnimeThemes flagged as spoiling the show.
  *
  * A warning, not a cover. What spoils is the theme itself, its visuals and often its lyrics,
- * so hiding the episode range would withhold the one thing that is safe to read.
+ * so hiding the episode range would withhold the one thing that is safe to read. Drawn as a
+ * tonal pill so it sits in the same family as the number and qualifier pills rather than
+ * shouting over the row.
  */
 @Composable
 fun SpoilerTag(modifier: Modifier = Modifier) {
     Surface(
-        color = Color.Transparent,
+        color = MaterialTheme.colorScheme.errorContainer,
         shape = RoundedCornerShape(50),
-        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.error),
         modifier = modifier
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
+        Text(
+            text = stringResource(R.string.themes_spoiler_tag),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.ExtraBold,
+            color = MaterialTheme.colorScheme.onErrorContainer,
+            maxLines = 1,
+            softWrap = false,
             modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp)
-        ) {
-            Icon(
-                imageVector = Icons.Default.VisibilityOff,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.error,
-                modifier = Modifier.size(12.dp)
-            )
-            Spacer(Modifier.width(5.dp))
-            Text(
-                text = stringResource(R.string.themes_spoiler_tag),
-                style = MaterialTheme.typography.labelSmall,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.error,
-                maxLines = 1,
-                softWrap = false
-            )
-        }
+        )
     }
 }
 

--- a/app/src/main/java/com/anisync/android/presentation/details/components/MediaThemesComponents.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/components/MediaThemesComponents.kt
@@ -1,0 +1,609 @@
+package com.anisync.android.presentation.details.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.anisync.android.R
+import com.anisync.android.domain.EpisodeSpan
+import com.anisync.android.domain.MediaTheme
+import com.anisync.android.domain.ThemeType
+import com.anisync.android.domain.countCoveredEpisodes
+import com.anisync.android.domain.formatEpisodeSpans
+import com.anisync.android.presentation.util.bouncyClickable
+
+/** Past this many episodes a per-episode mark is thinner than a hairline, so the bar draws spans. */
+private const val TICK_LIMIT = 50
+
+private val TILE_WIDTH = 160.dp
+private val TILE_ART_HEIGHT = 90.dp
+private val ROW_ART_WIDTH = 104.dp
+private val ROW_ART_HEIGHT = 59.dp
+
+/**
+ * Where a theme plays across a show's run.
+ *
+ * Two shapes, picked from the episode count rather than a flag, because they answer the same
+ * question at different scales. Up to [TICK_LIMIT] episodes each one gets its own mark, so a
+ * single skipped episode is visible. Past that the marks would be sub-pixel, so each range is
+ * drawn as one proportional span instead.
+ *
+ * A range the API left open ("13-") fades out rather than claiming episodes that have not
+ * aired. No episode data at all draws the whole bar at half strength, which is the honest
+ * reading of a field AnimeThemes never filled in.
+ */
+@Composable
+fun EpisodeCoverageBar(
+    spans: List<EpisodeSpan>,
+    totalEpisodes: Int?,
+    modifier: Modifier = Modifier,
+    height: Dp = 6.dp,
+    coveredColor: Color = MaterialTheme.colorScheme.primary,
+    trackColor: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.14f)
+) {
+    val total = totalEpisodes ?: return
+    if (total <= 0) return
+
+    Canvas(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(height)
+    ) {
+        val radius = CornerRadius(size.height / 2f, size.height / 2f)
+
+        if (spans.isEmpty()) {
+            drawRoundRect(color = coveredColor.copy(alpha = 0.4f), cornerRadius = radius)
+            return@Canvas
+        }
+
+        if (total <= TICK_LIMIT) {
+            val gap = 2.dp.toPx()
+            val tickWidth = ((size.width - gap * (total - 1)) / total).coerceAtLeast(1f)
+            for (episode in 1..total) {
+                val covered = spans.any { it.contains(episode) }
+                drawRoundRect(
+                    color = if (covered) coveredColor else trackColor,
+                    topLeft = Offset((episode - 1) * (tickWidth + gap), 0f),
+                    size = Size(tickWidth, size.height),
+                    cornerRadius = radius
+                )
+            }
+            return@Canvas
+        }
+
+        drawRoundRect(color = trackColor, cornerRadius = radius)
+        val minWidth = 3.dp.toPx()
+        for (span in spans) {
+            val last = span.end ?: total
+            val startX = ((span.start - 1).toFloat() / total) * size.width
+            val rawWidth = ((last - span.start + 1).toFloat() / total) * size.width
+            val spanWidth = rawWidth.coerceAtLeast(minWidth)
+            val x = startX.coerceAtMost((size.width - spanWidth).coerceAtLeast(0f))
+
+            if (span.isOpen) {
+                drawRoundRect(
+                    brush = Brush.horizontalGradient(
+                        colorStops = arrayOf(
+                            0f to coveredColor,
+                            0.55f to coveredColor,
+                            1f to coveredColor.copy(alpha = 0f)
+                        ),
+                        startX = x,
+                        endX = x + spanWidth
+                    ),
+                    topLeft = Offset(x, 0f),
+                    size = Size(spanWidth, size.height),
+                    cornerRadius = radius
+                )
+            } else {
+                drawRoundRect(
+                    color = coveredColor,
+                    topLeft = Offset(x, 0f),
+                    size = Size(spanWidth, size.height),
+                    cornerRadius = radius
+                )
+            }
+        }
+    }
+}
+
+/**
+ * The picture on a theme card.
+ *
+ * The show's own art, dimmed and tinted by kind. AnimeThemes serves no still for a theme, and
+ * decoding one out of the video would mean pulling tens of megabytes per row, so the art is
+ * the cover the page has already loaded.
+ */
+@Composable
+private fun ThemeArtwork(
+    coverUrl: String?,
+    slug: String,
+    type: ThemeType,
+    cornerRadius: Dp,
+    playGlyphSize: Dp,
+    modifier: Modifier = Modifier
+) {
+    val tint = if (type == ThemeType.OP) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.tertiary
+    }
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(cornerRadius))
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+    ) {
+        if (coverUrl != null) {
+            AsyncImage(
+                model = coverUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.5f))
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(tint.copy(alpha = 0.34f))
+        )
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .size(playGlyphSize)
+                .clip(CircleShape)
+                .background(Color.Black.copy(alpha = 0.5f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.PlayArrow,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier.size(playGlyphSize * 0.55f)
+            )
+        }
+
+        Surface(
+            color = Color.Black.copy(alpha = 0.78f),
+            shape = RoundedCornerShape(50),
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(6.dp)
+        ) {
+            Text(
+                text = slug,
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.ExtraBold,
+                color = Color.White,
+                modifier = Modifier.padding(horizontal = 7.dp, vertical = 2.dp)
+            )
+        }
+    }
+}
+
+/** One theme in the horizontal rail on the media page. */
+@Composable
+fun ThemeTile(
+    theme: MediaTheme,
+    coverUrl: String?,
+    totalEpisodes: Int?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val spans = remember(theme) { theme.episodeSpans }
+    val coverageLabel = remember(spans) { formatEpisodeSpans(spans) }
+    val description = if (theme.isSpoiler || spans.isEmpty()) {
+        theme.songTitle.orEmpty()
+    } else {
+        stringResource(R.string.themes_episodes, coverageLabel)
+    }
+
+    Column(
+        modifier = modifier
+            .width(TILE_WIDTH)
+            .clip(RoundedCornerShape(14.dp))
+            .bouncyClickable(onClick = onClick, clipShape = RoundedCornerShape(14.dp))
+            .semantics { contentDescription = "${theme.slug}. $description" }
+    ) {
+        ThemeArtwork(
+            coverUrl = coverUrl,
+            slug = theme.slug,
+            type = theme.type,
+            cornerRadius = 14.dp,
+            playGlyphSize = 30.dp,
+            modifier = Modifier
+                .width(TILE_WIDTH)
+                .height(TILE_ART_HEIGHT)
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = theme.songTitle ?: theme.slug,
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        if (theme.artists.isNotEmpty()) {
+            Text(
+                text = theme.artists.joinToString(", "),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        Spacer(Modifier.height(8.dp))
+        if (!theme.isSpoiler) {
+            EpisodeCoverageBar(
+                spans = spans,
+                totalEpisodes = totalEpisodes,
+                height = 5.dp
+            )
+        }
+    }
+}
+
+/** One theme in the full list, where the bars of every row share a scale. */
+@Composable
+fun ThemeRow(
+    theme: MediaTheme,
+    coverUrl: String?,
+    totalEpisodes: Int?,
+    isSpoilerRevealed: Boolean,
+    onClick: () -> Unit,
+    onRevealSpoiler: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val spans = remember(theme) { theme.episodeSpans }
+    val hideEpisodes = theme.isSpoiler && !isSpoilerRevealed
+
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = RoundedCornerShape(16.dp),
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .bouncyClickable(onClick = onClick, clipShape = RoundedCornerShape(16.dp))
+    ) {
+        Column(modifier = Modifier.padding(10.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                ThemeArtwork(
+                    coverUrl = coverUrl,
+                    slug = theme.slug,
+                    type = theme.type,
+                    cornerRadius = 10.dp,
+                    playGlyphSize = 26.dp,
+                    modifier = Modifier
+                        .width(ROW_ART_WIDTH)
+                        .height(ROW_ART_HEIGHT)
+                )
+                Spacer(Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = theme.songTitle ?: theme.slug,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    if (theme.artists.isNotEmpty()) {
+                        Text(
+                            text = theme.artists.joinToString(", "),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                    if (hideEpisodes) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.bouncyClickable(onClick = onRevealSpoiler)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.VisibilityOff,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(14.dp)
+                            )
+                            Spacer(Modifier.width(6.dp))
+                            Text(
+                                text = stringResource(R.string.themes_spoiler_hidden),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Text(
+                                text = stringResource(R.string.themes_spoiler_reveal),
+                                style = MaterialTheme.typography.bodySmall,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    } else {
+                        Text(
+                            text = themeCoverageLabel(theme, spans),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.75f),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+                Spacer(Modifier.width(12.dp))
+                Box(
+                    modifier = Modifier
+                        .size(36.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.PlayArrow,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+            }
+            Spacer(Modifier.height(10.dp))
+            EpisodeCoverageBar(
+                spans = if (hideEpisodes) emptyList() else spans,
+                totalEpisodes = totalEpisodes,
+                height = 6.dp,
+                coveredColor = if (hideEpisodes) {
+                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.14f)
+                } else {
+                    MaterialTheme.colorScheme.primary
+                }
+            )
+        }
+    }
+}
+
+/**
+ * The rail on the media page, with the count in the subheading and the full list behind
+ * the arrow. Renders nothing at all when AnimeThemes does not list the title.
+ */
+@Composable
+fun MediaThemesSection(
+    themes: List<MediaTheme>,
+    isLoading: Boolean,
+    errorMessage: String?,
+    coverUrl: String?,
+    totalEpisodes: Int?,
+    onSeeAllClick: () -> Unit,
+    onThemeClick: (MediaTheme) -> Unit,
+    onRetryClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (themes.isEmpty() && !isLoading && errorMessage == null) return
+
+    val horizontal = dimensionResource(R.dimen.spacing_large)
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        ThemesSectionHeader(
+            themes = themes,
+            onSeeAllClick = onSeeAllClick.takeIf { themes.isNotEmpty() }
+        )
+        Spacer(Modifier.height(dimensionResource(R.dimen.spacing_normal)))
+
+        when {
+            themes.isNotEmpty() -> LazyRow(
+                contentPadding = PaddingValues(horizontal = horizontal),
+                horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.spacing_normal))
+            ) {
+                items(themes, key = { it.id }) { theme ->
+                    ThemeTile(
+                        theme = theme,
+                        coverUrl = coverUrl,
+                        totalEpisodes = totalEpisodes,
+                        onClick = { onThemeClick(theme) }
+                    )
+                }
+            }
+
+            isLoading -> Row(
+                horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.spacing_normal)),
+                modifier = Modifier.padding(horizontal = horizontal)
+            ) {
+                repeat(2) { ThemeTileSkeleton() }
+            }
+
+            else -> ThemesErrorCard(
+                onRetryClick = onRetryClick,
+                modifier = Modifier.padding(horizontal = horizontal)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ThemesSectionHeader(
+    themes: List<MediaTheme>,
+    onSeeAllClick: (() -> Unit)?
+) {
+    val openings = themes.count { it.type == ThemeType.OP }
+    val endings = themes.count { it.type == ThemeType.ED }
+    val subtitle = when {
+        themes.isEmpty() -> null
+        else -> listOfNotNull(
+            pluralStringResource(R.plurals.themes_openings_count, openings, openings)
+                .takeIf { openings > 0 },
+            pluralStringResource(R.plurals.themes_endings_count, endings, endings)
+                .takeIf { endings > 0 }
+        ).joinToString("  ·  ")
+    }
+
+    com.anisync.android.presentation.components.SectionHeader(
+        title = stringResource(R.string.section_themes),
+        level = com.anisync.android.presentation.components.HeaderLevel.Section,
+        subtitle = subtitle,
+        onActionClick = onSeeAllClick
+    )
+}
+
+@Composable
+private fun ThemeTileSkeleton() {
+    val shimmer = MaterialTheme.colorScheme.surfaceContainerHigh
+    Column(modifier = Modifier.width(TILE_WIDTH)) {
+        Box(
+            modifier = Modifier
+                .width(TILE_WIDTH)
+                .height(TILE_ART_HEIGHT)
+                .clip(RoundedCornerShape(14.dp))
+                .background(shimmer)
+        )
+        Spacer(Modifier.height(10.dp))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(12.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .background(shimmer)
+        )
+        Spacer(Modifier.height(6.dp))
+        Box(
+            modifier = Modifier
+                .width(TILE_WIDTH * 0.55f)
+                .height(10.dp)
+                .clip(RoundedCornerShape(5.dp))
+                .background(shimmer)
+        )
+        Spacer(Modifier.height(10.dp))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(5.dp)
+                .clip(RoundedCornerShape(3.dp))
+                .background(shimmer)
+        )
+    }
+}
+
+@Composable
+private fun ThemesErrorCard(
+    onRetryClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = RoundedCornerShape(16.dp),
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(dimensionResource(R.dimen.spacing_medium))) {
+            Text(
+                text = stringResource(R.string.themes_failed_title),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = stringResource(R.string.themes_failed_body),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(dimensionResource(R.dimen.spacing_normal)))
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                shape = RoundedCornerShape(50),
+                modifier = Modifier
+                    .clip(RoundedCornerShape(50))
+                    .bouncyClickable(onClick = onRetryClick, clipShape = RoundedCornerShape(50))
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Refresh,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(Modifier.width(7.dp))
+                    Text(
+                        text = stringResource(R.string.themes_retry),
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** "Episodes 14–22, 24 · 2 versions", or the honest fallback when the range is missing. */
+@Composable
+fun themeCoverageLabel(theme: MediaTheme, spans: List<EpisodeSpan>): String {
+    val range = when {
+        spans.isEmpty() -> stringResource(R.string.themes_all_episodes)
+        else -> stringResource(R.string.themes_episodes, formatEpisodeSpans(spans))
+    }
+    val versions = theme.versions.size
+    return if (versions > 1) {
+        range + "  ·  " + pluralStringResource(R.plurals.themes_versions_count, versions, versions)
+    } else {
+        range
+    }
+}
+
+/** "13 of 24 episodes", shown in the sheet where a number is worth more than a shape. */
+@Composable
+fun themeCoverageCount(spans: List<EpisodeSpan>, totalEpisodes: Int?): String? {
+    if (spans.isEmpty() || totalEpisodes == null || totalEpisodes <= 0) return null
+    val covered = countCoveredEpisodes(spans, totalEpisodes)
+    return stringResource(R.string.themes_coverage, covered, totalEpisodes)
+}

--- a/app/src/main/java/com/anisync/android/presentation/details/components/MediaThemesComponents.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/components/MediaThemesComponents.kt
@@ -63,6 +63,9 @@ private val TILE_ART_HEIGHT = 90.dp
 private val ROW_ART_WIDTH = 104.dp
 private val ROW_ART_HEIGHT = 59.dp
 
+/** Keeps a long slug ("OP1-EN4Kids") inside the artwork instead of wrapping out of it. */
+private const val BADGE_MAX_WIDTH_FRACTION = 0.82f
+
 /**
  * Where a theme plays across a show's run.
  *
@@ -82,7 +85,12 @@ fun EpisodeCoverageBar(
     modifier: Modifier = Modifier,
     height: Dp = 6.dp,
     coveredColor: Color = MaterialTheme.colorScheme.primary,
-    trackColor: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.14f)
+    trackColor: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.14f),
+    /**
+     * Whether no spans means the theme plays over everything. True for an entry AnimeThemes never
+     * gave a range, false when the range is merely being withheld behind a spoiler tap.
+     */
+    emptyMeansAll: Boolean = true
 ) {
     val total = totalEpisodes ?: return
     if (total <= 0) return
@@ -95,7 +103,8 @@ fun EpisodeCoverageBar(
         val radius = CornerRadius(size.height / 2f, size.height / 2f)
 
         if (spans.isEmpty()) {
-            drawRoundRect(color = coveredColor.copy(alpha = 0.4f), cornerRadius = radius)
+            val fill = if (emptyMeansAll) coveredColor.copy(alpha = 0.4f) else trackColor
+            drawRoundRect(color = fill, cornerRadius = radius)
             return@Canvas
         }
 
@@ -218,12 +227,15 @@ private fun ThemeArtwork(
             modifier = Modifier
                 .align(Alignment.TopStart)
                 .padding(6.dp)
+                .fillMaxWidth(BADGE_MAX_WIDTH_FRACTION)
         ) {
             Text(
                 text = slug,
                 style = MaterialTheme.typography.labelSmall,
                 fontWeight = FontWeight.ExtraBold,
                 color = Color.White,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.padding(horizontal = 7.dp, vertical = 2.dp)
             )
         }
@@ -244,7 +256,7 @@ fun ThemeTile(
     val description = if (theme.isSpoiler || spans.isEmpty()) {
         theme.songTitle.orEmpty()
     } else {
-        stringResource(R.string.themes_episodes, coverageLabel)
+        pluralStringResource(R.plurals.themes_episodes, episodeQuantity(spans), coverageLabel)
     }
 
     // The ripple is rounded at the top to match the artwork and left square at the bottom, so
@@ -364,14 +376,20 @@ fun ThemeRow(
                             Text(
                                 text = stringResource(R.string.themes_spoiler_hidden),
                                 style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.weight(1f, fill = false)
                             )
                             Spacer(Modifier.width(8.dp))
+                            // Never wraps: a broken "Revea/l" reads as a rendering fault.
                             Text(
                                 text = stringResource(R.string.themes_spoiler_reveal),
                                 style = MaterialTheme.typography.bodySmall,
                                 fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.primary
+                                color = MaterialTheme.colorScheme.primary,
+                                maxLines = 1,
+                                softWrap = false
                             )
                         }
                     } else {
@@ -379,7 +397,7 @@ fun ThemeRow(
                             text = themeCoverageLabel(theme, spans),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.75f),
-                            maxLines = 1,
+                            maxLines = 2,
                             overflow = TextOverflow.Ellipsis
                         )
                     }
@@ -405,11 +423,7 @@ fun ThemeRow(
                 spans = if (hideEpisodes) emptyList() else spans,
                 totalEpisodes = totalEpisodes,
                 height = 6.dp,
-                coveredColor = if (hideEpisodes) {
-                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.14f)
-                } else {
-                    MaterialTheme.colorScheme.primary
-                }
+                emptyMeansAll = !hideEpisodes
             )
         }
     }
@@ -593,7 +607,11 @@ private fun ThemesErrorCard(
 fun themeCoverageLabel(theme: MediaTheme, spans: List<EpisodeSpan>): String {
     val range = when {
         spans.isEmpty() -> stringResource(R.string.themes_all_episodes)
-        else -> stringResource(R.string.themes_episodes, formatEpisodeSpans(spans))
+        else -> pluralStringResource(
+            R.plurals.themes_episodes,
+            episodeQuantity(spans),
+            formatEpisodeSpans(spans)
+        )
     }
     val versions = theme.versions.size
     return if (versions > 1) {
@@ -601,6 +619,12 @@ fun themeCoverageLabel(theme: MediaTheme, spans: List<EpisodeSpan>): String {
     } else {
         range
     }
+}
+
+/** 1 when the theme plays over a single episode, so the label can say "Episode" not "Episodes". */
+fun episodeQuantity(spans: List<EpisodeSpan>): Int {
+    val only = spans.singleOrNull() ?: return 2
+    return if (only.end == only.start) 1 else 2
 }
 
 /** "13 of 24 episodes", shown in the sheet where a number is worth more than a shape. */

--- a/app/src/main/java/com/anisync/android/presentation/details/components/MediaThemesComponents.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/components/MediaThemesComponents.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -62,8 +63,8 @@ private val TILE_ART_HEIGHT = 90.dp
 private val ROW_ART_WIDTH = 104.dp
 private val ROW_ART_HEIGHT = 59.dp
 
-/** Keeps a long slug ("OP1-EN4Kids") inside the artwork instead of wrapping out of it. */
-private const val BADGE_MAX_WIDTH_FRACTION = 0.82f
+/** Room left around a long slug ("OP1-EN4Kids") so it ellipsises inside the artwork. */
+private val BADGE_INSET = 16.dp
 
 /**
  * Where a theme plays across a show's run.
@@ -166,6 +167,7 @@ private fun ThemeArtwork(
     type: ThemeType,
     cornerRadius: Dp,
     playGlyphSize: Dp,
+    artWidth: Dp,
     modifier: Modifier = Modifier,
     /** False in the full list, where the row already carries a play button the glyph would sit under. */
     showPlayGlyph: Boolean = true
@@ -224,7 +226,8 @@ private fun ThemeArtwork(
             modifier = Modifier
                 .align(Alignment.TopStart)
                 .padding(6.dp)
-                .fillMaxWidth(BADGE_MAX_WIDTH_FRACTION)
+                // A cap, not a width: "OP1" stays tight and only a long slug is trimmed.
+                .widthIn(max = artWidth - BADGE_INSET)
         ) {
             Text(
                 text = slug,
@@ -272,6 +275,7 @@ fun ThemeTile(
             type = theme.type,
             cornerRadius = 14.dp,
             playGlyphSize = 30.dp,
+            artWidth = TILE_WIDTH,
             modifier = Modifier
                 .width(TILE_WIDTH)
                 .height(TILE_ART_HEIGHT)
@@ -331,6 +335,7 @@ fun ThemeRow(
                     type = theme.type,
                     cornerRadius = 10.dp,
                     playGlyphSize = 26.dp,
+                    artWidth = ROW_ART_WIDTH,
                     showPlayGlyph = false,
                     modifier = Modifier
                         .width(ROW_ART_WIDTH)

--- a/app/src/main/java/com/anisync/android/presentation/details/components/MediaThemesComponents.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/components/MediaThemesComponents.kt
@@ -27,7 +27,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -54,6 +58,7 @@ import com.anisync.android.domain.ThemeType
 import com.anisync.android.domain.countCoveredEpisodes
 import com.anisync.android.domain.formatEpisodeSpans
 import com.anisync.android.presentation.util.bouncyClickable
+import kotlinx.coroutines.delay
 
 /** Past this many episodes a per-episode mark is thinner than a hairline, so the bar draws spans. */
 private const val TICK_LIMIT = 50
@@ -410,6 +415,7 @@ fun MediaThemesSection(
     themes: List<MediaTheme>,
     isLoading: Boolean,
     errorMessage: String?,
+    retryAfterSeconds: Long? = null,
     coverUrl: String?,
     totalEpisodes: Int?,
     onSeeAllClick: () -> Unit,
@@ -451,6 +457,8 @@ fun MediaThemesSection(
             }
 
             else -> ThemesErrorCard(
+                message = errorMessage,
+                retryAfterSeconds = retryAfterSeconds,
                 onRetryClick = onRetryClick,
                 modifier = Modifier.padding(horizontal = horizontal)
             )
@@ -523,9 +531,22 @@ private fun ThemeTileSkeleton() {
 
 @Composable
 private fun ThemesErrorCard(
+    message: String?,
+    retryAfterSeconds: Long?,
     onRetryClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    // A rate limit is the one failure with a known end, so it counts down and holds the
+    // button rather than inviting a tap that will fail the same way.
+    var remaining by remember(retryAfterSeconds) { mutableLongStateOf(retryAfterSeconds ?: 0L) }
+    LaunchedEffect(retryAfterSeconds) {
+        while (remaining > 0) {
+            delay(1_000)
+            remaining -= 1
+        }
+    }
+    val waiting = remaining > 0
+
     Surface(
         color = MaterialTheme.colorScheme.surfaceContainer,
         shape = RoundedCornerShape(16.dp),
@@ -540,7 +561,7 @@ private fun ThemesErrorCard(
             )
             Spacer(Modifier.height(6.dp))
             Text(
-                text = stringResource(R.string.themes_failed_body),
+                text = message ?: stringResource(R.string.themes_failed_body),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -550,7 +571,13 @@ private fun ThemesErrorCard(
                 shape = RoundedCornerShape(50),
                 modifier = Modifier
                     .clip(RoundedCornerShape(50))
-                    .bouncyClickable(onClick = onRetryClick, clipShape = RoundedCornerShape(50))
+                    .then(
+                        if (waiting) Modifier
+                        else Modifier.bouncyClickable(
+                            onClick = onRetryClick,
+                            clipShape = RoundedCornerShape(50)
+                        )
+                    )
             ) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
@@ -564,7 +591,11 @@ private fun ThemesErrorCard(
                     )
                     Spacer(Modifier.width(7.dp))
                     Text(
-                        text = stringResource(R.string.themes_retry),
+                        text = if (waiting) {
+                            stringResource(R.string.themes_retry_in, remaining)
+                        } else {
+                            stringResource(R.string.themes_retry)
+                        },
                         style = MaterialTheme.typography.labelLarge,
                         color = MaterialTheme.colorScheme.primary
                     )

--- a/app/src/main/java/com/anisync/android/presentation/details/components/MediaThemesComponents.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/components/MediaThemesComponents.kt
@@ -615,7 +615,7 @@ fun SpoilerTag(modifier: Modifier = Modifier) {
             color = MaterialTheme.colorScheme.onErrorContainer,
             maxLines = 1,
             softWrap = false,
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp)
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
         )
     }
 }

--- a/app/src/main/java/com/anisync/android/presentation/details/components/ThemeSheet.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/components/ThemeSheet.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -138,20 +139,24 @@ fun ThemeSheet(
             } else {
                 SheetLabel(stringResource(R.string.themes_appears_in))
                 Spacer(Modifier.height(dimensionResource(R.dimen.spacing_small)))
-                EpisodeCoverageBar(
-                    spans = theme.episodeSpans,
-                    totalEpisodes = totalEpisodes,
-                    height = 10.dp
-                )
-                Spacer(Modifier.height(dimensionResource(R.dimen.spacing_small)))
+                // A show with no episode count on AniList gets no bar, so the slot goes with it.
+                if (totalEpisodes != null && totalEpisodes > 0) {
+                    EpisodeCoverageBar(
+                        spans = theme.episodeSpans,
+                        totalEpisodes = totalEpisodes,
+                        height = 10.dp
+                    )
+                    Spacer(Modifier.height(dimensionResource(R.dimen.spacing_small)))
+                }
                 val coverage = themeCoverageCount(theme.episodeSpans, totalEpisodes)
                 Text(
                     text = listOfNotNull(
                         if (theme.episodeSpans.isEmpty()) {
                             stringResource(R.string.themes_all_episodes)
                         } else {
-                            stringResource(
-                                R.string.themes_episodes,
+                            pluralStringResource(
+                                R.plurals.themes_episodes,
+                                episodeQuantity(theme.episodeSpans),
                                 formatEpisodeSpans(theme.episodeSpans)
                             )
                         },
@@ -215,27 +220,20 @@ fun ThemeSheet(
 
 @Composable
 private fun ThemeIdentity(theme: MediaTheme) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Surface(
-            color = MaterialTheme.colorScheme.primaryContainer,
-            shape = RoundedCornerShape(50)
-        ) {
-            Text(
-                text = theme.slug,
-                style = MaterialTheme.typography.labelMedium,
-                fontWeight = FontWeight.ExtraBold,
-                color = MaterialTheme.colorScheme.onPrimaryContainer,
-                modifier = Modifier.padding(horizontal = 9.dp, vertical = 3.dp)
-            )
+    Surface(
+        color = MaterialTheme.colorScheme.primaryContainer,
+        shape = RoundedCornerShape(50)
+    ) {
+        val name = when (theme.type) {
+            ThemeType.OP -> stringResource(R.string.themes_opening_number, theme.sequence ?: 1)
+            ThemeType.ED -> stringResource(R.string.themes_ending_number, theme.sequence ?: 1)
         }
-        Spacer(Modifier.width(dimensionResource(R.dimen.spacing_small)))
         Text(
-            text = when (theme.type) {
-                ThemeType.OP -> stringResource(R.string.themes_opening_number, theme.sequence ?: 1)
-                ThemeType.ED -> stringResource(R.string.themes_ending_number, theme.sequence ?: 1)
-            },
+            text = theme.qualifier?.let { "$name  ·  $it" } ?: name,
             style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            fontWeight = FontWeight.ExtraBold,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
         )
     }
     Spacer(Modifier.height(6.dp))
@@ -334,7 +332,11 @@ private fun VersionCard(
                         text = if (spans.isEmpty()) {
                             stringResource(R.string.themes_all_episodes)
                         } else {
-                            stringResource(R.string.themes_episodes, formatEpisodeSpans(spans))
+                            pluralStringResource(
+                                R.plurals.themes_episodes,
+                                episodeQuantity(spans),
+                                formatEpisodeSpans(spans)
+                            )
                         },
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/app/src/main/java/com/anisync/android/presentation/details/components/ThemeSheet.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/components/ThemeSheet.kt
@@ -23,7 +23,6 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Share
-import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme

--- a/app/src/main/java/com/anisync/android/presentation/details/components/ThemeSheet.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/components/ThemeSheet.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -83,13 +84,11 @@ fun ThemeSheet(
     val context = LocalContext.current
     var selectedVersionIndex by rememberSaveable(theme.id) { mutableIntStateOf(0) }
     var selectedVideoId by rememberSaveable(theme.id) { mutableStateOf<Int?>(null) }
-    var spoilerRevealed by rememberSaveable(theme.id) { mutableStateOf(false) }
 
     val version = theme.versions.getOrNull(selectedVersionIndex) ?: theme.versions.first()
     val video = remember(version, selectedVideoId) {
         version.videos.firstOrNull { it.id == selectedVideoId } ?: version.preferredVideo
     }
-    val hideEpisodes = theme.isSpoiler && !spoilerRevealed
 
     AppModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -118,9 +117,7 @@ fun ThemeSheet(
 
             Spacer(Modifier.height(dimensionResource(R.dimen.spacing_medium)))
 
-            if (hideEpisodes) {
-                SpoilerNotice(onReveal = { spoilerRevealed = true })
-            } else if (theme.versions.size > 1) {
+            if (theme.versions.size > 1) {
                 SheetLabel(stringResource(R.string.themes_versions))
                 Spacer(Modifier.height(dimensionResource(R.dimen.spacing_small)))
                 theme.versions.forEachIndexed { index, entry ->
@@ -225,23 +222,47 @@ fun ThemeSheet(
     }
 }
 
+private val ACTION_CHIP_HEIGHT = 40.dp
+
 @Composable
 private fun ThemeIdentity(theme: MediaTheme) {
-    Surface(
-        color = MaterialTheme.colorScheme.primaryContainer,
-        shape = RoundedCornerShape(50)
-    ) {
-        val name = when (theme.type) {
-            ThemeType.OP -> stringResource(R.string.themes_opening_number, theme.sequence ?: 1)
-            ThemeType.ED -> stringResource(R.string.themes_ending_number, theme.sequence ?: 1)
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Surface(
+            color = MaterialTheme.colorScheme.primaryContainer,
+            shape = RoundedCornerShape(50)
+        ) {
+            Text(
+                text = when (theme.type) {
+                    ThemeType.OP -> stringResource(R.string.themes_opening_number, theme.sequence ?: 1)
+                    ThemeType.ED -> stringResource(R.string.themes_ending_number, theme.sequence ?: 1)
+                },
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.ExtraBold,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+            )
         }
-        Text(
-            text = theme.qualifier?.let { "$name  ·  $it" } ?: name,
-            style = MaterialTheme.typography.labelMedium,
-            fontWeight = FontWeight.ExtraBold,
-            color = MaterialTheme.colorScheme.onPrimaryContainer,
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
-        )
+        // Only what the slug adds on top of the number, since the pill beside it already
+        // says "Ending 11". Without this, ED11 and ED11-EN would read identically.
+        theme.qualifier?.let { qualifier ->
+            Spacer(Modifier.width(dimensionResource(R.dimen.spacing_small)))
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                shape = RoundedCornerShape(50)
+            ) {
+                Text(
+                    text = qualifier,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.ExtraBold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+                )
+            }
+        }
+        if (theme.isSpoiler) {
+            Spacer(Modifier.width(dimensionResource(R.dimen.spacing_small)))
+            SpoilerTag()
+        }
     }
     Spacer(Modifier.height(6.dp))
     Text(
@@ -267,43 +288,6 @@ private fun SheetLabel(text: String) {
         style = MaterialTheme.typography.labelLarge,
         color = MaterialTheme.colorScheme.onSurfaceVariant
     )
-}
-
-@Composable
-private fun SpoilerNotice(onReveal: () -> Unit) {
-    Surface(
-        color = MaterialTheme.colorScheme.surfaceContainer,
-        shape = RoundedCornerShape(16.dp),
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(16.dp))
-            .bouncyClickable(onClick = onReveal, clipShape = RoundedCornerShape(16.dp))
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(dimensionResource(R.dimen.spacing_medium))
-        ) {
-            Icon(
-                imageVector = Icons.Default.VisibilityOff,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(18.dp)
-            )
-            Spacer(Modifier.width(dimensionResource(R.dimen.spacing_normal)))
-            Text(
-                text = stringResource(R.string.themes_spoiler_hidden),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.weight(1f)
-            )
-            Text(
-                text = stringResource(R.string.themes_spoiler_reveal),
-                style = MaterialTheme.typography.labelLarge,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.primary
-            )
-        }
-    }
 }
 
 @Composable
@@ -444,12 +428,17 @@ private fun ActionChip(
         color = MaterialTheme.colorScheme.surfaceContainer,
         shape = RoundedCornerShape(50),
         modifier = Modifier
+            // Fixed height so the icon-only chip matches the labelled ones instead of
+            // sitting short and looking lifted.
+            .height(ACTION_CHIP_HEIGHT)
             .clip(RoundedCornerShape(50))
             .bouncyClickable(onClick = onClick, clipShape = RoundedCornerShape(50))
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(horizontal = 14.dp, vertical = 9.dp)
+            modifier = Modifier
+                .fillMaxHeight()
+                .padding(horizontal = 14.dp)
         ) {
             Icon(
                 imageVector = icon,
@@ -462,7 +451,9 @@ private fun ActionChip(
                 Text(
                     text = label,
                     style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    softWrap = false
                 )
             }
         }

--- a/app/src/main/java/com/anisync/android/presentation/details/components/ThemeSheet.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/components/ThemeSheet.kt
@@ -2,6 +2,7 @@ package com.anisync.android.presentation.details.components
 
 import android.content.Intent
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -171,7 +172,10 @@ fun ThemeSheet(
                 Spacer(Modifier.height(dimensionResource(R.dimen.spacing_medium)))
                 SheetLabel(stringResource(R.string.themes_video))
                 Spacer(Modifier.height(dimensionResource(R.dimen.spacing_small)))
-                Row(horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.spacing_small))) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.spacing_small)),
+                    modifier = Modifier.horizontalScroll(rememberScrollState())
+                ) {
                     version.videos.forEach { candidate ->
                         VariantChip(
                             video = candidate,
@@ -184,7 +188,10 @@ fun ThemeSheet(
 
             Spacer(Modifier.height(dimensionResource(R.dimen.spacing_medium)))
 
-            Row(horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.spacing_small))) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.spacing_small)),
+                modifier = Modifier.horizontalScroll(rememberScrollState())
+            ) {
                 ActionChip(
                     icon = Icons.Default.Search,
                     label = stringResource(R.string.themes_action_youtube),

--- a/app/src/main/java/com/anisync/android/presentation/details/components/ThemeSheet.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/components/ThemeSheet.kt
@@ -1,0 +1,487 @@
+package com.anisync.android.presentation.details.components
+
+import android.content.Intent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.anisync.android.R
+import com.anisync.android.domain.MediaTheme
+import com.anisync.android.domain.ThemeType
+import com.anisync.android.domain.ThemeVersion
+import com.anisync.android.domain.ThemeVideo
+import com.anisync.android.domain.formatEpisodeSpans
+import com.anisync.android.presentation.components.AppModalBottomSheet
+import com.anisync.android.presentation.components.VideoPlayer
+import com.anisync.android.presentation.util.bouncyClickable
+import java.net.URLEncoder
+
+/**
+ * One theme, expanded.
+ *
+ * The video plays here rather than handing off to a browser, because AnimeThemes serves the
+ * file itself and the app already carries a player for it. Sound is on from the start, which
+ * is the one place in the app where that is the right default: the user tapped a song.
+ *
+ * A theme with more than one version lists them apart, each with its own episode range and
+ * its own videos, since that is the shape of the data and the thing the collapsed row cannot
+ * show.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ThemeSheet(
+    theme: MediaTheme,
+    totalEpisodes: Int?,
+    animeSlug: String?,
+    onDismiss: () -> Unit,
+    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+) {
+    val context = LocalContext.current
+    var selectedVersionIndex by rememberSaveable(theme.id) { mutableIntStateOf(0) }
+    var selectedVideoId by rememberSaveable(theme.id) { mutableStateOf<Int?>(null) }
+    var spoilerRevealed by rememberSaveable(theme.id) { mutableStateOf(false) }
+
+    val version = theme.versions.getOrNull(selectedVersionIndex) ?: theme.versions.first()
+    val video = remember(version, selectedVideoId) {
+        version.videos.firstOrNull { it.id == selectedVideoId } ?: version.preferredVideo
+    }
+    val hideEpisodes = theme.isSpoiler && !spoilerRevealed
+
+    AppModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = dimensionResource(R.dimen.spacing_large))
+                .padding(bottom = dimensionResource(R.dimen.spacing_large))
+        ) {
+            if (video != null) {
+                VideoPlayer(
+                    url = video.url,
+                    playerCache = null,
+                    startMuted = false,
+                    loop = false,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(Modifier.height(dimensionResource(R.dimen.spacing_medium)))
+            }
+
+            ThemeIdentity(theme = theme)
+
+            Spacer(Modifier.height(dimensionResource(R.dimen.spacing_medium)))
+
+            if (hideEpisodes) {
+                SpoilerNotice(onReveal = { spoilerRevealed = true })
+            } else if (theme.versions.size > 1) {
+                SheetLabel(stringResource(R.string.themes_versions))
+                Spacer(Modifier.height(dimensionResource(R.dimen.spacing_small)))
+                theme.versions.forEachIndexed { index, entry ->
+                    VersionCard(
+                        version = entry,
+                        totalEpisodes = totalEpisodes,
+                        isSelected = index == selectedVersionIndex,
+                        onClick = {
+                            selectedVersionIndex = index
+                            selectedVideoId = null
+                        }
+                    )
+                    if (index != theme.versions.lastIndex) {
+                        Spacer(Modifier.height(dimensionResource(R.dimen.spacing_small)))
+                    }
+                }
+            } else {
+                SheetLabel(stringResource(R.string.themes_appears_in))
+                Spacer(Modifier.height(dimensionResource(R.dimen.spacing_small)))
+                EpisodeCoverageBar(
+                    spans = theme.episodeSpans,
+                    totalEpisodes = totalEpisodes,
+                    height = 10.dp
+                )
+                Spacer(Modifier.height(dimensionResource(R.dimen.spacing_small)))
+                val coverage = themeCoverageCount(theme.episodeSpans, totalEpisodes)
+                Text(
+                    text = listOfNotNull(
+                        if (theme.episodeSpans.isEmpty()) {
+                            stringResource(R.string.themes_all_episodes)
+                        } else {
+                            stringResource(
+                                R.string.themes_episodes,
+                                formatEpisodeSpans(theme.episodeSpans)
+                            )
+                        },
+                        coverage
+                    ).joinToString("  ·  "),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            if (version.videos.size > 1) {
+                Spacer(Modifier.height(dimensionResource(R.dimen.spacing_medium)))
+                SheetLabel(stringResource(R.string.themes_video))
+                Spacer(Modifier.height(dimensionResource(R.dimen.spacing_small)))
+                Row(horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.spacing_small))) {
+                    version.videos.forEach { candidate ->
+                        VariantChip(
+                            video = candidate,
+                            isSelected = candidate.id == video?.id,
+                            onClick = { selectedVideoId = candidate.id }
+                        )
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(dimensionResource(R.dimen.spacing_medium)))
+
+            Row(horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.spacing_small))) {
+                ActionChip(
+                    icon = Icons.Default.Search,
+                    label = stringResource(R.string.themes_action_youtube),
+                    onClick = { context.openUrl(youtubeSearchUrl(theme)) }
+                )
+                ActionChip(
+                    icon = Icons.Default.Public,
+                    label = stringResource(R.string.themes_action_animethemes),
+                    onClick = { context.openUrl(animeThemesUrl(animeSlug, theme, video)) }
+                )
+                ActionChip(
+                    icon = Icons.Default.Share,
+                    label = null,
+                    onClick = {
+                        val text = listOfNotNull(theme.songTitle, theme.artists.firstOrNull())
+                            .joinToString(" by ")
+                        context.shareText(
+                            "$text\n${animeThemesUrl(animeSlug, theme, video)}"
+                        )
+                    }
+                )
+            }
+
+            Spacer(Modifier.height(dimensionResource(R.dimen.spacing_normal)))
+            Text(
+                text = stringResource(R.string.themes_attribution),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ThemeIdentity(theme: MediaTheme) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Surface(
+            color = MaterialTheme.colorScheme.primaryContainer,
+            shape = RoundedCornerShape(50)
+        ) {
+            Text(
+                text = theme.slug,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.ExtraBold,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.padding(horizontal = 9.dp, vertical = 3.dp)
+            )
+        }
+        Spacer(Modifier.width(dimensionResource(R.dimen.spacing_small)))
+        Text(
+            text = when (theme.type) {
+                ThemeType.OP -> stringResource(R.string.themes_opening_number, theme.sequence ?: 1)
+                ThemeType.ED -> stringResource(R.string.themes_ending_number, theme.sequence ?: 1)
+            },
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+    Spacer(Modifier.height(6.dp))
+    Text(
+        text = theme.songTitle ?: theme.slug,
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.ExtraBold,
+        color = MaterialTheme.colorScheme.onSurface
+    )
+    if (theme.artists.isNotEmpty()) {
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = theme.artists.joinToString(", "),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun SheetLabel(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
+}
+
+@Composable
+private fun SpoilerNotice(onReveal: () -> Unit) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = RoundedCornerShape(16.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .bouncyClickable(onClick = onReveal, clipShape = RoundedCornerShape(16.dp))
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(dimensionResource(R.dimen.spacing_medium))
+        ) {
+            Icon(
+                imageVector = Icons.Default.VisibilityOff,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(Modifier.width(dimensionResource(R.dimen.spacing_normal)))
+            Text(
+                text = stringResource(R.string.themes_spoiler_hidden),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.weight(1f)
+            )
+            Text(
+                text = stringResource(R.string.themes_spoiler_reveal),
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+    }
+}
+
+@Composable
+private fun VersionCard(
+    version: ThemeVersion,
+    totalEpisodes: Int?,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    val spans = version.episodeSpans
+    Surface(
+        color = if (isSelected) {
+            MaterialTheme.colorScheme.secondaryContainer
+        } else {
+            MaterialTheme.colorScheme.surfaceContainer
+        },
+        shape = RoundedCornerShape(14.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .bouncyClickable(onClick = onClick, clipShape = RoundedCornerShape(14.dp))
+    ) {
+        Column(modifier = Modifier.padding(dimensionResource(R.dimen.spacing_normal))) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.themes_version_label, version.version),
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Text(
+                        text = if (spans.isEmpty()) {
+                            stringResource(R.string.themes_all_episodes)
+                        } else {
+                            stringResource(R.string.themes_episodes, formatEpisodeSpans(spans))
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                Spacer(Modifier.width(dimensionResource(R.dimen.spacing_normal)))
+                Box(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clip(CircleShape)
+                        .background(
+                            if (isSelected) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.surfaceContainerHighest
+                            }
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.PlayArrow,
+                        contentDescription = null,
+                        tint = if (isSelected) {
+                            MaterialTheme.colorScheme.onPrimary
+                        } else {
+                            MaterialTheme.colorScheme.primary
+                        },
+                        modifier = Modifier.size(16.dp)
+                    )
+                }
+            }
+            Spacer(Modifier.height(dimensionResource(R.dimen.spacing_small)))
+            EpisodeCoverageBar(
+                spans = spans,
+                totalEpisodes = totalEpisodes,
+                height = 5.dp,
+                coveredColor = if (isSelected) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.primary.copy(alpha = 0.55f)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun VariantChip(
+    video: ThemeVideo,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    val parts = buildList {
+        add(
+            stringResource(
+                if (video.creditless) R.string.themes_variant_creditless
+                else R.string.themes_variant_with_credits
+            )
+        )
+        video.resolution?.let { add("${it}p") }
+        if (video.subbed) add(stringResource(R.string.themes_variant_subbed))
+        if (video.lyrics) add(stringResource(R.string.themes_variant_lyrics))
+    }
+
+    Surface(
+        color = if (isSelected) {
+            MaterialTheme.colorScheme.secondaryContainer
+        } else {
+            MaterialTheme.colorScheme.surfaceContainer
+        },
+        shape = RoundedCornerShape(50),
+        modifier = Modifier
+            .clip(RoundedCornerShape(50))
+            .bouncyClickable(onClick = onClick, clipShape = RoundedCornerShape(50))
+    ) {
+        Text(
+            text = parts.joinToString(" · "),
+            style = MaterialTheme.typography.labelLarge,
+            color = if (isSelected) {
+                MaterialTheme.colorScheme.onSecondaryContainer
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
+            modifier = Modifier.padding(horizontal = 13.dp, vertical = 8.dp)
+        )
+    }
+}
+
+@Composable
+private fun ActionChip(
+    icon: ImageVector,
+    label: String?,
+    onClick: () -> Unit
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = RoundedCornerShape(50),
+        modifier = Modifier
+            .clip(RoundedCornerShape(50))
+            .bouncyClickable(onClick = onClick, clipShape = RoundedCornerShape(50))
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 9.dp)
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = label,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(16.dp)
+            )
+            if (label != null) {
+                Spacer(Modifier.width(7.dp))
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+private fun youtubeSearchUrl(theme: MediaTheme): String {
+    val query = listOfNotNull(theme.songTitle, theme.artists.firstOrNull()).joinToString(" ")
+    return "https://www.youtube.com/results?search_query=" +
+        URLEncoder.encode(query.ifBlank { theme.slug }, "UTF-8")
+}
+
+private fun animeThemesUrl(animeSlug: String?, theme: MediaTheme, video: ThemeVideo?): String = when {
+    animeSlug != null -> "https://animethemes.moe/anime/$animeSlug/${theme.slug}"
+    video != null -> "https://animethemes.moe/video/${video.url.substringAfterLast('/')}"
+    else -> "https://animethemes.moe"
+}
+
+private fun android.content.Context.openUrl(url: String) {
+    runCatching {
+        startActivity(Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url)))
+    }
+}
+
+private fun android.content.Context.shareText(text: String) {
+    val intent = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_TEXT, text)
+    }
+    runCatching { startActivity(Intent.createChooser(intent, null)) }
+}

--- a/app/src/main/java/com/anisync/android/presentation/navigation/NavHost.kt
+++ b/app/src/main/java/com/anisync/android/presentation/navigation/NavHost.kt
@@ -31,6 +31,7 @@ import com.anisync.android.presentation.details.CharacterMediaGridScreen
 import com.anisync.android.presentation.details.MediaDetailsScreen
 import com.anisync.android.presentation.details.MediaRecommendationsGridScreen
 import com.anisync.android.presentation.details.MediaRelationsGridScreen
+import com.anisync.android.presentation.details.MediaThemesScreen
 import com.anisync.android.presentation.details.StaffDetailsScreen
 import com.anisync.android.presentation.details.StaffMediaGridScreen
 import com.anisync.android.presentation.details.StaffProductionMediaGridScreen
@@ -574,6 +575,9 @@ fun AniSyncNavHost(
                     onRecommendationsSeeAllClick = { mediaId, mediaTitle ->
                         navController.navigate(MediaRecommendationsGrid(mediaId, mediaTitle))
                     },
+                    onThemesSeeAllClick = { mediaId, mediaTitle ->
+                        navController.navigate(MediaThemes(mediaId, mediaTitle))
+                    },
                     onWriteReviewClick = { mediaId, mediaTitle ->
                         navController.navigate(WriteReview(mediaId, mediaTitle))
                     },
@@ -909,6 +913,22 @@ fun AniSyncNavHost(
                     },
                     sharedTransitionScope = this@SharedTransitionLayout,
                     animatedVisibilityScope = this
+                )
+            }
+
+            // =================================================================
+            // MEDIA THEMES (OPENINGS & ENDINGS) - Shared Axis Z (Depth)
+            // =================================================================
+            composable<MediaThemes>(
+                enterTransition = { sharedAxisZEnter() },
+                exitTransition = { sharedAxisZExit() },
+                popEnterTransition = { sharedAxisZPopEnter() },
+                popExitTransition = { sharedAxisZPopExit() }
+            ) { backStackEntry ->
+                val route: MediaThemes = backStackEntry.toRoute()
+                MediaThemesScreen(
+                    mediaTitle = route.mediaTitle,
+                    onBackClick = { navController.popBackStack() }
                 )
             }
 

--- a/app/src/main/java/com/anisync/android/presentation/navigation/NavHost.kt
+++ b/app/src/main/java/com/anisync/android/presentation/navigation/NavHost.kt
@@ -575,8 +575,8 @@ fun AniSyncNavHost(
                     onRecommendationsSeeAllClick = { mediaId, mediaTitle ->
                         navController.navigate(MediaRecommendationsGrid(mediaId, mediaTitle))
                     },
-                    onThemesSeeAllClick = { mediaId, mediaTitle ->
-                        navController.navigate(MediaThemes(mediaId, mediaTitle))
+                    onThemesSeeAllClick = { mediaId, mediaTitle, totalEpisodes, coverUrl ->
+                        navController.navigate(MediaThemes(mediaId, mediaTitle, totalEpisodes, coverUrl))
                     },
                     onWriteReviewClick = { mediaId, mediaTitle ->
                         navController.navigate(WriteReview(mediaId, mediaTitle))
@@ -928,6 +928,8 @@ fun AniSyncNavHost(
                 val route: MediaThemes = backStackEntry.toRoute()
                 MediaThemesScreen(
                     mediaTitle = route.mediaTitle,
+                    totalEpisodes = route.totalEpisodes,
+                    coverUrl = route.coverUrl,
                     onBackClick = { navController.popBackStack() }
                 )
             }

--- a/app/src/main/java/com/anisync/android/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/navigation/Screen.kt
@@ -144,7 +144,9 @@ data class CharacterMediaGrid(
 @Serializable
 data class MediaThemes(
     val mediaId: Int,
-    val mediaTitle: String
+    val mediaTitle: String,
+    val totalEpisodes: Int? = null,
+    val coverUrl: String? = null
 )
 
 /**

--- a/app/src/main/java/com/anisync/android/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/navigation/Screen.kt
@@ -136,6 +136,18 @@ data class CharacterMediaGrid(
 )
 
 /**
+ * Full list of a title's openings and endings, opened from the section arrow on the
+ * media details page.
+ * @param mediaId The ID of the media
+ * @param mediaTitle The title of the media (for display under the app bar)
+ */
+@Serializable
+data class MediaThemes(
+    val mediaId: Int,
+    val mediaTitle: String
+)
+
+/**
  * Grid screen for displaying all recommendations for a media.
  * @param mediaId The ID of the media
  * @param mediaTitle The title of the media (for display in app bar)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -700,7 +700,10 @@
     <string name="themes_filter_all">All</string>
     <string name="themes_group_openings">Openings</string>
     <string name="themes_group_endings">Endings</string>
-    <string name="themes_episodes">Episodes %1$s</string>
+    <plurals name="themes_episodes">
+        <item quantity="one">Episode %1$s</item>
+        <item quantity="other">Episodes %1$s</item>
+    </plurals>
     <string name="themes_all_episodes">All episodes</string>
     <string name="themes_coverage">%1$d of %2$d episodes</string>
     <string name="themes_episode_scale">Ep 1 – %1$d</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -683,6 +683,14 @@
     <string name="subsection_reading">Read On</string>
     <string name="subsection_external">External Links</string>
 
+    <!-- Video playback errors -->
+    <string name="player_error_network">No connection. Check your network and try again.</string>
+    <string name="player_error_server">The video host is having trouble right now. Try again in a moment.</string>
+    <string name="player_error_rate_limited">The video host is refusing requests. Wait a moment and try again.</string>
+    <string name="player_error_missing">This video is no longer on the host.</string>
+    <string name="player_error_format">This video format is not supported.</string>
+    <string name="player_error_generic">Unable to play this video.</string>
+
     <!-- Openings &amp; Endings (AnimeThemes) -->
     <string name="section_themes">Openings &amp; Endings</string>
     <plurals name="themes_openings_count">
@@ -714,6 +722,7 @@
     <string name="themes_failed_title">Themes did not load</string>
     <string name="themes_failed_body">AniList data on this page is unaffected. Only the AnimeThemes request failed.</string>
     <string name="themes_retry">Retry</string>
+    <string name="themes_retry_in">Retry in %1$ds</string>
     <string name="themes_empty">AnimeThemes does not list this title yet.</string>
     <string name="themes_video">Video</string>
     <string name="themes_appears_in">Appears in</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -685,7 +685,6 @@
 
     <!-- Openings &amp; Endings (AnimeThemes) -->
     <string name="section_themes">Openings &amp; Endings</string>
-    <string name="themes_screen_subtitle">%1$s</string>
     <plurals name="themes_openings_count">
         <item quantity="one">%d opening</item>
         <item quantity="other">%d openings</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -709,8 +709,8 @@
     <string name="themes_episode_scale">Ep 1 – %1$d</string>
     <string name="themes_opening_number">Opening %1$d</string>
     <string name="themes_ending_number">Ending %1$d</string>
-    <string name="themes_spoiler_hidden">Episodes hidden</string>
-    <string name="themes_spoiler_reveal">Reveal</string>
+    <string name="themes_spoiler_tag">Spoiler</string>
+    <string name="cd_theme_spoiler">This theme may spoil the show</string>
     <string name="themes_failed_title">Themes did not load</string>
     <string name="themes_failed_body">AniList data on this page is unaffected. Only the AnimeThemes request failed.</string>
     <string name="themes_retry">Retry</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -683,6 +683,52 @@
     <string name="subsection_reading">Read On</string>
     <string name="subsection_external">External Links</string>
 
+    <!-- Openings &amp; Endings (AnimeThemes) -->
+    <string name="section_themes">Openings &amp; Endings</string>
+    <string name="themes_screen_subtitle">%1$s</string>
+    <plurals name="themes_openings_count">
+        <item quantity="one">%d opening</item>
+        <item quantity="other">%d openings</item>
+    </plurals>
+    <plurals name="themes_endings_count">
+        <item quantity="one">%d ending</item>
+        <item quantity="other">%d endings</item>
+    </plurals>
+    <plurals name="themes_versions_count">
+        <item quantity="one">%d version</item>
+        <item quantity="other">%d versions</item>
+    </plurals>
+    <string name="themes_filter_all">All</string>
+    <string name="themes_group_openings">Openings</string>
+    <string name="themes_group_endings">Endings</string>
+    <string name="themes_episodes">Episodes %1$s</string>
+    <string name="themes_all_episodes">All episodes</string>
+    <string name="themes_coverage">%1$d of %2$d episodes</string>
+    <string name="themes_episode_scale">Ep 1 – %1$d</string>
+    <string name="themes_opening_number">Opening %1$d</string>
+    <string name="themes_ending_number">Ending %1$d</string>
+    <string name="themes_spoiler_hidden">Episodes hidden</string>
+    <string name="themes_spoiler_reveal">Reveal</string>
+    <string name="themes_failed_title">Themes did not load</string>
+    <string name="themes_failed_body">AniList data on this page is unaffected. Only the AnimeThemes request failed.</string>
+    <string name="themes_retry">Retry</string>
+    <string name="themes_empty">AnimeThemes does not list this title yet.</string>
+    <string name="themes_video">Video</string>
+    <string name="themes_appears_in">Appears in</string>
+    <string name="themes_versions">Versions</string>
+    <string name="themes_version_label">Version %1$d</string>
+    <string name="themes_variant_creditless">Creditless</string>
+    <string name="themes_variant_with_credits">With credits</string>
+    <string name="themes_variant_subbed">Subbed</string>
+    <string name="themes_variant_lyrics">Lyrics</string>
+    <string name="themes_open_source">Open on AnimeThemes</string>
+    <string name="themes_attribution">Theme data and video from AnimeThemes.moe</string>
+    <string name="themes_action_youtube">YouTube</string>
+    <string name="themes_action_animethemes">AnimeThemes</string>
+    <string name="themes_action_share">Share</string>
+    <string name="themes_share_subject">%1$s by %2$s</string>
+    <string name="cd_theme_play">Play %1$s</string>
+
     <!-- Edit Library Entry -->
     <string name="edit_entry">Edit Entry</string>
     <string name="no_score">No Score</string>

--- a/app/src/test/java/com/anisync/android/domain/EpisodeSpanTest.kt
+++ b/app/src/test/java/com/anisync/android/domain/EpisodeSpanTest.kt
@@ -1,0 +1,140 @@
+package com.anisync.android.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Locks the reading of AnimeThemes' `episodes` field, which is free text rather than numbers.
+ * Every shape here came off the live API: plain ranges, comma-separated lists with holes in
+ * them, single episodes, open ranges written with a trailing dash, and the null the API sends
+ * for films and for entries nobody has filled in.
+ */
+class EpisodeSpanTest {
+
+    @Test
+    fun `a plain range parses to one span`() {
+        assertEquals(listOf(EpisodeSpan(1, 13)), parseEpisodeSpans("1-13"))
+    }
+
+    @Test
+    fun `a list keeps the hole between its parts`() {
+        val spans = parseEpisodeSpans("20-22, 24")
+        assertEquals(listOf(EpisodeSpan(20, 22), EpisodeSpan(24, 24)), spans)
+        assertTrue(spans.none { it.contains(23) })
+        assertTrue(spans.any { it.contains(24) })
+    }
+
+    @Test
+    fun `a single episode is a span of one`() {
+        assertEquals(listOf(EpisodeSpan(5, 5)), parseEpisodeSpans("5"))
+    }
+
+    @Test
+    fun `a trailing dash leaves the range open`() {
+        val spans = parseEpisodeSpans("13-")
+        assertEquals(listOf(EpisodeSpan(13, null)), spans)
+        assertTrue(spans.single().isOpen)
+        assertTrue(spans.single().contains(999))
+    }
+
+    @Test
+    fun `missing episode data reads as no spans rather than episode zero`() {
+        assertEquals(emptyList<EpisodeSpan>(), parseEpisodeSpans(null))
+        assertEquals(emptyList<EpisodeSpan>(), parseEpisodeSpans(""))
+        assertEquals(emptyList<EpisodeSpan>(), parseEpisodeSpans("None"))
+    }
+
+    @Test
+    fun `unparseable parts are dropped instead of guessed at`() {
+        assertEquals(listOf(EpisodeSpan(3, 4)), parseEpisodeSpans("3-4, ova, 9-2"))
+    }
+
+    @Test
+    fun `touching ranges merge so a bar never draws an episode twice`() {
+        assertEquals(
+            listOf(EpisodeSpan(1, 12)),
+            mergeEpisodeSpans(listOf(EpisodeSpan(1, 8), EpisodeSpan(9, 12)))
+        )
+        assertEquals(
+            listOf(EpisodeSpan(1, 8), EpisodeSpan(10, 12)),
+            mergeEpisodeSpans(listOf(EpisodeSpan(10, 12), EpisodeSpan(1, 8)))
+        )
+    }
+
+    @Test
+    fun `formatting matches the way the API writes a range`() {
+        assertEquals("1–13", formatEpisodeSpans(parseEpisodeSpans("1-13")))
+        assertEquals("14–22, 24", formatEpisodeSpans(parseEpisodeSpans("14-22, 24")))
+        assertEquals("5", formatEpisodeSpans(parseEpisodeSpans("5")))
+        assertEquals("13+", formatEpisodeSpans(parseEpisodeSpans("13-")))
+    }
+
+    @Test
+    fun `coverage counts episodes and closes an open range against the total`() {
+        assertEquals(13, countCoveredEpisodes(parseEpisodeSpans("1-13"), 24))
+        assertEquals(10, countCoveredEpisodes(parseEpisodeSpans("14-22, 24"), 24))
+        assertEquals(12, countCoveredEpisodes(parseEpisodeSpans("13-"), 24))
+        assertEquals(0, countCoveredEpisodes(parseEpisodeSpans("13-"), null))
+    }
+
+    @Test
+    fun `a theme merges the ranges of all of its versions`() {
+        val theme = MediaTheme(
+            id = 1,
+            type = ThemeType.ED,
+            sequence = 2,
+            slug = "ED2",
+            songTitle = "Kirakira no Hai",
+            artists = listOf("Regal Lily"),
+            versions = listOf(
+                version(id = 1, episodes = "14-19"),
+                version(id = 2, episodes = "20-22, 24")
+            )
+        )
+
+        assertEquals(
+            listOf(EpisodeSpan(14, 22), EpisodeSpan(24, 24)),
+            theme.episodeSpans
+        )
+        assertEquals("14–22, 24", formatEpisodeSpans(theme.episodeSpans))
+    }
+
+    @Test
+    fun `the preferred video is the creditless one at the highest resolution`() {
+        val entry = ThemeVersion(
+            id = 1,
+            version = 1,
+            rawEpisodes = "1-13",
+            notes = null,
+            spoiler = false,
+            nsfw = false,
+            videos = listOf(
+                video(id = 1, creditless = false, resolution = 720),
+                video(id = 2, creditless = true, resolution = 1080),
+                video(id = 3, creditless = true, resolution = 720)
+            )
+        )
+        assertEquals(2, entry.preferredVideo?.id)
+    }
+
+    private fun version(id: Int, episodes: String?) = ThemeVersion(
+        id = id,
+        version = id,
+        rawEpisodes = episodes,
+        notes = null,
+        spoiler = false,
+        nsfw = false,
+        videos = listOf(video(id = id, creditless = true, resolution = 1080))
+    )
+
+    private fun video(id: Int, creditless: Boolean, resolution: Int) = ThemeVideo(
+        id = id,
+        url = "https://v.animethemes.moe/Example-$id.webm",
+        resolution = resolution,
+        creditless = creditless,
+        subbed = false,
+        lyrics = false,
+        source = "BD"
+    )
+}

--- a/app/src/test/java/com/anisync/android/domain/EpisodeSpanTest.kt
+++ b/app/src/test/java/com/anisync/android/domain/EpisodeSpanTest.kt
@@ -146,6 +146,17 @@ class EpisodeSpanTest {
         assertEquals(2, entry.preferredVideo?.id)
     }
 
+    @Test
+    fun `an airing show measures coverage against the episodes that have aired`() {
+        // Bleach: finished, AniList gives the real total.
+        assertEquals(366, coverageEpisodeCount(episodes = 366, nextAiringEpisode = null))
+        // One Piece: still airing, so the total comes off the next episode number.
+        assertEquals(1174, coverageEpisodeCount(episodes = null, nextAiringEpisode = 1175))
+        // Nothing has aired yet, which is no scale rather than a scale of zero.
+        assertEquals(null, coverageEpisodeCount(episodes = null, nextAiringEpisode = 1))
+        assertEquals(null, coverageEpisodeCount(episodes = null, nextAiringEpisode = null))
+    }
+
     private fun theme(slug: String, type: ThemeType, sequence: Int) = MediaTheme(
         id = 1,
         type = type,

--- a/app/src/test/java/com/anisync/android/domain/EpisodeSpanTest.kt
+++ b/app/src/test/java/com/anisync/android/domain/EpisodeSpanTest.kt
@@ -118,6 +118,44 @@ class EpisodeSpanTest {
         assertEquals(2, entry.preferredVideo?.id)
     }
 
+    @Test
+    fun `a dub theme keeps the part of its slug the readable name drops`() {
+        val dub = theme(slug = "ED11-EN", type = ThemeType.ED, sequence = 11)
+        val original = theme(slug = "ED11", type = ThemeType.ED, sequence = 11)
+        val edit = theme(slug = "OP1-EN4Kids", type = ThemeType.OP, sequence = 1)
+
+        assertEquals("EN", dub.qualifier)
+        assertEquals(null, original.qualifier)
+        assertEquals("EN4Kids", edit.qualifier)
+    }
+
+    @Test
+    fun `a plain cut wins over a lyrics one when neither is creditless`() {
+        val entry = ThemeVersion(
+            id = 1,
+            version = 1,
+            rawEpisodes = "493-516",
+            notes = null,
+            spoiler = false,
+            nsfw = false,
+            videos = listOf(
+                video(id = 1, creditless = false, resolution = 720, lyrics = true),
+                video(id = 2, creditless = false, resolution = 720)
+            )
+        )
+        assertEquals(2, entry.preferredVideo?.id)
+    }
+
+    private fun theme(slug: String, type: ThemeType, sequence: Int) = MediaTheme(
+        id = 1,
+        type = type,
+        sequence = sequence,
+        slug = slug,
+        songTitle = "Song",
+        artists = emptyList(),
+        versions = listOf(version(id = 1, episodes = "1-2"))
+    )
+
     private fun version(id: Int, episodes: String?) = ThemeVersion(
         id = id,
         version = id,
@@ -128,13 +166,18 @@ class EpisodeSpanTest {
         videos = listOf(video(id = id, creditless = true, resolution = 1080))
     )
 
-    private fun video(id: Int, creditless: Boolean, resolution: Int) = ThemeVideo(
+    private fun video(
+        id: Int,
+        creditless: Boolean,
+        resolution: Int,
+        lyrics: Boolean = false
+    ) = ThemeVideo(
         id = id,
         url = "https://v.animethemes.moe/Example-$id.webm",
         resolution = resolution,
         creditless = creditless,
         subbed = false,
-        lyrics = false,
+        lyrics = lyrics,
         source = "BD"
     )
 }


### PR DESCRIPTION
Closes #108.

A title's openings and endings were nowhere in the app, so finding out what a song was
meant leaving for a browser. This adds them to the media page with the song, the artist
and where each one plays across the run, and plays the video in place.

### On the media page

The section sits under External and Streaming Links, anime only, and is left out entirely
when AnimeThemes does not list the title. It is a horizontal rail, so it costs the page
about 200dp whether a show has four themes or seventy, and the arrow in its header opens
the full list rather than growing the page.

Artwork is the show's own, dimmed and tinted green for an opening and warm for an ending.
AnimeThemes serves no still for a theme, and pulling a frame out of the video would mean
downloading tens of megabytes a row, so nothing extra is fetched to draw the section.

### The full list

Rows stacked so every episode bar starts at the same x against the same episode count,
which is the comparison a horizontal rail cannot give. A filter cuts thirty four openings
down to something readable, and each group states the scale its bars are drawn against.

### The episode bar

One picture of when a song belongs, from the show's episode count and the ranges
AnimeThemes records:

- Up to 50 episodes, one mark per episode, so a single skipped episode is visible.
- Past that the marks would be sub-pixel, so each range becomes one proportional span.
- A range still running fades out rather than claiming episodes that have not aired.
- An entry with no range at all is drawn at half strength and reads as All episodes.
- AniList leaves the episode total empty until a show ends, which would cost every long
  runner its bar, so an airing show is measured against how many episodes have aired.

### The sheet

Tapping a theme opens it over the page. The video plays inline through the player the app
already ships for forum embeds, so there is no second playback stack and no API key, and
it starts with sound because the user tapped a song. A theme that changed part way through
a run is listed as separate versions, each with its own range and its own videos, which is
the part a merged row cannot show. Video variants, creditless or not, disc or broadcast,
are chips that swap the source without closing the sheet.

### Spoilers, dubs and missing data

- A spoiler flag is a tag, not a cover. What spoils is the theme itself, its visuals and
  often its lyrics, so the episode range stays readable.
- One Piece lists OP1, OP1-EN and OP1-EN4Kids all as opening one, so the sheet keeps
  whatever the slug adds beyond the number.
- Themes are ordered openings first then endings. AnimeThemes returns them in the order
  they were added, which interleaves the two once a show gets a second cour.

### When something fails

AnimeThemes and the CDN that serves its video fail in ways that need different answers, so
the messages say which one happened and whether waiting will help.

- A playback failure now reads its HTTP status off the cause chain. Media3 reports a 503
  and a 404 under codes that look alike, and the two were being shown as the same
  permanent "no longer available", which is wrong for a host having a bad ten minutes.
- A rate limit counts down. The retry button holds until the wait AnimeThemes asked for
  has passed rather than inviting a tap that fails the same way.
- The section shows the reason it was given instead of one generic line, and an
  AnimeThemes failure leaves every AniList backed section on the page untouched.

The player's error state also scrolls now. It sits inside a box locked to the clip's
aspect ratio, so a two line message used to push the retry button out of frame and clip
it in half. That applies to forum video embeds too.

### Where the data comes from

- One lookup by AniList id, cached in Room at schema v24 and kept for a week. New table
  only, added by auto migration with its schema exported.
- An empty answer is stored too, so a title AnimeThemes does not carry stops being asked
  about on every visit.
- The lookup resolves after the page has already drawn, so a slow or missing answer costs
  the page nothing.
- Episode ranges are free text rather than numbers, so parsing them is covered by unit
  tests against the shapes the live API returns: open ranges, comma separated lists with
  holes in them, single episodes and missing data.
