### PR TITLE
fix(media): one poster radius, and even library grid cards

### DIFF
--- a/app/src/main/java/com/anisync/android/presentation/calendar/components/AiringEpisodeCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/calendar/components/AiringEpisodeCard.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.anisync.android.ui.theme.ExpressiveShapes
 import com.anisync.android.R
 import com.anisync.android.data.TitleLanguage
 import com.anisync.android.domain.AiringEpisode
@@ -103,7 +104,7 @@ fun AiringEpisodeCard(
                 modifier = Modifier
                     .width(58.dp)
                     .aspectRatio(0.7f)
-                    .clip(RoundedCornerShape(10.dp))
+                    .clip(ExpressiveShapes.mediaCover)
             )
 
             Spacer(Modifier.width(12.dp))

--- a/app/src/main/java/com/anisync/android/presentation/components/AniListLinkCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/components/AniListLinkCard.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
+import com.anisync.android.ui.theme.ExpressiveShapes
 import com.anisync.android.domain.LinkPreview
 import com.anisync.android.domain.parser.RichTextBlock
 import com.anisync.android.ui.theme.emphasis
@@ -51,7 +52,7 @@ private val MediaCoverHeight = 90.dp        // 2:3, matches AniList covers (no c
 private val ProfileCardWidth = 132.dp
 private val ProfileAvatarSize = 76.dp
 private val CardShape = RoundedCornerShape(12.dp)
-private val PosterShape = RoundedCornerShape(10.dp)
+private val PosterShape = ExpressiveShapes.mediaCover
 
 private fun typeColor(type: String): Color = when (type.lowercase()) {
     "anime" -> Color(0xFF3DB4F2)

--- a/app/src/main/java/com/anisync/android/presentation/components/LibraryMediaCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/components/LibraryMediaCard.kt
@@ -75,6 +75,10 @@ import com.anisync.android.presentation.util.rememberHapticFeedback
 import com.anisync.android.type.MediaType
 import com.anisync.android.util.getTitle
 
+/** One line of the badge/countdown row, and the gap between two of them. */
+private val BadgeRowHeight = 20.dp
+private val BadgeRowSpacing = 2.dp
+
 /**
  * Configuration for the LibraryMediaCard content display.
  */
@@ -317,14 +321,24 @@ fun LibraryMediaCard(
 
                     // Both stay on screen. They sit side by side while the card is wide enough and
                     // drop onto a second line when a many-column grid makes it too narrow, rather
-                    // than the badge clipping the countdown out of view. The min height keeps card
-                    // heights aligned across the grid when neither piece applies.
+                    // than the badge clipping the countdown out of view.
+                    //
+                    // Whichever list can show both reserves the second line on every card, even the
+                    // ones with nothing to say. A grid row is only as tall as its tallest card and
+                    // the rest sit top-aligned inside it, so reserving a single line would leave a
+                    // title with no airing date visibly shorter than the one beside it.
+                    val reservedRowHeight = if (config.showBehindBadge && config.showAiringInfo) {
+                        BadgeRowHeight * 2 + BadgeRowSpacing
+                    } else {
+                        BadgeRowHeight
+                    }
+
                     FlowRow(
                         itemVerticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                        verticalArrangement = Arrangement.spacedBy(BadgeRowSpacing),
                         maxLines = 2,
-                        modifier = Modifier.heightIn(min = 20.dp)
+                        modifier = Modifier.heightIn(min = reservedRowHeight)
                     ) {
                         if (behindText != null) {
                             StatusBadge(

--- a/app/src/main/java/com/anisync/android/presentation/components/MediaPosterCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/components/MediaPosterCard.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import coil.request.CachePolicy
 import coil.request.ImageRequest
+import com.anisync.android.ui.theme.ExpressiveShapes
 import com.anisync.android.R
 import com.anisync.android.data.TitleLanguage
 import com.anisync.android.domain.LibraryEntry
@@ -52,7 +53,7 @@ import java.util.Locale
 /** Poster aspect from the design: a 171dp card carries a 243dp cover. */
 private const val PosterAspect = 171f / 243f
 
-private val CoverShape = RoundedCornerShape(18.dp)
+private val CoverShape = ExpressiveShapes.mediaCover
 
 private val CoverToTextGap = 10.dp
 private val TitleToMetaGap = 10.dp

--- a/app/src/main/java/com/anisync/android/presentation/components/PosterCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/components/PosterCard.kt
@@ -1,5 +1,6 @@
 package com.anisync.android.presentation.components
 
+import com.anisync.android.ui.theme.ExpressiveShapes
 import com.anisync.android.domain.url
 
 import androidx.compose.animation.AnimatedVisibility
@@ -72,7 +73,7 @@ fun PosterCard(
     modifier: Modifier = Modifier,
     transitionPrefix: String = TransitionKeys.POSTER,
     aspectRatio: Float = 0.7f,
-    shape: Shape = RoundedCornerShape(12.dp)
+    shape: Shape = ExpressiveShapes.mediaCover
 ) {
     // Use memoized motion specs from AppMotion
     val spatialSpec = AppMotion.rememberSpatialSpec()

--- a/app/src/main/java/com/anisync/android/presentation/details/StudioDetailsScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/StudioDetailsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
+import com.anisync.android.ui.theme.ExpressiveShapes
 import com.anisync.android.presentation.util.LocalPaneIsRoot
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.Business
@@ -418,7 +419,7 @@ private fun StudioWorkItem(
     modifier: Modifier = Modifier
 ) {
     val cardShape = RoundedCornerShape(24.dp)
-    val coverShape = RoundedCornerShape(8.dp)
+    val coverShape = ExpressiveShapes.mediaCover
     val mainChipLabel = stringResource(R.string.studio_main_studio_chip)
     val listStatus = LocalLibraryStatuses.current[media.mediaId]
     // This card sets its own description, which replaces anything its children say, so the

--- a/app/src/main/java/com/anisync/android/presentation/details/components/CharacterDetailsComponents.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/components/CharacterDetailsComponents.kt
@@ -1,5 +1,6 @@
 package com.anisync.android.presentation.details.components
 
+import com.anisync.android.ui.theme.ExpressiveShapes
 import com.anisync.android.ui.theme.emphasis
 import com.anisync.android.domain.url
 
@@ -388,7 +389,7 @@ fun FeaturedMediaItem(
     animatedVisibilityScope: AnimatedVisibilityScope? = null,
     modifier: Modifier = Modifier
 ) {
-    val cardShape = RoundedCornerShape(16.dp)
+    val cardShape = ExpressiveShapes.mediaCover
     val spatialSpec = if (sharedTransitionScope != null) {
         AppMotion.rememberSpatialSpec()
     } else {

--- a/app/src/main/java/com/anisync/android/presentation/details/components/DetailItems.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/components/DetailItems.kt
@@ -1,5 +1,6 @@
 package com.anisync.android.presentation.details.components
 
+import com.anisync.android.ui.theme.ExpressiveShapes
 import com.anisync.android.ui.theme.emphasis
 import com.anisync.android.domain.url
 
@@ -93,7 +94,7 @@ fun CharacterItem(
     sharedTransitionScope: SharedTransitionScope? = null,
     animatedVisibilityScope: AnimatedVisibilityScope? = null
 ) {
-    val imageShape = RoundedCornerShape(dimensionResource(R.dimen.corner_radius_large))
+    val imageShape = ExpressiveShapes.mediaCover
     val copyToClipboard = rememberCopyToClipboard()
     val copyLabel = stringResource(R.string.a11y_action_copy)
     val nameClipLabel = stringResource(R.string.clip_label_character_name)
@@ -195,7 +196,7 @@ fun StaffItem(
     sharedTransitionScope: SharedTransitionScope? = null,
     animatedVisibilityScope: AnimatedVisibilityScope? = null
 ) {
-    val imageShape = RoundedCornerShape(dimensionResource(R.dimen.corner_radius_large))
+    val imageShape = ExpressiveShapes.mediaCover
     val copyToClipboard = rememberCopyToClipboard()
     val copyLabel = stringResource(R.string.a11y_action_copy)
     val nameClipLabel = stringResource(R.string.clip_label_staff_name)
@@ -365,7 +366,7 @@ fun RelationItem(
     sharedTransitionScope: SharedTransitionScope? = null,
     animatedVisibilityScope: AnimatedVisibilityScope? = null
 ) {
-    val imageShape = RoundedCornerShape(dimensionResource(R.dimen.corner_radius_large))
+    val imageShape = ExpressiveShapes.mediaCover
 
     val widthModifier = if (fillCell) {
         Modifier.fillMaxWidth()
@@ -451,7 +452,7 @@ fun RecommendationItem(
     modifier: Modifier = Modifier,
     fillCell: Boolean = false
 ) {
-    val imageShape = RoundedCornerShape(dimensionResource(R.dimen.corner_radius_large))
+    val imageShape = ExpressiveShapes.mediaCover
     val isUpvoted = recommendation.userRating == "RATE_UP"
     val isDownvoted = recommendation.userRating == "RATE_DOWN"
 

--- a/app/src/main/java/com/anisync/android/presentation/details/components/RecommendMediaSheet.kt
+++ b/app/src/main/java/com/anisync/android/presentation/details/components/RecommendMediaSheet.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
+import com.anisync.android.ui.theme.ExpressiveShapes
 import com.anisync.android.presentation.components.AppCircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -169,7 +170,7 @@ private fun RecommendResultRow(entry: LibraryEntry, onClick: () -> Unit) {
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
                     .size(width = 48.dp, height = 64.dp)
-                    .clip(RoundedCornerShape(8.dp))
+                    .clip(ExpressiveShapes.mediaCover)
             )
             Spacer(Modifier.width(12.dp))
             Column(modifier = Modifier.weight(1f)) {

--- a/app/src/main/java/com/anisync/android/presentation/discover/components/DiscoverHeroCarousel.kt
+++ b/app/src/main/java/com/anisync/android/presentation/discover/components/DiscoverHeroCarousel.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import coil.request.CachePolicy
 import coil.request.ImageRequest
+import com.anisync.android.ui.theme.ExpressiveShapes
 import com.anisync.android.data.TitleLanguage
 import com.anisync.android.domain.LibraryEntry
 import com.anisync.android.domain.LocalCoverQuality
@@ -192,7 +193,7 @@ private fun HeroCarouselItem(
     animatedVisibilityScope: AnimatedVisibilityScope,
     modifier: Modifier = Modifier
 ) {
-    val itemShape = MaterialTheme.shapes.extraLarge
+    val itemShape = ExpressiveShapes.mediaCover
     val spatialSpec = AppMotion.rememberSpatialSpec()
 
     // Section-scoped prefix: the same media often sits in the rows below too, and duplicate

--- a/app/src/main/java/com/anisync/android/presentation/discover/components/DiscoverLists.kt
+++ b/app/src/main/java/com/anisync/android/presentation/discover/components/DiscoverLists.kt
@@ -1,5 +1,6 @@
 package com.anisync.android.presentation.discover.components
 
+import com.anisync.android.ui.theme.ExpressiveShapes
 import com.anisync.android.domain.url
 
 import androidx.compose.animation.AnimatedVisibility
@@ -200,9 +201,8 @@ fun DiscoverMediaCard(
 ) {
     val cardShape = remember(style) {
         when (style) {
-            is CardStyle.Hero -> RoundedCornerShape(28.dp)
-            is CardStyle.Standard, is CardStyle.Grid -> RoundedCornerShape(24.dp)
-            is CardStyle.ListItem -> RoundedCornerShape(16.dp)
+            is CardStyle.Hero, is CardStyle.Standard, is CardStyle.Grid, is CardStyle.ListItem ->
+                ExpressiveShapes.mediaCover
         }
     }
 

--- a/app/src/main/java/com/anisync/android/presentation/discover/components/SearchResultPanels.kt
+++ b/app/src/main/java/com/anisync/android/presentation/discover/components/SearchResultPanels.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.anisync.android.ui.theme.ExpressiveShapes
 import com.anisync.android.R
 import com.anisync.android.data.DiscoverViewMode
 import com.anisync.android.data.TitleLanguage
@@ -500,7 +501,7 @@ private fun SearchGridCard(
                 modifier = Modifier
                     .fillMaxWidth()
                     .aspectRatio(imageAspect)
-                    .clip(RoundedCornerShape(16.dp))
+                    .clip(ExpressiveShapes.mediaCover)
                     .background(MaterialTheme.colorScheme.surfaceContainerHighest),
                 contentAlignment = Alignment.Center,
             ) {

--- a/app/src/main/java/com/anisync/android/presentation/notes/NotesJournalScreen.kt
+++ b/app/src/main/java/com/anisync/android/presentation/notes/NotesJournalScreen.kt
@@ -179,7 +179,7 @@ private fun NoteJournalCard(
     val title = entry.getTitle(titleLanguage)
     val snippet = entry.notes.orEmpty().replace("\n", " ").trim()
     val edited = entry.updatedAt?.takeIf { it > 0L }?.let { formatProfileRelativeTime(it) }
-    val coverShape = RoundedCornerShape(topStart = 16.dp, bottomStart = 16.dp)
+    val coverShape = RoundedCornerShape(topStart = 18.dp, bottomStart = 18.dp)
 
     Card(
         shape = RoundedCornerShape(16.dp),

--- a/app/src/main/java/com/anisync/android/presentation/profile/components/ProfileMediaListCard.kt
+++ b/app/src/main/java/com/anisync/android/presentation/profile/components/ProfileMediaListCard.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.anisync.android.ui.theme.ExpressiveShapes
 import com.anisync.android.R
 import com.anisync.android.data.TitleLanguage
 import com.anisync.android.domain.LibraryEntry
@@ -102,7 +103,7 @@ fun ProfileMediaListCard(
 
     var showNoteSheet by remember(entry.id) { mutableStateOf(false) }
 
-    val coverShape = RoundedCornerShape(10.dp)
+    val coverShape = ExpressiveShapes.mediaCover
     val coverSharedModifier = if (sharedTransitionScope != null && animatedVisibilityScope != null) {
         with(sharedTransitionScope) {
             Modifier.sharedBounds(

--- a/app/src/main/java/com/anisync/android/ui/theme/Shape.kt
+++ b/app/src/main/java/com/anisync/android/ui/theme/Shape.kt
@@ -65,4 +65,12 @@ object ExpressiveShapes {
      * Maximum expressiveness for prominent UI elements
      */
     val extraLarge = RoundedCornerShape(28.dp)
+
+    /**
+     * Media cover art (18dp). One radius for every poster in the app outside the Library screen,
+     * which keeps its own. The list-indicator corner tab is drawn against this radius — its concave
+     * fillets are cut for 18dp — so a cover that deviates leaves the tab welded on at the wrong
+     * curve. Change this and [com.anisync.android.R.drawable.ic_list_corner_tab] together.
+     */
+    val mediaCover = RoundedCornerShape(18.dp)
 }


### PR DESCRIPTION
Two card fixes that came out of the onboarding work.

One poster radius

Media covers were running at 8, 10, 12, 16, 18, 24 and 28dp depending on the screen. The list-indicator corner tab is cut for 18dp, so its concave fillets only met the art on the Discover poster card and looked welded on wrong everywhere else.

Adds an ExpressiveShapes.mediaCover token at 18dp and points every poster at it. The Library screen keeps its own 16dp, as agreed. Share and export cards are untouched since they never show an indicator.

Even library grid cards

A card carrying both an episodes-behind badge and an airing countdown wraps onto a second line in a narrow grid. A grid row is only as tall as its tallest card and the rest sit top-aligned inside it, so a title with no airing date looked visibly short next to a wrapped neighbour.

Any list that can show both now reserves the second line on every card. Lists that show neither, like Completed, still reserve nothing. The cost is around 22dp of reserved space per card in wide grids where nothing wraps, which is what uniform heights cost here.

Verified on the tablet emulator at both tablet and phone metrics.